### PR TITLE
introduce codebase documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,28 @@
+# Project Guidelines
+
+## Framework Warning
+
+This project uses Next.js 16 with breaking changes. Read `node_modules/next/dist/docs/` before writing code. Heed deprecation notices.
+
+## Architecture
+
+- Product graph browser built with React Flow on Next.js App Router
+- 8-level species hierarchy (token → product) + 2 parallel layers (data-model, api-endpoint)
+- Local-first data with provider abstraction (localStorage now, Supabase planned)
+- See `docs/` for detailed documentation
+
+## Documentation
+
+When reviewing or making changes:
+
+- If a new component, hook, node type, or data type is added → update relevant doc in `docs/`
+- If a public function/hook signature changes → verify JSDoc is updated
+- If species, statuses, platforms, or edge types change → update `docs/graph-model.md`
+- If architecture or data flow changes → update `docs/architecture.md`
+
+## Conventions
+
+- State: local hooks (`useNodes`, `useEdges`, `useProject`, `useGraphNavigation`) — no global store
+- Styling: Tailwind + shadcn/ui + class-variance-authority
+- Config: typed const arrays in `lib/config/` — add new taxonomies there
+- Data: all mutations go through `DataProvider` interface in `lib/data/`

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -1,0 +1,14 @@
+---
+description: "Use when creating or modifying documentation in docs/. Ensures docs stay concise, link to source code, and follow project standards."
+applyTo: "docs/**"
+---
+
+# Documentation Standards
+
+- Use H2 for major sections, H3 for subsections
+- Link to source files using relative paths from repo root: `lib/config/species.ts`, `components/graph/Canvas.tsx`
+- Keep docs actionable — explain what to do, not just what exists
+- When adding a new doc file, add it to the index in `docs/README.md`
+- Include "Config source" references when documenting taxonomies (species, statuses, platforms, edge types)
+- Use tables for structured data (type fields, taxonomy values, component maps)
+- Do not duplicate full source code — show signatures and key types, link to the file for implementation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,0 @@
-<!-- BEGIN:nextjs-agent-rules -->
-# This is NOT the Next.js you know
-
-This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
-<!-- END:nextjs-agent-rules -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Documentation
+
+See [`docs/`](docs/README.md) for detailed documentation:
+
+- [Architecture](docs/architecture.md) — System design, component relationships, data flow
+- [Graph Model](docs/graph-model.md) — Species hierarchy, statuses, platforms, edge types
+- [Data Layer](docs/data-layer.md) — DataProvider interface, storage, import/export
+- [Conventions](docs/conventions.md) — Coding patterns, file organization, state management
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+# arkaik Documentation
+
+## Contents
+
+- [Architecture](architecture.md) — System design, component relationships, data flow
+- [Graph Model](graph-model.md) — Species hierarchy, statuses, platforms, edge types, node rendering
+- [Data Layer](data-layer.md) — DataProvider interface, local storage, import/export
+- [Conventions](conventions.md) — Coding patterns, file organization, state management

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,94 @@
+# Architecture
+
+## Overview
+
+arkaik is a product graph browser built on **Next.js 16 App Router** with **React Flow** (`@xyflow/react`). It renders an interactive, semantically zoomable graph of product architecture — from high-level products down to individual tokens, with parallel layers for data models and API endpoints.
+
+## App Router Structure
+
+```
+app/
+  layout.tsx            # Root layout: fonts (Geist), ThemeProvider, global CSS
+  page.tsx              # Home page: component showcase / project list
+  project/
+    [id]/
+      layout.tsx        # Minimal wrapper
+      page.tsx          # Main canvas — semantic zoom logic lives here
+```
+
+The project page (`app/project/[id]/page.tsx`) is the core of the app. It:
+
+1. Loads a `ProjectBundle` (project + nodes + edges) via `useProject`
+2. Manages expansion state for products, scenarios, and flows
+3. Maps domain nodes to React Flow nodes with position and type
+4. Renders the `Canvas` component with computed nodes and edges
+
+## Component Map
+
+```
+components/
+  graph/
+    Canvas.tsx              # ReactFlow wrapper — registers node/edge types
+    nodes/                  # Custom React Flow node components
+      ProductNode.tsx       # Level 7 — large circle, Package icon
+      ScenarioNode.tsx      # Level 6 — rounded rect, platform dots
+      FlowNode.tsx          # Level 5 — rounded rect, violet accent
+      StepNode.tsx          # Level 4–0 — views, components, tokens
+      ConditionNode.tsx     # Diamond — branching logic
+      DataModelNode.tsx     # Parallel layer — amber, Database icon
+      ApiEndpointNode.tsx   # Parallel layer — teal, Plug icon
+      node-styles.ts        # Status/platform style maps
+    edges/
+      ComposeEdge.tsx       # Straight — hierarchy (composes, displays, queries)
+      BranchEdge.tsx        # Bezier — flow branching
+      CrossLayerEdge.tsx    # Dashed straight — cross-layer references
+  layout/
+    Breadcrumb.tsx          # Navigation breadcrumb trail
+    Minimap.tsx             # React Flow minimap wrapper
+    PlatformDots.tsx        # Colored dots for web/ios/android
+    Sidebar.tsx             # Left panel container (stub)
+    StatusBadge.tsx         # Colored pill with status label
+  panels/
+    NewNodeForm.tsx         # Quick node creation form
+    NodeDetailPanel.tsx     # Slide-in sheet for node properties (stub)
+    PlatformVariants.tsx    # Platform tab switcher
+  ui/                       # shadcn/ui primitives (button, card, input, etc.)
+```
+
+## Data Flow
+
+```
+localStorage
+    ↕ (read/write)
+localProvider (implements DataProvider)
+    ↕ (async calls)
+Hooks: useProject, useNodes, useEdges
+    ↕ (state)
+app/project/[id]/page.tsx (semantic zoom logic)
+    ↕ (props)
+Canvas → ReactFlow → Custom Nodes/Edges
+```
+
+All data mutations flow through the `DataProvider` interface (`lib/data/data-provider.ts`). The current implementation is `localProvider` backed by `localStorage`. The interface is designed for a future Supabase migration — swap the provider, keep the hooks and UI unchanged.
+
+## Semantic Zoom
+
+The project page manages three expansion sets:
+
+- `expandedProducts` — which products show their child scenarios
+- `expandedScenarios` — which scenarios show their child flows
+- `expandedFlows` — which flows show their child steps/conditions
+
+When a user clicks a product node, its `onToggle` fires, adding child scenario nodes to the visible graph. Clicking a scenario reveals flows, and clicking a flow reveals steps and conditions. A breadcrumb trail tracks navigation depth.
+
+Nodes are positioned dynamically:
+- **Product children** (scenarios): radial layout around the parent
+- **Scenario children** (flows): radial layout
+- **Flow children** (steps/conditions): linear horizontal layout
+
+## Theming
+
+- `next-themes` for light/dark mode
+- `ThemeProvider` wraps the entire app in the root layout
+- `ThemeToggle` component for user switching
+- Tailwind CSS with shadcn/ui design tokens

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,78 @@
+# Conventions
+
+## File Organization
+
+```
+app/                    # Next.js App Router pages and layouts
+components/
+  graph/                # React Flow canvas, custom nodes, custom edges
+  layout/               # Shell UI: breadcrumb, sidebar, minimap, badges
+  panels/               # Slide-in panels and forms
+  ui/                   # shadcn/ui primitives (do not edit directly — use CLI)
+lib/
+  config/               # Typed const arrays: species, statuses, platforms, edge types
+  data/                 # DataProvider interface + implementations
+  hooks/                # React hooks for state management
+  utils/                # Helpers: layout, export, cn()
+seed/                   # Example project JSON for development
+docs/                   # This documentation
+```
+
+## State Management
+
+- **No global store.** No Zustand, Redux, or Context-based state.
+- All state lives in local hooks: `useNodes`, `useEdges`, `useProject`, `useGraphNavigation`.
+- Data flows via props from the project page down to canvas components.
+- Semantic zoom state (expanded sets, breadcrumbs) is managed in `app/project/[id]/page.tsx`.
+
+## Styling
+
+- **Tailwind CSS** for all styling — no CSS modules, no styled-components.
+- **shadcn/ui** for UI primitives (`components/ui/`). Generated via CLI — don't edit these files by hand.
+- **class-variance-authority (CVA)** for component variants.
+- **`cn()` helper** (`lib/utils.ts`) for merging Tailwind classes: `cn("base-class", conditional && "active-class")`.
+- **`tailwind-merge`** resolves conflicting Tailwind classes automatically via `cn()`.
+
+## Config / Taxonomies
+
+All domain enums live in `lib/config/` as `const` arrays with `as const`:
+
+```typescript
+// lib/config/species.ts
+export const SPECIES = [
+  { id: "product", level: 7, label: "Product", description: "top-level" },
+  // ...
+] as const;
+
+export type SpeciesId = (typeof SPECIES)[number]["id"];
+```
+
+This pattern gives you:
+- Runtime array for iteration (dropdowns, mapping)
+- Compile-time union type for type safety
+- Single source of truth — no duplicate enum + array
+
+To add a new taxonomy value, add it to the array. The type updates automatically.
+
+## Components
+
+- **Node components** receive React Flow `NodeProps` with a `data` object containing `label`, `status`, `platforms`, `expanded`, `onToggle`.
+- **Edge components** receive React Flow `EdgeProps` and render SVG paths.
+- All node components are in `components/graph/nodes/` and must be registered in the `nodeTypes` map in `Canvas.tsx`.
+
+## Data Mutations
+
+All writes go through the `DataProvider` interface:
+
+```
+Component → Hook (useNodes.addNode) → Provider (localProvider.createNode) → Storage
+```
+
+Never write to `localStorage` directly. Always use the provider.
+
+## Naming
+
+- **Files:** kebab-case for config and utils (`edge-types.ts`), PascalCase for components (`ProductNode.tsx`)
+- **Types:** PascalCase (`SpeciesId`, `ProjectBundle`)
+- **Config arrays:** UPPER_SNAKE_CASE (`SPECIES`, `STATUSES`, `EDGE_TYPES`)
+- **Hooks:** camelCase with `use` prefix (`useNodes`, `useGraphNavigation`)

--- a/docs/data-layer.md
+++ b/docs/data-layer.md
@@ -1,0 +1,130 @@
+# Data Layer
+
+## Data Types
+
+Defined in `lib/data/types.ts`:
+
+### Node
+
+```typescript
+interface Node {
+  id: string;
+  project_id: string;
+  species: SpeciesId;
+  title: string;
+  description?: string;
+  status: StatusId;
+  platforms: PlatformId[];
+  parent_id?: string | null;
+  position_x: number;
+  position_y: number;
+  metadata?: Record<string, unknown>;
+}
+```
+
+### Edge
+
+```typescript
+interface Edge {
+  id: string;
+  project_id: string;
+  source_id: string;
+  target_id: string;
+  edge_type: EdgeTypeId;
+  metadata?: Record<string, unknown>;
+}
+```
+
+### Project
+
+```typescript
+interface Project {
+  id: string;
+  title: string;
+  description?: string;
+  created_at: string;  // ISO 8601
+  updated_at: string;  // ISO 8601
+}
+```
+
+### ProjectBundle
+
+```typescript
+interface ProjectBundle {
+  project: Project;
+  nodes: Node[];
+  edges: Edge[];
+}
+```
+
+A `ProjectBundle` is the unit of storage and export — one project with all its nodes and edges.
+
+## DataProvider Interface
+
+Defined in `lib/data/data-provider.ts`. All data access goes through this interface:
+
+```typescript
+interface DataProvider {
+  // Projects
+  getProject(id: string): Promise<ProjectBundle | undefined>;
+  listProjects(): Promise<ProjectBundle[]>;
+  saveProject(bundle: ProjectBundle): Promise<void>;
+
+  // Nodes
+  getNodes(projectId: string): Promise<Node[]>;
+  createNode(node: Node): Promise<Node>;
+  updateNode(id: string, patch: Partial<Omit<Node, "id" | "project_id">>): Promise<Node>;
+  deleteNode(id: string): Promise<void>;
+
+  // Edges
+  getEdges(projectId: string): Promise<Edge[]>;
+  createEdge(edge: Edge): Promise<Edge>;
+  deleteEdge(id: string): Promise<void>;
+
+  // Import/Export
+  exportProject(id: string): Promise<ProjectBundle>;
+  importProject(bundle: ProjectBundle): Promise<Project>;
+}
+```
+
+## Local Provider
+
+Implemented in `lib/data/local-provider.ts`.
+
+- **Storage key:** `arkaik:store`
+- **Backend:** `localStorage` with an in-memory `Map<string, ProjectBundle>`
+- **Indexing:** Dual index maps — `nodeIndex` (node ID → project ID) and `edgeIndex` (edge ID → project ID) for fast lookups
+- **Persistence:** Auto-persists to `localStorage` on every mutation
+- **Cascade:** `deleteNode` also removes all edges referencing that node
+
+## Import / Export
+
+Utilities in `lib/utils/export.ts`:
+
+- `exportToJson(bundle)` — Serializes a `ProjectBundle` to formatted JSON
+- `downloadJson(bundle)` — Triggers browser download as `{projectId}.json`
+- `exportProject(id)` / `importProject(bundle)` — Delegate to `localProvider`
+
+## Hooks
+
+Hooks in `lib/hooks/` provide React state wrappers around the provider:
+
+| Hook | Returns | Purpose |
+|------|---------|---------|
+| `useProject(id)` | `{ project, loading }` | Load a full `ProjectBundle` |
+| `useNodes(projectId)` | `{ nodes, loading, addNode, removeNode, updateNode }` | CRUD for nodes |
+| `useEdges(projectId)` | `{ edges, loading, addEdge, removeEdge }` | CRUD for edges |
+| `useGraphNavigation()` | `{ expandedNodeIds, zoomLevel, breadcrumbs, expand, collapse, navigateTo }` | Semantic zoom state |
+
+## Migration Path
+
+The `DataProvider` interface abstracts storage so the backend can change without touching hooks or UI:
+
+1. **Current:** `localStorage` via `localProvider`
+2. **Planned:** Supabase (auth, RLS, realtime sync)
+
+To add a new provider: implement the `DataProvider` interface and swap the import in the hooks.
+
+## Seed Data
+
+`seed/pebbles.json` contains an example project ("Pebbles") demonstrating the data shape with products, scenarios, flows, views, conditions, and all edge types.

--- a/docs/graph-model.md
+++ b/docs/graph-model.md
@@ -1,0 +1,92 @@
+# Graph Model
+
+The product graph is built from **nodes** (entities) connected by **edges** (relationships). Every node has a species, a status, and optional platform tags.
+
+## Species Hierarchy
+
+8 levels forming a composition tree, plus 2 parallel layers:
+
+| Level | Species | Description | Node Component |
+|-------|---------|-------------|----------------|
+| 7 | `product` | Top-level product | `ProductNode` — large circle, Package icon |
+| 6 | `scenario` | Composed set of flows | `ScenarioNode` — rounded rect, chevron toggle |
+| 5 | `flow` | Sequence of steps | `FlowNode` — rounded rect, violet accent |
+| 4 | `view` | A page or screen | `StepNode` — platform-aware card stacking |
+| 3 | `section` | Card grid, header bar | `StepNode` |
+| 2 | `component` | Button, Card, Input | `StepNode` |
+| 1 | `state` | button:hover, input:error | `StepNode` |
+| 0 | `token` | Color, spacing, translation key | `StepNode` |
+| — | `condition` | Branching logic in flows | `ConditionNode` — diamond shape, amber border |
+| — | `data-model` | Database table / entity | `DataModelNode` — amber border, Database icon |
+| — | `api-endpoint` | REST endpoint | `ApiEndpointNode` — teal border, Plug icon |
+
+**Config source:** `lib/config/species.ts`
+
+### Flow Children
+
+Species that can appear inside an expanded flow:
+
+- `view`, `component`, `section`, `state`, `token` → rendered as `StepNode`
+- `condition` → rendered as `ConditionNode`
+
+## Statuses
+
+Lifecycle states for any node:
+
+| ID | Label | Order | Badge Color | Visual Effect |
+|----|-------|-------|-------------|---------------|
+| `idea` | Idea | 0 | Gray | Dashed border, 60% opacity |
+| `planned` | Planned | 1 | Blue | Normal |
+| `in-development` | In Development | 2 | Orange | Normal |
+| `live` | Live | 3 | Green | Normal |
+| `deprecated` | Deprecated | 4 | Red | Normal |
+
+**Config source:** `lib/config/statuses.ts`
+
+## Platforms
+
+First-class multi-platform support. Nodes can target any combination:
+
+| ID | Label | Dot Color | Border Color |
+|----|-------|-----------|--------------|
+| `web` | Web | Green | `border-green-500` |
+| `ios` | iOS | Blue | `border-blue-500` |
+| `android` | Android | Purple | `border-purple-500` |
+
+**Config source:** `lib/config/platforms.ts`
+
+### Platform Rendering in StepNode
+
+- **All 3 platforms**: Stacked cards with opacity cascade
+- **2 platforms**: Single card with platform dots
+- **1 platform**: Single card with platform-colored border
+
+## Edge Types
+
+| ID | Label | Visual | Use |
+|----|-------|--------|-----|
+| `composes` | Composes | Straight solid | Hierarchy: product→scenario→flow |
+| `branches` | Branches | Bezier curve | Flow branching: step→condition→step |
+| `calls` | Calls | Straight solid | View → API endpoint |
+| `displays` | Displays | Straight solid | View → data model |
+| `queries` | Queries | Straight solid | API endpoint → data model |
+
+**Config source:** `lib/config/edge-types.ts`
+
+### Edge Components
+
+| Component | Path Style | Used For |
+|-----------|------------|----------|
+| `ComposeEdge` | Straight | composes, displays, queries |
+| `BranchEdge` | Bezier | branches |
+| `CrossLayerEdge` | Dashed straight | Cross-layer references (not yet registered in Canvas) |
+
+## Adding New Taxonomies
+
+All taxonomies live in `lib/config/` as typed `const` arrays:
+
+1. Add the new entry to the relevant array in `lib/config/`
+2. The `SpeciesId`, `StatusId`, `PlatformId`, or `EdgeTypeId` type updates automatically via `typeof`
+3. If adding a new species: create a node component in `components/graph/nodes/`, register it in `Canvas.tsx`
+4. If adding a new edge type: create an edge component in `components/graph/edges/`, register it in `Canvas.tsx`
+5. Update this document


### PR DESCRIPTION
- [x] Create copilot-instructions.md — single workspace instructions file for Copilot PR reviews + agent sessions (replaces AGENTS.md and CLAUDE.md)
- [x] Create docs with 5 files: index, architecture, graph model, data layer, conventions — all sourced from the actual codebase
- [x] Create docs.instructions.md — auto-applies documentation standards when editing `docs/**`
- [x] Remove AGENTS.md and CLAUDE.md — redundant with the new copilot-instructions.md
- [x] Update README.md — added Documentation section linking to all docs files

| Action | File |
|--------|------|
| **Created** | copilot-instructions.md — workspace instructions for Copilot (PR reviews + agent sessions) |
| **Created** | docs.instructions.md — auto-loaded when editing `docs/**` |
| **Created** | README.md — documentation index |
| **Created** | architecture.md — system design, component map, data flow |
| **Created** | graph-model.md — species, statuses, platforms, edges |
| **Created** | data-layer.md — types, DataProvider, hooks, migration path |
| **Created** | conventions.md — coding patterns, naming, state management |
| **Updated** | README.md — added Documentation section with links |
| **Removed** | AGENTS.md, CLAUDE.md — superseded by copilot-instructions.md |

**How Copilot will use this:**
- **PR reviews**: Copilot reads copilot-instructions.md automatically and will flag missing doc updates
- **VS Code agent sessions**: Same file is loaded as workspace instructions
- **Editing docs**: The `docs.instructions.md` file activates automatically via `applyTo: "docs/**"`

Made changes.