### PR TITLE
update the docs with milestone 4

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,17 +18,19 @@ app/
 
 The project page (`app/project/[id]/page.tsx`) is the core of the app. It:
 
-1. Loads a `ProjectBundle` (project + nodes + edges) via `useProject`
-2. Manages expansion state for products, scenarios, and flows
-3. Maps domain nodes to React Flow nodes with position and type
-4. Renders the `Canvas` component with computed nodes and edges
+1. Loads nodes and edges via `useNodes` and `useEdges`
+2. Manages expansion state for products, scenarios, and flows via local `useState` sets
+3. Maps domain nodes to React Flow nodes with position, type, and toggle handlers
+4. Handles per-platform split rendering for step-like nodes
+5. Renders the `Canvas` component with computed nodes and edges
+6. Opens `NodeDetailPanel` on node click for viewing/editing properties
 
 ## Component Map
 
 ```
 components/
   graph/
-    Canvas.tsx              # ReactFlow wrapper — registers node/edge types
+    Canvas.tsx              # ReactFlow wrapper — registers node/edge types, renders Controls, MiniMap, Background
     nodes/                  # Custom React Flow node components
       ProductNode.tsx       # Level 7 — large circle, Package icon
       ScenarioNode.tsx      # Level 6 — rounded rect, platform dots
@@ -39,19 +41,19 @@ components/
       ApiEndpointNode.tsx   # Parallel layer — teal, Plug icon
       node-styles.ts        # Status/platform style maps
     edges/
-      ComposeEdge.tsx       # Straight — hierarchy (composes, displays, queries)
+      ComposeEdge.tsx       # Straight — hierarchy (composes)
       BranchEdge.tsx        # Bezier — flow branching
-      CrossLayerEdge.tsx    # Dashed straight — cross-layer references
+      CrossLayerEdge.tsx    # Dashed straight — cross-layer references (not yet registered in Canvas)
   layout/
     Breadcrumb.tsx          # Navigation breadcrumb trail
-    Minimap.tsx             # React Flow minimap wrapper
+    Minimap.tsx             # React Flow minimap wrapper (unused — Canvas uses @xyflow/react MiniMap directly)
     PlatformDots.tsx        # Colored dots for web/ios/android
     Sidebar.tsx             # Left panel container (stub)
     StatusBadge.tsx         # Colored pill with status label
   panels/
     NewNodeForm.tsx         # Quick node creation form
-    NodeDetailPanel.tsx     # Slide-in sheet for node properties (stub)
-    PlatformVariants.tsx    # Platform tab switcher
+    NodeDetailPanel.tsx     # Slide-in sheet: edit title, description, status, platforms; connection navigation; per-platform variant notes
+    PlatformVariants.tsx    # Platform tab switcher with per-platform notes
   ui/                       # shadcn/ui primitives (button, card, input, etc.)
 ```
 
@@ -62,18 +64,20 @@ localStorage
     ↕ (read/write)
 localProvider (implements DataProvider)
     ↕ (async calls)
-Hooks: useProject, useNodes, useEdges
+Hooks: useNodes, useEdges
     ↕ (state)
-app/project/[id]/page.tsx (semantic zoom logic)
+app/project/[id]/page.tsx (semantic zoom + platform split logic)
     ↕ (props)
 Canvas → ReactFlow → Custom Nodes/Edges
+    ↕ (click events)
+NodeDetailPanel → Hook (updateNode) → Provider → Storage
 ```
 
 All data mutations flow through the `DataProvider` interface (`lib/data/data-provider.ts`). The current implementation is `localProvider` backed by `localStorage`. The interface is designed for a future Supabase migration — swap the provider, keep the hooks and UI unchanged.
 
 ## Semantic Zoom
 
-The project page manages three expansion sets:
+The project page manages three expansion sets as local `useState`:
 
 - `expandedProducts` — which products show their child scenarios
 - `expandedScenarios` — which scenarios show their child flows
@@ -85,6 +89,26 @@ Nodes are positioned dynamically:
 - **Product children** (scenarios): radial layout around the parent
 - **Scenario children** (flows): radial layout
 - **Flow children** (steps/conditions): linear horizontal layout
+
+### Platform Split Rendering
+
+When a flow is expanded, step-like nodes (`view`, `component`, `section`, `state`, `token`) that target 2+ platforms but **not all 3** are split into one React Flow node per platform. Each split node receives a single-platform `platforms` array.
+
+- Split node IDs use a `__` delimiter: `{nodeId}__{platformId}`
+- A `splitNodeMap` tracks original → split IDs so persisted edges fan out correctly to all split variants
+- On click, split IDs are stripped back to the base ID to locate the source data node
+
+Nodes targeting all 3 platforms or a single platform are rendered as a single node (no split).
+
+## Node Detail Panel
+
+Clicking any node opens a slide-in `Sheet` (`NodeDetailPanel`) with:
+
+- **Editable fields**: title, description, status dropdown, platform toggles
+- **Connections**: parent, children, and cross-layer nodes (data-model, api-endpoint) with click-to-navigate
+- **Platform Variants** (step-species only): per-platform tabbed notes stored in `node.metadata.platformNotes`
+
+Edits call `useNodes.updateNode` which flows through the `DataProvider`.
 
 ## Theming
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -21,9 +21,10 @@ docs/                   # This documentation
 ## State Management
 
 - **No global store.** No Zustand, Redux, or Context-based state.
-- All state lives in local hooks: `useNodes`, `useEdges`, `useProject`, `useGraphNavigation`.
+- Reusable state logic lives in hooks: `useNodes`, `useEdges`, `useProject`, `useGraphNavigation`.
+- The project canvas page (`app/project/[id]/page.tsx`) uses `useNodes` and `useEdges` for data, but manages expansion and breadcrumb state as local `useState` sets (`expandedProducts`, `expandedScenarios`, `expandedFlows`).
 - Data flows via props from the project page down to canvas components.
-- Semantic zoom state (expanded sets, breadcrumbs) is managed in `app/project/[id]/page.tsx`.
+- `useProject` and `useGraphNavigation` exist as utilities but are not currently used on the canvas page.
 
 ## Styling
 

--- a/docs/data-layer.md
+++ b/docs/data-layer.md
@@ -114,7 +114,22 @@ Hooks in `lib/hooks/` provide React state wrappers around the provider:
 | `useProject(id)` | `{ project, loading }` | Load a full `ProjectBundle` |
 | `useNodes(projectId)` | `{ nodes, loading, addNode, removeNode, updateNode }` | CRUD for nodes |
 | `useEdges(projectId)` | `{ edges, loading, addEdge, removeEdge }` | CRUD for edges |
-| `useGraphNavigation()` | `{ expandedNodeIds, zoomLevel, breadcrumbs, expand, collapse, navigateTo }` | Semantic zoom state |
+| `useGraphNavigation()` | `{ expandedNodeIds, zoomLevel, breadcrumbs, expand, collapse, navigateTo }` | Generic semantic zoom state |
+
+> **Note:** The project canvas page (`app/project/[id]/page.tsx`) uses `useNodes` and `useEdges` directly but does **not** use `useProject` or `useGraphNavigation`. It manages expansion sets (`expandedProducts`, `expandedScenarios`, `expandedFlows`) and breadcrumbs as local `useState` — the granularity required three separate sets rather than the single `expandedNodeIds` set in `useGraphNavigation`.
+
+### Node Editing Flow
+
+The `NodeDetailPanel` is the primary UI for editing nodes. The mutation path:
+
+```
+NodeDetailPanel (title, status, platforms, description, metadata)
+  → useNodes.updateNode(id, patch)
+    → localProvider.updateNode(id, patch)
+      → localStorage
+```
+
+Platform variant notes are stored in `node.metadata.platformNotes` as `Partial<Record<PlatformId, string>>`.
 
 ## Migration Path
 

--- a/docs/graph-model.md
+++ b/docs/graph-model.md
@@ -47,16 +47,22 @@ Lifecycle states for any node:
 
 First-class multi-platform support. Nodes can target any combination:
 
-| ID | Label | Dot Color | Border Color |
-|----|-------|-----------|--------------|
-| `web` | Web | Green | `border-green-500` |
-| `ios` | iOS | Blue | `border-blue-500` |
-| `android` | Android | Purple | `border-purple-500` |
+| ID | Label | Emoji | Dot Color | Border Color |
+|----|-------|-------|-----------|--------------|
+| `web` | Web | 🟢 | `bg-green-500` | `border-green-500` |
+| `ios` | iOS | 🔵 | `bg-blue-500` | `border-blue-500` |
+| `android` | Android | 🟣 | `bg-purple-500` | `border-purple-500` |
 
 **Config source:** `lib/config/platforms.ts`
 
-### Platform Rendering in StepNode
+### Platform Split Rendering
 
+When a flow is expanded, step-like nodes are checked for platform-split rendering in `app/project/[id]/page.tsx`:
+
+- **All 3 platforms or 1 platform**: rendered as a single `StepNode`
+- **2 platforms (proper subset)**: split into separate React Flow nodes, one per platform, each with a single-platform `platforms` array and ID `{nodeId}__{platformId}`
+
+Within the `StepNode` component itself, platform count affects visual rendering:
 - **All 3 platforms**: Stacked cards with opacity cascade
 - **2 platforms**: Single card with platform dots
 - **1 platform**: Single card with platform-colored border
@@ -67,19 +73,25 @@ First-class multi-platform support. Nodes can target any combination:
 |----|-------|--------|-----|
 | `composes` | Composes | Straight solid | Hierarchy: product→scenario→flow |
 | `branches` | Branches | Bezier curve | Flow branching: step→condition→step |
-| `calls` | Calls | Straight solid | View → API endpoint |
-| `displays` | Displays | Straight solid | View → data model |
-| `queries` | Queries | Straight solid | API endpoint → data model |
+| `calls` | Calls | Default (no custom component) | View → API endpoint |
+| `displays` | Displays | Default (no custom component) | View → data model |
+| `queries` | Queries | Default (no custom component) | API endpoint → data model |
 
 **Config source:** `lib/config/edge-types.ts`
 
 ### Edge Components
 
-| Component | Path Style | Used For |
-|-----------|------------|----------|
-| `ComposeEdge` | Straight | composes, displays, queries |
-| `BranchEdge` | Bezier | branches |
-| `CrossLayerEdge` | Dashed straight | Cross-layer references (not yet registered in Canvas) |
+| Component | Path Style | Mapped Edge Types |
+|-----------|------------|-------------------|
+| `ComposeEdge` | Straight | `composes` |
+| `BranchEdge` | Bezier | `branches` |
+| `CrossLayerEdge` | Dashed straight | Not yet registered in `Canvas.tsx` |
+| *(React Flow default)* | Straight | `calls`, `displays`, `queries` |
+
+The mapping from domain `edge_type` to React Flow edge type is in `app/project/[id]/page.tsx`:
+- `composes` → `"compose"` → `ComposeEdge`
+- `branches` → `"branch"` → `BranchEdge`
+- All others → `undefined` → React Flow default edge
 
 ## Adding New Taxonomies
 
@@ -87,6 +99,6 @@ All taxonomies live in `lib/config/` as typed `const` arrays:
 
 1. Add the new entry to the relevant array in `lib/config/`
 2. The `SpeciesId`, `StatusId`, `PlatformId`, or `EdgeTypeId` type updates automatically via `typeof`
-3. If adding a new species: create a node component in `components/graph/nodes/`, register it in `Canvas.tsx`
-4. If adding a new edge type: create an edge component in `components/graph/edges/`, register it in `Canvas.tsx`
+3. If adding a new species: create a node component in `components/graph/nodes/`, register it in `Canvas.tsx`, and add a mapping in `SPECIES_TO_NODE_TYPE` in `app/project/[id]/page.tsx`
+4. If adding a new edge type: create an edge component in `components/graph/edges/`, register it in `Canvas.tsx`, and add a mapping in the edge-type-to-xy-type logic in `app/project/[id]/page.tsx`
 5. Update this document


### PR DESCRIPTION
| File | Fixes applied |
|------|--------------|
| architecture.md | Project page uses `useNodes`/`useEdges` not `useProject`; `NodeDetailPanel` fully described (no longer "stub"); data flow diagram updated with click-event path; Canvas description includes Controls/MiniMap/Background; `Minimap.tsx` marked unused; `ComposeEdge` comment corrected; new **Platform Split Rendering** and **Node Detail Panel** sections added |
| graph-model.md | Platform table adds `Emoji` column matching config; `calls`/`displays`/`queries` marked as default edges (not `ComposeEdge`); edge component table corrected with mapping explanation; platform split rendering documented; taxonomy steps reference `SPECIES_TO_NODE_TYPE` |
| data-layer.md | Note added that canvas page doesn't use `useProject`/`useGraphNavigation`; new **Node Editing Flow** section documenting `NodeDetailPanel` → `updateNode` path and `metadata.platformNotes` |
| conventions.md | State management section clarifies which hooks are actually used on the canvas page vs. available as utilities |
