### PR TITLE
fix ux double fire on nodes

### DIFF
--- a/app/project/[id]/page.tsx
+++ b/app/project/[id]/page.tsx
@@ -352,6 +352,10 @@ export default function ProjectCanvasPage() {
           platforms: n.platforms,
           expanded: expandedProducts.has(n.id),
           onToggle: () => toggleProduct(n.id, n.title),
+          onOpenDetails: () => {
+            setSelectedNode(n);
+            setPanelOpen(true);
+          },
           onAddChild: (() => {
             const child = getChildSpecies(n.species);
             return child ? () => handleAddChildNode(n.id, child) : undefined;
@@ -389,6 +393,10 @@ export default function ProjectCanvasPage() {
             platforms: scenario.platforms,
             expanded: expandedScenarios.has(scenario.id),
             onToggle: () => toggleScenario(scenario.id, scenario.title, product.id, product.title),
+            onOpenDetails: () => {
+              setSelectedNode(scenario);
+              setPanelOpen(true);
+            },
             onAddChild: (() => {
               const child = getChildSpecies(scenario.species);
               return child ? () => handleAddChildNode(scenario.id, child) : undefined;
@@ -439,6 +447,10 @@ export default function ProjectCanvasPage() {
             platforms: flow.platforms,
             expanded: expandedFlows.has(flow.id),
             onToggle: () => toggleFlow(flow.id, flow.title, scenarioId, scenario.title, parentProduct?.id ?? "", parentProduct?.title ?? ""),
+            onOpenDetails: () => {
+              setSelectedNode(flow);
+              setPanelOpen(true);
+            },
             onAddChild: getChildSpecies(flow.species)
               ? () => handleAddChildNode(flow.id, getChildSpecies(flow.species)!)
               : undefined,

--- a/components/graph/nodes/FlowNode.tsx
+++ b/components/graph/nodes/FlowNode.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Handle, Position, NodeToolbar, type NodeProps } from "@xyflow/react";
-import { ChevronDown, ChevronRight, PlusCircle } from "lucide-react";
+import { ChevronDown, ChevronRight, Info, PlusCircle } from "lucide-react";
 import type { StatusId } from "@/lib/config/statuses";
 import type { PlatformId } from "@/lib/config/platforms";
 import { StatusBadge } from "@/components/layout/StatusBadge";
@@ -15,6 +15,7 @@ export function FlowNode({ data }: NodeProps) {
   const platforms = (data.platforms as PlatformId[]) ?? [];
   const expanded = Boolean(data.expanded);
   const onToggle = data.onToggle as (() => void) | undefined;
+  const onOpenDetails = data.onOpenDetails as (() => void) | undefined;
   const onAddChild = data.onAddChild as (() => void) | undefined;
   const ghostClass = STATUS_GHOST_STYLES[status];
   const { isHovered, nodeProps, toolbarProps } = useToolbarHover();
@@ -41,7 +42,10 @@ export function FlowNode({ data }: NodeProps) {
         aria-label={label}
         aria-expanded={expanded}
         className={`flex flex-col gap-2 w-48 px-3 py-2.5 rounded-lg bg-background border-2 border-violet-400 shadow-sm cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-ring ${ghostClass.wrapper} ${ghostClass.border}`}
-        onClick={() => onToggle?.()}
+        onClick={(e) => {
+          e.stopPropagation();
+          onToggle?.();
+        }}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
@@ -54,11 +58,26 @@ export function FlowNode({ data }: NodeProps) {
           <span title={label} className="text-sm font-medium leading-tight line-clamp-2 flex-1">
             {label}
           </span>
-          {expanded ? (
-            <ChevronDown className="w-4 h-4 shrink-0 text-muted-foreground" />
-          ) : (
-            <ChevronRight className="w-4 h-4 shrink-0 text-muted-foreground" />
-          )}
+          <div className="flex items-center gap-1">
+            {onOpenDetails && (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onOpenDetails();
+                }}
+                className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                aria-label={`Open details for ${label}`}
+              >
+                <Info className="w-3.5 h-3.5" />
+              </button>
+            )}
+            {expanded ? (
+              <ChevronDown className="w-4 h-4 shrink-0 text-muted-foreground" />
+            ) : (
+              <ChevronRight className="w-4 h-4 shrink-0 text-muted-foreground" />
+            )}
+          </div>
         </div>
         <div className="flex items-center justify-between gap-2">
           <StatusBadge status={status} />

--- a/components/graph/nodes/ProductNode.tsx
+++ b/components/graph/nodes/ProductNode.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Handle, Position, NodeToolbar, type NodeProps } from "@xyflow/react";
-import { Package, PlusCircle } from "lucide-react";
+import { Info, Package, PlusCircle } from "lucide-react";
 import type { StatusId } from "@/lib/config/statuses";
 import { StatusBadge } from "@/components/layout/StatusBadge";
 import { STATUS_GHOST_STYLES } from "./node-styles";
@@ -12,6 +12,7 @@ export function ProductNode({ data }: NodeProps) {
   const label = String(data.label ?? "Product");
   const expanded = Boolean(data.expanded);
   const onToggle = data.onToggle as (() => void) | undefined;
+  const onOpenDetails = data.onOpenDetails as (() => void) | undefined;
   const onAddChild = data.onAddChild as (() => void) | undefined;
   const ghostClass = STATUS_GHOST_STYLES[status];
   const { isHovered, nodeProps, toolbarProps } = useToolbarHover();
@@ -37,8 +38,11 @@ export function ProductNode({ data }: NodeProps) {
         tabIndex={0}
         aria-label={label}
         aria-expanded={expanded}
-        className={`flex w-40 h-40 flex-col items-center justify-center rounded-full bg-primary text-primary-foreground border-4 border-border shadow-xl cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-ring ${ghostClass.wrapper} ${ghostClass.border}`}
-        onClick={() => onToggle?.()}
+        className={`relative flex w-40 h-40 flex-col items-center justify-center rounded-full bg-primary text-primary-foreground border-4 border-border shadow-xl cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-ring ${ghostClass.wrapper} ${ghostClass.border}`}
+        onClick={(e) => {
+          e.stopPropagation();
+          onToggle?.();
+        }}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
@@ -47,6 +51,19 @@ export function ProductNode({ data }: NodeProps) {
         }}
         {...nodeProps}
       >
+        {onOpenDetails && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onOpenDetails();
+            }}
+            className="absolute top-2 right-2 inline-flex h-6 w-6 items-center justify-center rounded-full bg-background/90 text-foreground border border-border hover:bg-muted transition-colors"
+            aria-label={`Open details for ${label}`}
+          >
+            <Info className="w-3.5 h-3.5" />
+          </button>
+        )}
         <Package className="w-8 h-8 mb-1 shrink-0" />
         <span title={label} className="text-sm font-bold text-center px-4 leading-tight line-clamp-2">
           {label}

--- a/components/graph/nodes/ScenarioNode.tsx
+++ b/components/graph/nodes/ScenarioNode.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Handle, Position, NodeToolbar, type NodeProps } from "@xyflow/react";
-import { ChevronDown, ChevronRight, PlusCircle } from "lucide-react";
+import { ChevronDown, ChevronRight, Info, PlusCircle } from "lucide-react";
 import type { StatusId } from "@/lib/config/statuses";
 import type { PlatformId } from "@/lib/config/platforms";
 import { StatusBadge } from "@/components/layout/StatusBadge";
@@ -15,6 +15,7 @@ export function ScenarioNode({ data }: NodeProps) {
   const platforms = (data.platforms as PlatformId[]) ?? [];
   const expanded = Boolean(data.expanded);
   const onToggle = data.onToggle as (() => void) | undefined;
+  const onOpenDetails = data.onOpenDetails as (() => void) | undefined;
   const onAddChild = data.onAddChild as (() => void) | undefined;
   const ghostClass = STATUS_GHOST_STYLES[status];
   const { isHovered, nodeProps, toolbarProps } = useToolbarHover();
@@ -41,7 +42,10 @@ export function ScenarioNode({ data }: NodeProps) {
         aria-label={label}
         aria-expanded={expanded}
         className={`flex flex-col gap-2 w-56 px-4 py-3 rounded-xl bg-background border-2 border-border shadow-md cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-ring ${ghostClass.wrapper} ${ghostClass.border}`}
-        onClick={() => onToggle?.()}
+        onClick={(e) => {
+          e.stopPropagation();
+          onToggle?.();
+        }}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
@@ -54,11 +58,26 @@ export function ScenarioNode({ data }: NodeProps) {
           <span title={label} className="text-sm font-semibold leading-tight line-clamp-1 flex-1">
             {label}
           </span>
-          {expanded ? (
-            <ChevronDown className="w-4 h-4 shrink-0 text-muted-foreground" />
-          ) : (
-            <ChevronRight className="w-4 h-4 shrink-0 text-muted-foreground" />
-          )}
+          <div className="flex items-center gap-1">
+            {onOpenDetails && (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onOpenDetails();
+                }}
+                className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                aria-label={`Open details for ${label}`}
+              >
+                <Info className="w-3.5 h-3.5" />
+              </button>
+            )}
+            {expanded ? (
+              <ChevronDown className="w-4 h-4 shrink-0 text-muted-foreground" />
+            ) : (
+              <ChevronRight className="w-4 h-4 shrink-0 text-muted-foreground" />
+            )}
+          </div>
         </div>
         <div className="flex items-center justify-between gap-2">
           <StatusBadge status={status} />


### PR DESCRIPTION
What changed

- Tap on Product, Scenario, and Flow node bodies now only drills (expands/collapses), and no longer bubbles to the canvas click handler.
- Added a dedicated details button (info icon) on Product, Scenario, and Flow nodes to open the drawer intentionally.
- Wired this dedicated button to set selected node + open panel from page-level node mapping.


Product/Scenario/Flow:
- Tap node body: drill only.
- Tap info button: open drawer.

Leaf nodes (step/condition/data-model/api-endpoint): tap still opens drawer via existing canvas node click behavior.