### PR TITLE
compact platform views

### DIFF
--- a/app/project/[id]/page.tsx
+++ b/app/project/[id]/page.tsx
@@ -79,16 +79,6 @@ const FLOW_CHILD_SPECIES = new Set<SpeciesId>([
   "view", "component", "section", "state", "token", "condition",
 ]);
 
-/** Step-like species eligible for per-platform split rendering. */
-const STEP_SPLIT_SPECIES = new Set<SpeciesId>([
-  "view", "component", "section", "state", "token",
-]);
-
-const ALL_PLATFORM_IDS = PLATFORMS.map((p) => p.id);
-
-/** Delimiter used to build per-platform split node IDs: `${nodeId}${SPLIT_SEP}${platformId}`. */
-const SPLIT_SEP = "__";
-
 const COLLISION_PADDING = 24;
 const MAX_COLLISION_ITERATIONS = 30;
 
@@ -423,9 +413,7 @@ export default function ProjectCanvasPage() {
   );
 
   const handleNodeClick = useCallback<NodeMouseHandler>((_event, xyNode) => {
-    // Split nodes have IDs like `${nodeId}${SPLIT_SEP}${platform}` — strip the suffix to find the source data node
-    const baseId = xyNode.id.includes(SPLIT_SEP) ? xyNode.id.split(SPLIT_SEP)[0] : xyNode.id;
-    const dataNode = dataNodes.find((n) => n.id === baseId);
+    const dataNode = dataNodes.find((n) => n.id === xyNode.id);
     if (dataNode) {
       setSelectedNode(dataNode);
       setPanelOpen(true);
@@ -440,18 +428,11 @@ export default function ProjectCanvasPage() {
 
   const handleEdgeTypeSelect = useCallback(async (edgeType: EdgeTypeId) => {
     if (!pendingConnection?.source || !pendingConnection?.target) return;
-    // Resolve base node IDs in case the source/target are split (platform) nodes
-    const sourceBaseId = pendingConnection.source.includes(SPLIT_SEP)
-      ? pendingConnection.source.split(SPLIT_SEP)[0]
-      : pendingConnection.source;
-    const targetBaseId = pendingConnection.target.includes(SPLIT_SEP)
-      ? pendingConnection.target.split(SPLIT_SEP)[0]
-      : pendingConnection.target;
     await addEdge({
       id: crypto.randomUUID(),
       project_id: id,
-      source_id: sourceBaseId,
-      target_id: targetBaseId,
+      source_id: pendingConnection.source,
+      target_id: pendingConnection.target,
       edge_type: edgeType,
     });
     setEdgeDialogOpen(false);
@@ -459,8 +440,6 @@ export default function ProjectCanvasPage() {
   }, [pendingConnection, addEdge, id]);
 
   const { nodes, edges } = useMemo(() => {
-    // Tracks nodes split by platform: originalId → [splitId, …]
-    const splitNodeMap = new Map<string, string[]>();
     const layoutRules = new Map<string, LayoutRule>();
 
     const productDataNodes = dataNodes.filter((n) => n.species === "product");
@@ -622,52 +601,23 @@ export default function ProjectCanvasPage() {
         (n) => n.parent_id === flowId && FLOW_CHILD_SPECIES.has(n.species),
       );
 
-      // Build visual items: step-like nodes with a proper subset of platforms
-      // are expanded into one visual node per platform; all others stay as-is.
-      const visualItems: Array<{
-        id: string;
-        dataNode: (typeof children)[0];
-        platform?: PlatformId;
-      }> = [];
+      const childPositions = linearPositions(flow.position_x, flow.position_y, children.length);
+      const maxSpreadX = Math.max(320, children.length * 110);
 
-      for (const child of children) {
-        const childPlatforms = (child.platforms ?? []) as PlatformId[];
-        const childIsAllPlatforms = ALL_PLATFORM_IDS.every((p) =>
-          childPlatforms.includes(p),
-        );
-        const shouldSplit =
-          STEP_SPLIT_SPECIES.has(child.species) &&
-          childPlatforms.length >= 2 &&
-          !childIsAllPlatforms;
-
-        if (shouldSplit) {
-          const splitIds = childPlatforms.map((p) => `${child.id}${SPLIT_SEP}${p}`);
-          splitNodeMap.set(child.id, splitIds);
-          for (const platform of childPlatforms) {
-            visualItems.push({ id: `${child.id}${SPLIT_SEP}${platform}`, dataNode: child, platform });
-          }
-        } else {
-          visualItems.push({ id: child.id, dataNode: child });
-        }
-      }
-
-      const childPositions = linearPositions(flow.position_x, flow.position_y, visualItems.length);
-      const maxSpreadX = Math.max(320, visualItems.length * 110);
-
-      for (const [i, item] of visualItems.entries()) {
+      for (const [i, child] of children.entries()) {
         const childPosition = childPositions[i];
-        visibleNodeIds.add(item.id);
+        visibleNodeIds.add(child.id);
         visibleNodes.push({
-          id: item.id,
-          type: SPECIES_TO_NODE_TYPE[item.dataNode.species],
+          id: child.id,
+          type: SPECIES_TO_NODE_TYPE[child.species],
           position: childPosition,
           data: {
-            label: item.dataNode.title,
-            status: item.dataNode.status,
-            platforms: item.platform ? [item.platform] : item.dataNode.platforms,
+            label: child.title,
+            status: child.status,
+            platforms: child.platforms,
           },
         });
-        layoutRules.set(item.id, {
+        layoutRules.set(child.id, {
           axis: "both",
           clampX: [flow.position_x - maxSpreadX, flow.position_x + maxSpreadX],
           clampY: [flow.position_y + FLOW_CHILD_Y_OFFSET - 80, flow.position_y + FLOW_CHILD_Y_OFFSET + 80],
@@ -675,41 +625,30 @@ export default function ProjectCanvasPage() {
       }
     }
 
-    // Include any persisted edges that connect two visible nodes (deduplicated).
-    // When a node was split into per-platform variants, fan the edge out to all
-    // applicable split IDs.
+    // Include any persisted edges that connect two visible nodes.
     const renderedEdgePairs = new Set(visibleEdges.map((e) => `${e.source}:${e.target}`));
+    const EDGE_TYPE_MAP: Record<string, string> = {
+      composes: "compose",
+      branches: "branch",
+      calls: "calls",
+      displays: "displays",
+      queries: "queries",
+    };
+
     for (const edge of dataEdges) {
-      const sourceIds =
-        splitNodeMap.get(edge.source_id) ??
-        (visibleNodeIds.has(edge.source_id) ? [edge.source_id] : []);
-      const targetIds =
-        splitNodeMap.get(edge.target_id) ??
-        (visibleNodeIds.has(edge.target_id) ? [edge.target_id] : []);
+      if (!visibleNodeIds.has(edge.source_id) || !visibleNodeIds.has(edge.target_id)) continue;
 
-      const EDGE_TYPE_MAP: Record<string, string> = {
-        composes: "compose",
-        branches: "branch",
-        calls: "calls",
-        displays: "displays",
-        queries: "queries",
-      };
+      const pairKey = `${edge.source_id}:${edge.target_id}`;
+      if (renderedEdgePairs.has(pairKey)) continue;
+
       const xyType = EDGE_TYPE_MAP[edge.edge_type];
-
-      for (const srcId of sourceIds) {
-        for (const tgtId of targetIds) {
-          const pairKey = `${srcId}:${tgtId}`;
-          if (!renderedEdgePairs.has(pairKey)) {
-            visibleEdges.push({
-              id: `${edge.id}--${srcId}--${tgtId}`,
-              source: srcId,
-              target: tgtId,
-              type: xyType,
-            });
-            renderedEdgePairs.add(pairKey);
-          }
-        }
-      }
+      visibleEdges.push({
+        id: `${edge.id}--${edge.source_id}--${edge.target_id}`,
+        source: edge.source_id,
+        target: edge.target_id,
+        type: xyType,
+      });
+      renderedEdgePairs.add(pairKey);
     }
 
     const collisionFreeNodes = resolveNodeCollisions(visibleNodes, layoutRules);

--- a/components/graph/nodes/PlatformList.tsx
+++ b/components/graph/nodes/PlatformList.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import type { PlatformId } from "@/lib/config/platforms";
+import { PLATFORMS } from "@/lib/config/platforms";
+import { PLATFORM_ICONS, STATUS_STYLES, STATUS_LABELS } from "./node-styles";
+import type { StatusId } from "@/lib/config/statuses";
+
+interface PlatformListProps {
+  platforms: PlatformId[];
+  status?: StatusId;
+}
+
+export function PlatformList({ platforms, status = "idea" }: PlatformListProps) {
+  if (platforms.length === 0) return null;
+
+  const { dot: statusDot } = STATUS_STYLES[status] ?? STATUS_STYLES.idea;
+  const statusLabel = STATUS_LABELS[status];
+
+  return (
+    <div className="flex flex-col gap-1 text-xs">
+      {PLATFORMS.map((platform) => {
+        if (!platforms.includes(platform.id)) return null;
+        const Icon = PLATFORM_ICONS[platform.id];
+        return (
+          <div
+            key={platform.id}
+            className="flex items-center gap-2 leading-none"
+          >
+            <Icon className="w-3 h-3 text-muted-foreground shrink-0" />
+            <span className="text-muted-foreground truncate">{platform.label}</span>
+            <span
+              title={statusLabel}
+              className={`w-1.5 h-1.5 rounded-full ${statusDot} shrink-0 ml-auto`}
+              aria-label={`Status: ${statusLabel}`}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/graph/nodes/StepNode.tsx
+++ b/components/graph/nodes/StepNode.tsx
@@ -3,44 +3,35 @@
 import { Handle, Position, type NodeProps } from "@xyflow/react";
 import type { StatusId } from "@/lib/config/statuses";
 import type { PlatformId } from "@/lib/config/platforms";
-import { PLATFORMS } from "@/lib/config/platforms";
-import { PLATFORM_BORDER_STYLES, STATUS_GHOST_STYLES } from "./node-styles";
+import { STATUS_GHOST_STYLES } from "./node-styles";
 import { StatusBadge } from "@/components/layout/StatusBadge";
-import { PlatformDots } from "@/components/layout/PlatformDots";
-
-const ALL_PLATFORM_IDS = PLATFORMS.map((p) => p.id);
+import { PlatformList } from "./PlatformList";
 
 export function StepNode({ data }: NodeProps) {
   const status = (data.status as StatusId) ?? "idea";
   const label = String(data.label ?? "Step");
   const platforms = (data.platforms as PlatformId[]) ?? [];
-
-  const isAllPlatforms = ALL_PLATFORM_IDS.every((p) => platforms.includes(p));
-  const singlePlatform = !isAllPlatforms && platforms.length === 1 ? platforms[0] : null;
-  const borderClass = singlePlatform ? PLATFORM_BORDER_STYLES[singlePlatform] : "border-border";
   const ghostClass = STATUS_GHOST_STYLES[status];
 
   return (
     <>
       <Handle type="target" position={Position.Top} className="opacity-0" />
       <div className={`relative ${ghostClass.wrapper}`}>
-        {isAllPlatforms && (
-          <>
-            <div className="absolute inset-0 rounded-lg border-2 border-border bg-background opacity-60 translate-x-2 translate-y-2" />
-            <div className="absolute inset-0 rounded-lg border-2 border-border bg-background opacity-80 translate-x-1 translate-y-1" />
-          </>
-        )}
         <div
           role="img"
           aria-label={label}
-          className={`relative flex flex-col gap-2 w-44 px-3 py-2.5 rounded-lg bg-background border-2 ${borderClass} shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-ring ${ghostClass.border}`}
+          className={`relative flex flex-col gap-2 w-52 px-3 py-2.5 rounded-lg bg-background border-2 border-border shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-ring ${ghostClass.border}`}
         >
           <span title={label} className="text-sm font-medium leading-tight line-clamp-2">
             {label}
           </span>
           <div className="flex items-center justify-between gap-2">
             <StatusBadge status={status} />
-            <PlatformDots platforms={platforms} />
+            {platforms.length > 0 && (
+              <div className="text-xs flex-1 min-w-0">
+                <PlatformList platforms={platforms} status={status} />
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/components/graph/nodes/node-styles.ts
+++ b/components/graph/nodes/node-styles.ts
@@ -1,5 +1,7 @@
 import type { StatusId } from "@/lib/config/statuses";
 import type { PlatformId } from "@/lib/config/platforms";
+import type { LucideIcon } from "lucide-react";
+import { Monitor, Apple, Bot } from "lucide-react";
 
 export const STATUS_STYLES: Record<StatusId, { badge: string; dot: string }> = {
   idea: { badge: "bg-gray-100 text-gray-600", dot: "bg-gray-400" },
@@ -15,6 +17,12 @@ export const STATUS_LABELS: Record<StatusId, string> = {
   "in-development": "In Development",
   live: "Live",
   deprecated: "Deprecated",
+};
+
+export const PLATFORM_ICONS: Record<PlatformId, LucideIcon> = {
+  web: Monitor,
+  ios: Apple,
+  android: Bot,
 };
 
 export const PLATFORM_DOT_STYLES: Record<PlatformId, string> = {

--- a/lib/config/platforms.ts
+++ b/lib/config/platforms.ts
@@ -1,7 +1,7 @@
 export const PLATFORMS = [
-  { id: "web",     label: "Web",     emoji: "🟢" },
-  { id: "ios",     label: "iOS",     emoji: "🔵" },
-  { id: "android", label: "Android", emoji: "🟣" },
+  { id: "web",     label: "Web",     icon: "Monitor" },
+  { id: "ios",     label: "iOS",     icon: "Apple" },
+  { id: "android", label: "Android", icon: "Bot" },
 ] as const;
 
 export type PlatformId = (typeof PLATFORMS)[number]["id"];


### PR DESCRIPTION
Key Changes:
- Platform Config – Updated to use lucide-react icons (Monitor, Apple, Bot) instead of emojis
- New PlatformList Component – Displays platforms inline within view cards: [[icon] [name] [status dot]](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- StepNode Refactored – Now uses PlatformList, removed platform-specific borders (signal-focused design)
- Simplified Canvas Logic – Removed all split-node rendering and deletion of dangerous staticNodeMap, SPLIT_SEP, split ID stripping
- Cleaner Edge Handling – No more platform split fan-out; edges are now 1:1 from data to canvasKey Changes:
- Platform Config – Updated to use lucide-react icons (Monitor, Apple, Bot) instead of emojis
- New PlatformList Component – Displays platforms inline within view cards: [[icon] [name] [status dot]](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- StepNode Refactored – Now uses PlatformList, removed platform-specific borders (signal-focused design)
- Simplified Canvas Logic – Removed all split-node rendering and deletion of dangerous staticNodeMap, SPLIT_SEP, split ID stripping
- Cleaner Edge Handling – No more platform split fan-out; edges are now 1:1 from data to canvas