### PR TITLE
create import and delete projects

### DIFF
--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
@@ -12,41 +12,115 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-} from "@/components/ui/breadcrumb";
 import { ArkaikLogo } from "@/components/branding/ArkaikLogo";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { localProvider } from "@/lib/data/local-provider";
-import type { ProjectBundle } from "@/lib/data/types";
+import type { Project, ProjectBundle } from "@/lib/data/types";
+import { archiveProject, importProjectFromFile } from "@/lib/utils/export";
+import { DeleteConfirmDialog } from "@/components/graph/DeleteConfirmDialog";
+import { CreateProjectForm } from "@/components/panels/CreateProjectForm";
 import pebbles from "@/seed/pebbles.json";
 
 export default function ProjectsPage() {
   const router = useRouter();
   const [projects, setProjects] = useState<ProjectBundle[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<ProjectBundle | null>(null);
   const [importing, setImporting] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  async function loadProjects() {
+    setLoading(true);
+    try {
+      const list = await localProvider.listProjects();
+      setProjects(list);
+    } catch (err) {
+      console.error("[ProjectsPage] Failed to load projects:", err);
+      setError("Failed to load projects");
+    } finally {
+      setLoading(false);
+    }
+  }
 
   useEffect(() => {
-    localProvider
-      .listProjects()
-      .then((list) => setProjects(list))
-      .catch((err) => console.error("[ProjectsPage] Failed to load projects:", err))
-      .finally(() => setLoading(false));
+    loadProjects();
   }, []);
+
+  async function createProject(project: Pick<Project, "title" | "description">) {
+    setError(null);
+    const now = new Date().toISOString();
+    const id = crypto.randomUUID();
+    const bundle: ProjectBundle = {
+      project: {
+        id,
+        title: project.title,
+        description: project.description,
+        created_at: now,
+        updated_at: now,
+        archived_at: null,
+      },
+      nodes: [],
+      edges: [],
+    };
+
+    await localProvider.saveProject(bundle);
+    await loadProjects();
+    router.push(`/project/${id}`);
+  }
 
   async function handleImportExample() {
     setImporting(true);
+    setError(null);
     try {
-      await localProvider.importProject(pebbles as ProjectBundle);
-      router.push(`/project/${pebbles.project.id}`);
+      const project = await importProjectFromFile(
+        new File([JSON.stringify(pebbles)], "pebbles.json", { type: "application/json" })
+      );
+      await loadProjects();
+      router.push(`/project/${project.id}`);
     } catch (err) {
       console.error("[ProjectsPage] Failed to import example project:", err);
+      setError("Failed to import example project");
     } finally {
       setImporting(false);
+    }
+  }
+
+  async function handleImportFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    e.target.value = "";
+    if (!file) return;
+
+    setImporting(true);
+    setError(null);
+    try {
+      const project = await importProjectFromFile(file);
+      await loadProjects();
+      router.push(`/project/${project.id}`);
+    } catch (err) {
+      console.error("[ProjectsPage] Failed to import project JSON:", err);
+      const message = err instanceof Error ? err.message : "Failed to import project JSON";
+      setError(message);
+    } finally {
+      setImporting(false);
+    }
+  }
+
+  async function handleArchiveProject() {
+    if (!deleteTarget || deleting) return;
+    setDeleting(true);
+    setError(null);
+    try {
+      await archiveProject(deleteTarget.project.id);
+      setDeleteTarget(null);
+      await loadProjects();
+    } catch (err) {
+      console.error("[ProjectsPage] Failed to archive project:", err);
+      setError("Failed to archive project");
+    } finally {
+      setDeleting(false);
     }
   }
 
@@ -62,7 +136,26 @@ export default function ProjectsPage() {
       <main className="mx-auto flex w-full max-w-4xl flex-1 flex-col gap-6 p-6">
         <div className="flex items-center justify-between">
           <h1 className="text-2xl font-semibold">Projects</h1>
+          <div className="flex items-center gap-2">
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="application/json,.json"
+              onChange={handleImportFileChange}
+              className="hidden"
+            />
+            <Button
+              variant="outline"
+              disabled={importing}
+              onClick={() => fileInputRef.current?.click()}
+            >
+              {importing ? "Importing..." : "Import JSON"}
+            </Button>
+            <Button onClick={() => setCreateOpen(true)}>Create project</Button>
+          </div>
         </div>
+
+        {error && <p className="text-sm text-destructive">{error}</p>}
 
         {loading ? (
           <div className="flex flex-1 items-center justify-center">
@@ -71,11 +164,14 @@ export default function ProjectsPage() {
         ) : projects.length === 0 ? (
           <div className="flex flex-1 flex-col items-center justify-center gap-4 py-24 text-center">
             <p className="max-w-xs text-sm text-muted-foreground">
-              No projects yet. Import the example project to get started.
+              No projects yet. Create one, import your JSON, or load the example project.
             </p>
-            <Button onClick={handleImportExample} disabled={importing}>
-              {importing ? "Importing…" : "Import example project"}
-            </Button>
+            <div className="flex items-center gap-2">
+              <Button onClick={() => setCreateOpen(true)}>Create project</Button>
+              <Button variant="outline" onClick={handleImportExample} disabled={importing}>
+                {importing ? "Importing..." : "Import example project"}
+              </Button>
+            </div>
           </div>
         ) : (
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
@@ -93,9 +189,12 @@ export default function ProjectsPage() {
                     {bundle.edges.length} edge{bundle.edges.length !== 1 ? "s" : ""}
                   </p>
                 </CardContent>
-                <CardFooter>
+                <CardFooter className="flex items-center gap-2">
                   <Button size="sm" onClick={() => router.push(`/project/${bundle.project.id}`)}>
                     Open
+                  </Button>
+                  <Button size="sm" variant="outline" onClick={() => setDeleteTarget(bundle)}>
+                    Delete
                   </Button>
                 </CardFooter>
               </Card>
@@ -103,6 +202,18 @@ export default function ProjectsPage() {
           </div>
         )}
       </main>
+
+      <CreateProjectForm open={createOpen} onOpenChange={setCreateOpen} onSubmit={createProject} />
+
+      <DeleteConfirmDialog
+        open={Boolean(deleteTarget)}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTarget(null);
+        }}
+        title="Delete project"
+        description={`Archive \"${deleteTarget?.project.title ?? "this project"}\" and remove it from your list?`}
+        onConfirm={handleArchiveProject}
+      />
     </div>
   );
 }

--- a/components/panels/CreateProjectForm.tsx
+++ b/components/panels/CreateProjectForm.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+export interface CreateProjectFormData {
+  title: string;
+  description?: string;
+}
+
+interface CreateProjectFormProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (data: CreateProjectFormData) => Promise<void> | void;
+}
+
+export function CreateProjectForm({ open, onOpenChange, onSubmit }: CreateProjectFormProps) {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  function resetForm() {
+    setTitle("");
+    setDescription("");
+    setSubmitting(false);
+  }
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen) resetForm();
+    onOpenChange(nextOpen);
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!title.trim() || submitting) return;
+    setSubmitting(true);
+    try {
+      await onSubmit({
+        title: title.trim(),
+        description: description.trim() || undefined,
+      });
+      handleOpenChange(false);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Create project</DialogTitle>
+          <DialogDescription>Start a new empty project.</DialogDescription>
+        </DialogHeader>
+
+        <form id="create-project-form" onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Title</span>
+            <Input
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Project title"
+              required
+              aria-label="Project title"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+              Description
+            </span>
+            <Input
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Optional description"
+              aria-label="Project description"
+            />
+          </div>
+        </form>
+
+        <DialogFooter>
+          <Button variant="outline" type="button" onClick={() => handleOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button type="submit" form="create-project-form" disabled={submitting || !title.trim()}>
+            {submitting ? "Creating..." : "Create project"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/docs/data-layer.md
+++ b/docs/data-layer.md
@@ -45,6 +45,7 @@ interface Project {
   description?: string;
   created_at: string;  // ISO 8601
   updated_at: string;  // ISO 8601
+  archived_at?: string | null; // ISO 8601 when archived
 }
 ```
 
@@ -70,6 +71,7 @@ interface DataProvider {
   getProject(id: string): Promise<ProjectBundle | undefined>;
   listProjects(): Promise<ProjectBundle[]>;
   saveProject(bundle: ProjectBundle): Promise<void>;
+  archiveProject(id: string): Promise<void>;
 
   // Nodes
   getNodes(projectId: string): Promise<Node[]>;
@@ -88,6 +90,8 @@ interface DataProvider {
 }
 ```
 
+`archiveProject` performs a soft delete. Archived projects remain in storage but are excluded by default from `listProjects()`.
+
 ## Local Provider
 
 Implemented in `lib/data/local-provider.ts`.
@@ -105,6 +109,9 @@ Utilities in `lib/utils/export.ts`:
 - `exportToJson(bundle)` — Serializes a `ProjectBundle` to formatted JSON
 - `downloadJson(bundle)` — Triggers browser download as `{projectId}.json`
 - `exportProject(id)` / `importProject(bundle)` — Delegate to `localProvider`
+- `importProjectFromFile(file)` — Parses and validates JSON file content, normalizes timestamps, and imports via provider
+
+When importing, if the incoming project ID already exists locally, a new project ID is generated and all `project_id` references in nodes and edges are rewritten to the new ID before saving.
 
 ## Hooks
 

--- a/lib/data/data-provider.ts
+++ b/lib/data/data-provider.ts
@@ -4,6 +4,7 @@ export interface DataProvider {
   getProject(id: string): Promise<ProjectBundle | undefined>;
   listProjects(): Promise<ProjectBundle[]>;
   saveProject(bundle: ProjectBundle): Promise<void>;
+  archiveProject(id: string): Promise<void>;
 
   getNodes(projectId: string): Promise<Node[]>;
   getEdges(projectId: string): Promise<Edge[]>;

--- a/lib/data/local-provider.ts
+++ b/lib/data/local-provider.ts
@@ -27,6 +27,10 @@ const nodeIndex = new Map<string, string>();
 /** Maps edge id → project id for O(1) lookup. */
 const edgeIndex = new Map<string, string>();
 
+function isArchived(bundle: ProjectBundle): boolean {
+  return Boolean(bundle.project.archived_at);
+}
+
 // Rebuild indexes from persisted data
 for (const bundle of store.values()) {
   bundle.nodes.forEach((n) => nodeIndex.set(n.id, bundle.project.id));
@@ -38,12 +42,23 @@ export const localProvider: DataProvider = {
     return store.get(id);
   },
   async listProjects() {
-    return Array.from(store.values());
+    return Array.from(store.values()).filter((bundle) => !isArchived(bundle));
   },
   async saveProject(bundle: ProjectBundle) {
     store.set(bundle.project.id, bundle);
     bundle.nodes.forEach((n) => nodeIndex.set(n.id, bundle.project.id));
     bundle.edges.forEach((e) => edgeIndex.set(e.id, bundle.project.id));
+    persistStore(store);
+  },
+  async archiveProject(id: string) {
+    const bundle = store.get(id);
+    if (!bundle) throw new Error(`Project ${id} not found`);
+    const now = new Date().toISOString();
+    bundle.project = {
+      ...bundle.project,
+      archived_at: now,
+      updated_at: now,
+    };
     persistStore(store);
   },
 

--- a/lib/data/types.ts
+++ b/lib/data/types.ts
@@ -44,6 +44,8 @@ export interface Project {
   created_at: string;
   /** ISO 8601 timestamp, e.g. "2024-01-01T00:00:00.000Z" */
   updated_at: string;
+  /** ISO 8601 timestamp when archived; null/undefined means active. */
+  archived_at?: string | null;
 }
 
 export interface ProjectBundle {

--- a/lib/utils/export.ts
+++ b/lib/utils/export.ts
@@ -1,6 +1,60 @@
 import type { Project, ProjectBundle } from "@/lib/data/types";
 import { localProvider } from "@/lib/data/local-provider";
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isValidIsoString(value: unknown): value is string {
+  return typeof value === "string" && !Number.isNaN(Date.parse(value));
+}
+
+function normalizeProjectTimestamps(project: Project): Project {
+  const now = new Date().toISOString();
+  return {
+    ...project,
+    created_at: isValidIsoString(project.created_at) ? project.created_at : now,
+    updated_at: isValidIsoString(project.updated_at) ? project.updated_at : now,
+    archived_at: isValidIsoString(project.archived_at) ? project.archived_at : null,
+  };
+}
+
+function assertProjectBundleShape(value: unknown): asserts value is ProjectBundle {
+  if (!isRecord(value)) throw new Error("Invalid JSON: expected object root");
+
+  const project = value.project;
+  if (!isRecord(project)) throw new Error("Invalid JSON: missing project object");
+  if (typeof project.id !== "string" || !project.id.trim()) {
+    throw new Error("Invalid JSON: project.id must be a non-empty string");
+  }
+  if (typeof project.title !== "string" || !project.title.trim()) {
+    throw new Error("Invalid JSON: project.title must be a non-empty string");
+  }
+
+  if (!Array.isArray(value.nodes)) {
+    throw new Error("Invalid JSON: nodes must be an array");
+  }
+  if (!Array.isArray(value.edges)) {
+    throw new Error("Invalid JSON: edges must be an array");
+  }
+}
+
+async function ensureUniqueProjectId(initialId: string): Promise<string> {
+  let candidate = initialId;
+  while (await localProvider.getProject(candidate)) {
+    candidate = crypto.randomUUID();
+  }
+  return candidate;
+}
+
+function rewriteBundleProjectId(bundle: ProjectBundle, newProjectId: string): ProjectBundle {
+  return {
+    project: { ...bundle.project, id: newProjectId },
+    nodes: bundle.nodes.map((node) => ({ ...node, project_id: newProjectId })),
+    edges: bundle.edges.map((edge) => ({ ...edge, project_id: newProjectId })),
+  };
+}
+
 export function exportToJson(bundle: ProjectBundle): string {
   return JSON.stringify(bundle, null, 2);
 }
@@ -32,4 +86,38 @@ export async function exportProject(id: string): Promise<ProjectBundle> {
  */
 export async function importProject(bundle: ProjectBundle): Promise<Project> {
   return localProvider.importProject(bundle);
+}
+
+export async function archiveProject(id: string): Promise<void> {
+  return localProvider.archiveProject(id);
+}
+
+/**
+ * Imports a project bundle from a user-selected JSON file.
+ * If the project id already exists locally, a new id is generated.
+ */
+export async function importProjectFromFile(file: File): Promise<Project> {
+  const rawText = await file.text();
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(rawText);
+  } catch {
+    throw new Error("Invalid JSON file");
+  }
+
+  assertProjectBundleShape(parsed);
+
+  const normalizedBundle: ProjectBundle = {
+    ...parsed,
+    project: normalizeProjectTimestamps(parsed.project),
+  };
+
+  const resolvedProjectId = await ensureUniqueProjectId(normalizedBundle.project.id);
+  const finalBundle =
+    resolvedProjectId === normalizedBundle.project.id
+      ? normalizedBundle
+      : rewriteBundleProjectId(normalizedBundle, resolvedProjectId);
+
+  return localProvider.importProject(finalBundle);
 }


### PR DESCRIPTION
Fixes #43 is now functionally wired on the projects screen with create, JSON import, and delete-with-confirmation (soft delete/archive under the hood).

### What I changed

1. Added soft-delete support to the data model and provider
- Added archived_at to project type in types.ts
- Added archiveProject to provider contract in data-provider.ts
- Implemented archive behavior and hidden-by-default archived filtering in local-provider.ts

2. Added import/archive utilities
- Added JSON validation + file import helper in export.ts
- Added collision handling: if imported project ID exists, generate a new project ID and rewrite all node/edge project_id references
- Added archiveProject utility wrapper

3. Added create project dialog
- New component: CreateProjectForm.tsx
- Includes title (required), description (optional), submit state handling

4. Upgraded projects page UX
- Updated page.tsx with:
- Create project button (opens dialog)
- Import JSON button (hidden file input)
- Empty-state create/import actions
- Per-card Delete button
- Confirmation modal via existing DeleteConfirmDialog.tsx
- Error state messaging + reload flow after mutations

5. Updated docs
- Documented archiveProject and import collision behavior in data-layer.md

### Validation run

- Changed files pass eslint:
  - npx eslint page.tsx types.ts data-provider.ts local-provider.ts export.ts CreateProjectForm.tsx
- Full repo lint still fails due a pre-existing unrelated error in [app/project/[id]/page.tsx](app/project/[id]/page.tsx#L245)

### Notes

- Delete action is soft delete (archive), matching your direction.
- Archived projects are excluded from listProjects by default.
- Home route was left unchanged; implementation is on /projects as requested.