### PR TITLE
introduce json import and diagnosis

### DIFF
--- a/app/project/[id]/page.tsx
+++ b/app/project/[id]/page.tsx
@@ -236,6 +236,7 @@ export default function ProjectCanvasPage() {
   const [newNodePreset, setNewNodePreset] = useState<{ parent_id: string; species: SpeciesId } | null>(null);
   const [exporting, setExporting] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
+  const [exportWarning, setExportWarning] = useState<string | null>(null);
 
   const { nodes: dataNodes, loading: nodesLoading, updateNode, addNode, removeNodes } = useNodes(id);
   const { edges: dataEdges, loading: edgesLoading, addEdge, removeEdge } = useEdges(id);
@@ -517,12 +518,15 @@ export default function ProjectCanvasPage() {
 
     setExporting(true);
     setExportError(null);
+    setExportWarning(null);
     try {
       const bundle = await exportProject(id);
-      downloadJson(bundle);
+      const result = downloadJson(bundle);
+      setExportWarning(result.warning);
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unknown export error";
       setExportError(`Unable to export project: ${message}`);
+      setExportWarning(null);
     } finally {
       setExporting(false);
     }
@@ -791,6 +795,11 @@ export default function ProjectCanvasPage() {
           </Link>
           {breadcrumbs.length > 0 && <Breadcrumb segments={breadcrumbSegments} />}
           <div className="ml-auto flex items-center gap-3">
+            {exportWarning && (
+              <span className="text-xs text-amber-700" role="status" aria-live="polite">
+                {exportWarning}
+              </span>
+            )}
             {exportError && (
               <span className="text-xs text-destructive" role="status" aria-live="polite">
                 {exportError}

--- a/docs/data-layer.md
+++ b/docs/data-layer.md
@@ -107,9 +107,11 @@ Implemented in `lib/data/local-provider.ts`.
 Utilities in `lib/utils/export.ts`:
 
 - `exportToJson(bundle)` — Serializes a `ProjectBundle` to formatted JSON
-- `downloadJson(bundle)` — Triggers browser download as `{projectId}.json`
+- `downloadJson(bundle)` — Triggers browser download as `{project-title-slug}-{projectId}.json` and returns export diagnostics (`filename`, `bytes`, `warning`)
 - `exportProject(id)` / `importProject(bundle)` — Delegate to `localProvider`
 - `importProjectFromFile(file)` — Parses and validates JSON file content, normalizes timestamps, and imports via provider
+
+`downloadJson(bundle)` applies a soft warning when the serialized bundle is larger than 4 MB. The warning is intended for UX guidance only and does not block download.
 
 When importing, if the incoming project ID already exists locally, a new project ID is generated and all `project_id` references in nodes and edges are rewritten to the new ID before saving.
 

--- a/lib/utils/export.ts
+++ b/lib/utils/export.ts
@@ -1,6 +1,14 @@
 import type { Project, ProjectBundle } from "@/lib/data/types";
 import { localProvider } from "@/lib/data/local-provider";
 
+const MAX_RECOMMENDED_EXPORT_BYTES = 4 * 1024 * 1024;
+
+export interface ExportDownloadResult {
+  filename: string;
+  bytes: number;
+  warning: string | null;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -59,17 +67,40 @@ export function exportToJson(bundle: ProjectBundle): string {
   return JSON.stringify(bundle, null, 2);
 }
 
-export function downloadJson(bundle: ProjectBundle): void {
+function sanitizeFilenameSegment(input: string): string {
+  const normalized = input.normalize("NFKD").replace(/[^\x00-\x7F]/g, "");
+  const compact = normalized.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  if (!compact) return "project";
+  return compact.slice(0, 48);
+}
+
+function buildExportFilename(bundle: ProjectBundle): string {
+  const titlePart = sanitizeFilenameSegment(bundle.project.title);
+  return `${titlePart}-${bundle.project.id}.json`;
+}
+
+function buildExportWarning(bytes: number): string | null {
+  if (bytes <= MAX_RECOMMENDED_EXPORT_BYTES) return null;
+  const sizeMb = (bytes / (1024 * 1024)).toFixed(1);
+  return `Large export (${sizeMb} MB). This may be hard to share or import on some devices.`;
+}
+
+export function downloadJson(bundle: ProjectBundle): ExportDownloadResult {
   const json = exportToJson(bundle);
+  const filename = buildExportFilename(bundle);
+  const bytes = new Blob([json]).size;
+  const warning = buildExportWarning(bytes);
   const blob = new Blob([json], { type: "application/json" });
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
-  a.download = `${bundle.project.id}.json`;
+  a.download = filename;
   document.body.appendChild(a);
   a.click();
   document.body.removeChild(a);
   URL.revokeObjectURL(url);
+
+  return { filename, bytes, warning };
 }
 
 /**


### PR DESCRIPTION
Fixes #45 

- [x] Add export diagnostics and size-threshold warning logic in export.ts:4, export.ts:6, export.ts:82, and export.ts:88.
- [x] Improve download filename ergonomics to use a sanitized title + stable project id in export.ts:70 and export.ts:77.
- [x] Update project toolbar export flow to surface warning state from download diagnostics in app/project/[id]/page.tsx, app/project/[id]/page.tsx, app/project/[id]/page.tsx, and app/project/[id]/page.tsx.
- [x] Sync data-layer docs for new filename behavior and non-blocking large-export warning in data-layer.md:110 and data-layer.md:114.