### PR TITLE
introduce keyboard shortcuts

### DIFF
--- a/app/project/[id]/page.tsx
+++ b/app/project/[id]/page.tsx
@@ -15,6 +15,7 @@ import { NewNodeForm, type NewNodeFormData } from "@/components/panels/NewNodeFo
 import { Button } from "@/components/ui/button";
 import { useNodes } from "@/lib/hooks/useNodes";
 import { useEdges } from "@/lib/hooks/useEdges";
+import { useKeyboardShortcuts } from "@/lib/hooks/useKeyboardShortcuts";
 import { downloadJson, exportProject } from "@/lib/utils/export";
 import type { SpeciesId } from "@/lib/config/species";
 import { getChildSpecies } from "@/lib/config/species";
@@ -531,6 +532,22 @@ export default function ProjectCanvasPage() {
       setExporting(false);
     }
   }, [id]);
+
+  useKeyboardShortcuts({
+    onEscape: () => {
+      if (!panelOpen) return;
+      setPanelOpen(false);
+    },
+    onDelete: () => {
+      if (deleteNodeDialogOpen || deleteEdgeDialogOpen || newNodeOpen || edgeDialogOpen) return;
+      if (!selectedNode) return;
+      handleDeleteNodeRequest(selectedNode.id);
+    },
+    onExport: () => {
+      if (exporting) return;
+      void handleExport();
+    },
+  });
 
   const { nodes, edges } = useMemo(() => {
     const layoutRules = new Map<string, LayoutRule>();

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -27,6 +27,14 @@ docs/                   # This documentation
 - Data flows via props from the project page down to canvas components.
 - `useProject` and `useGraphNavigation` exist as utilities but are not currently used on the canvas page.
 
+## Keyboard Shortcuts
+
+- Project-page shortcuts are wired in `app/project/[id]/page.tsx` using `lib/hooks/useKeyboardShortcuts.ts`.
+- Shortcut key checks and focus guards live in `lib/utils/keyboard.ts`.
+- Keep shortcut handlers thin: they should call existing page handlers (`handleDeleteNodeRequest`, `handleExport`) instead of duplicating business logic.
+- Delete shortcuts must not directly mutate storage. Always route through the existing confirmation dialog flow.
+- Ignore destructive shortcuts when focus is in editable controls (`input`, `textarea`, `contenteditable`, or combobox/textbox roles).
+
 ## Styling
 
 - **Tailwind CSS** for all styling — no CSS modules, no styled-components.

--- a/lib/hooks/useKeyboardShortcuts.ts
+++ b/lib/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,50 @@
+import { useEffect } from "react";
+import { isDeleteShortcut, isEditableElement, isExportShortcut } from "@/lib/utils/keyboard";
+
+interface KeyboardShortcutOptions {
+  onEscape: () => void;
+  onDelete: () => void;
+  onExport: () => void;
+}
+
+export function useKeyboardShortcuts({
+  onEscape,
+  onDelete,
+  onExport,
+}: KeyboardShortcutOptions): void {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || event.repeat) {
+        return;
+      }
+
+      if (isExportShortcut(event)) {
+        if (isEditableElement(event.target)) {
+          return;
+        }
+        event.preventDefault();
+        onExport();
+        return;
+      }
+
+      if (event.key === "Escape") {
+        onEscape();
+        return;
+      }
+
+      if (isDeleteShortcut(event)) {
+        if (isEditableElement(event.target)) {
+          return;
+        }
+
+        event.preventDefault();
+        onDelete();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onDelete, onEscape, onExport]);
+}

--- a/lib/utils/keyboard.ts
+++ b/lib/utils/keyboard.ts
@@ -1,0 +1,39 @@
+export function isEditableElement(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+
+  if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
+    return true;
+  }
+
+  if (target.isContentEditable) {
+    return true;
+  }
+
+  const role = target.getAttribute("role");
+  if (role === "textbox" || role === "combobox") {
+    return true;
+  }
+
+  return target.closest("input, textarea, [contenteditable='true'], [role='textbox'], [role='combobox']") !== null;
+}
+
+export function isDeleteShortcut(event: KeyboardEvent): boolean {
+  if (event.metaKey || event.ctrlKey || event.altKey) {
+    return false;
+  }
+
+  return event.key === "Delete" || event.key === "Backspace";
+}
+
+export function isExportShortcut(event: KeyboardEvent): boolean {
+  if (event.altKey || event.shiftKey) {
+    return false;
+  }
+
+  const isMod = event.metaKey || event.ctrlKey;
+  if (!isMod) {
+    return false;
+  }
+
+  return event.key.toLowerCase() === "e";
+}


### PR DESCRIPTION
Fixes #47 

- Added reusable keyboard helpers in [keyboard.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- Added a page-level shortcut hook in [useKeyboardShortcuts.ts](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- Wired shortcuts into the project canvas page in [app/project/[id]/page.tsx](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- Documented shortcut conventions in [conventions.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)

Behavior now implemented:

- Escape closes the detail panel when it is open.
- Delete or Backspace opens the existing delete confirmation for the selected node.
- Cmd+E (and Ctrl+E fallback) triggers export.
- Delete and export shortcuts are ignored while typing in editable controls (inputs, textareas, contenteditable, combobox/textbox roles).
- Delete always routes through the existing confirmation flow, not direct deletion.