### PR TITLE
introduce root node id

### DIFF
--- a/app/project/[id]/page.tsx
+++ b/app/project/[id]/page.tsx
@@ -14,6 +14,7 @@ import { NewNodeForm, type NewNodeFormData } from "@/components/panels/NewNodeFo
 import { Button } from "@/components/ui/button";
 import { useNodes } from "@/lib/hooks/useNodes";
 import { useEdges } from "@/lib/hooks/useEdges";
+import { useProject } from "@/lib/hooks/useProject";
 import { useKeyboardShortcuts } from "@/lib/hooks/useKeyboardShortcuts";
 import { downloadJson, exportProject } from "@/lib/utils/export";
 import type { SpeciesId } from "@/lib/config/species";
@@ -40,6 +41,7 @@ const ROOT_FLOW_SPACING = 360;
 const ROOT_FLOW_Y = 120;
 const ROOT_VIEW_SPACING = 300;
 const ROOT_VIEW_Y = 420;
+const ROOT_ANCHOR_Y = 270;
 const FLOW_CHILD_X_OFFSET = 320;
 const FLOW_CHILD_Y_SPACING = 180;
 
@@ -246,6 +248,7 @@ export default function ProjectCanvasPage() {
 
   const { nodes: dataNodes, loading: nodesLoading, updateNode, addNode, removeNodes } = useNodes(id);
   const { edges: dataEdges, loading: edgesLoading, addEdge, removeEdge } = useEdges(id);
+  const { project: projectBundle, loading: projectLoading } = useProject(id);
 
   const nodesById = useMemo(
     () => new Map(dataNodes.map((node) => [node.id, node])),
@@ -274,6 +277,12 @@ export default function ProjectCanvasPage() {
     return map;
   }, [dataEdges]);
 
+  const explicitRootNode = useMemo(() => {
+    const rootNodeId = projectBundle?.project.root_node_id;
+    if (!rootNodeId) return null;
+    return nodesById.get(rootNodeId) ?? null;
+  }, [nodesById, projectBundle?.project.root_node_id]);
+
   const getPlaylist = useCallback((nodeId: string): string[] => {
     const entries = nodesById.get(nodeId)?.metadata?.playlist?.entries;
     if (!Array.isArray(entries)) return [];
@@ -299,12 +308,14 @@ export default function ProjectCanvasPage() {
     if (nodesLoading) return;
     setExpandedFlows((prev) => {
       if (prev.size > 0) return prev;
-      const rootFlowIds = dataNodes
-        .filter((node) => node.species === "flow" && !composeParentByChild.has(node.id))
-        .map((node) => node.id);
+      const rootFlowIds = explicitRootNode
+        ? [explicitRootNode].filter((node) => node.species === "flow").map((node) => node.id)
+        : dataNodes
+            .filter((node) => node.species === "flow" && !composeParentByChild.has(node.id))
+            .map((node) => node.id);
       return new Set(rootFlowIds);
     });
-  }, [nodesLoading, dataNodes, composeParentByChild]);
+  }, [nodesLoading, dataNodes, composeParentByChild, explicitRootNode]);
 
   const [pendingConnection, setPendingConnection] = useState<Connection | null>(null);
   const [edgeDialogOpen, setEdgeDialogOpen] = useState(false);
@@ -624,25 +635,84 @@ export default function ProjectCanvasPage() {
       layoutRules.set(node.id, { axis: "both" });
     });
 
-    const rootNodes = dataNodes.filter((node) => !composeParentByChild.has(node.id));
-    const rootFlows = rootNodes.filter((node) => node.species === "flow");
-    const rootViews = rootNodes.filter((node) => node.species === "view");
-
-    const rootFlowPositions = horizontalPositions(900, ROOT_FLOW_Y, rootFlows.length, ROOT_FLOW_SPACING);
-    const rootViewPositions = horizontalPositions(900, ROOT_VIEW_Y, rootViews.length, ROOT_VIEW_SPACING);
-
-    rootFlows.forEach((flow, index) => {
-      addDataNode(flow, rootFlowPositions[index] ?? { x: 900, y: ROOT_FLOW_Y });
-      layoutRules.set(flow.id, { axis: "both", fixed: true });
-    });
-
-    rootViews.forEach((view, index) => {
-      addDataNode(view, rootViewPositions[index] ?? { x: 900, y: ROOT_VIEW_Y });
-      layoutRules.set(view.id, { axis: "both", fixed: true });
-    });
-
-    const queue: string[] = rootFlows.map((flow) => flow.id);
+    const queue: string[] = [];
     const visitedFlowIds = new Set<string>();
+
+    if (explicitRootNode) {
+      const rootPosition = { x: 900, y: ROOT_ANCHOR_Y };
+      addDataNode(explicitRootNode, rootPosition);
+      layoutRules.set(explicitRootNode.id, { axis: "both", fixed: true });
+
+      const rootChildren = getOrderedChildren(explicitRootNode.id).filter((child) => FLOW_CHILD_SPECIES.has(child.species));
+      const rootChildPositions = verticalPositions(
+        rootPosition.x + FLOW_CHILD_X_OFFSET,
+        rootPosition.y,
+        rootChildren.length,
+      );
+
+      rootChildren.forEach((child, index) => {
+        const childPosition = rootChildPositions[index] ?? {
+          x: rootPosition.x + FLOW_CHILD_X_OFFSET,
+          y: rootPosition.y,
+        };
+        addDataNode(child, childPosition);
+        layoutRules.set(child.id, {
+          axis: "both",
+          clampX: [rootPosition.x + FLOW_CHILD_X_OFFSET - 50, rootPosition.x + FLOW_CHILD_X_OFFSET + 260],
+          clampY: [rootPosition.y - 280, rootPosition.y + 280],
+        });
+
+        visibleEdges.push({
+          id: `compose-${explicitRootNode.id}-${child.id}`,
+          source: explicitRootNode.id,
+          target: child.id,
+          type: "compose",
+        });
+
+        if (child.species === "flow") {
+          queue.push(child.id);
+        }
+      });
+
+      const rootChildViews = rootChildren.filter((child) => child.species === "view");
+      for (let index = 1; index < rootChildViews.length; index += 1) {
+        const prev = rootChildViews[index - 1];
+        const curr = rootChildViews[index];
+        visibleEdges.push({
+          id: `compose-${prev.id}-${curr.id}`,
+          source: prev.id,
+          target: curr.id,
+          type: "compose",
+          data: {
+            insertLabel: "Insert a View",
+            onInsert: () => handleInsertBetween(prev.id, curr.id, "view"),
+          },
+        });
+      }
+
+      if (explicitRootNode.species === "flow") {
+        visitedFlowIds.add(explicitRootNode.id);
+      }
+    } else {
+      const rootNodes = dataNodes.filter((node) => !composeParentByChild.has(node.id));
+      const rootFlows = rootNodes.filter((node) => node.species === "flow");
+      const rootViews = rootNodes.filter((node) => node.species === "view");
+
+      const rootFlowPositions = horizontalPositions(900, ROOT_FLOW_Y, rootFlows.length, ROOT_FLOW_SPACING);
+      const rootViewPositions = horizontalPositions(900, ROOT_VIEW_Y, rootViews.length, ROOT_VIEW_SPACING);
+
+      rootFlows.forEach((flow, index) => {
+        addDataNode(flow, rootFlowPositions[index] ?? { x: 900, y: ROOT_FLOW_Y });
+        layoutRules.set(flow.id, { axis: "both", fixed: true });
+      });
+
+      rootViews.forEach((view, index) => {
+        addDataNode(view, rootViewPositions[index] ?? { x: 900, y: ROOT_VIEW_Y });
+        layoutRules.set(view.id, { axis: "both", fixed: true });
+      });
+
+      queue.push(...rootFlows.map((flow) => flow.id));
+    }
 
     while (queue.length > 0) {
       const flowId = queue.shift()!;
@@ -728,6 +798,7 @@ export default function ProjectCanvasPage() {
     const collisionFreeNodes = resolveNodeCollisions(visibleNodes, layoutRules);
     return { nodes: collisionFreeNodes, edges: visibleEdges };
   }, [
+    explicitRootNode,
     composeParentByChild,
     dataEdges,
     dataNodes,
@@ -738,7 +809,7 @@ export default function ProjectCanvasPage() {
     toggleFlow,
   ]);
 
-  if (nodesLoading || edgesLoading) {
+  if (nodesLoading || edgesLoading || projectLoading) {
     return (
       <div className="h-screen w-full flex items-center justify-center">
         <span className="text-muted-foreground text-sm">Loading graph…</span>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -80,7 +80,9 @@ The project page manages one expansion set as local `useState`:
 
 - `expandedFlows` — which flows show their direct flow/view children
 
-Root nodes are rendered first, then expanded flows reveal ordered children from `metadata.playlist` and `composes` edges.
+When `project.root_node_id` is present, that node is rendered as the primary anchor and top-level compose children fan out from it. When it is missing, root nodes are inferred from nodes with no compose parent.
+
+Expanded flows reveal ordered children from `metadata.playlist` and `composes` edges.
 
 Nodes are positioned dynamically:
 

--- a/docs/data-layer.md
+++ b/docs/data-layer.md
@@ -69,6 +69,7 @@ interface Project {
   id: string;
   title: string;
   description?: string;
+  root_node_id?: string; // Optional node id used as the canvas anchor
   created_at: string;  // ISO 8601
   updated_at: string;  // ISO 8601
   archived_at?: string | null; // ISO 8601 when archived
@@ -86,6 +87,8 @@ interface ProjectBundle {
 ```
 
 A `ProjectBundle` is the unit of storage and export — one project with all its nodes and edges.
+
+`project.root_node_id` (when present) points to the node that should render as the primary canvas anchor in [app/project/[id]/page.tsx](../app/project/[id]/page.tsx). If it is missing, the canvas falls back to inferred roots (nodes without compose parents).
 
 ## DataProvider Interface
 
@@ -141,6 +144,8 @@ Utilities in `lib/utils/export.ts`:
 `downloadJson(bundle)` applies a soft warning when the serialized bundle is larger than 4 MB. The warning is intended for UX guidance only and does not block download.
 
 When importing, if the incoming project ID already exists locally, a new project ID is generated and all `project_id` references in nodes and edges are rewritten to the new ID before saving.
+
+When importing JSON, `project.root_node_id` is optional. If provided, it must reference an existing node ID in `nodes` or the import fails validation.
 
 ## Hooks
 

--- a/docs/graph-model.md
+++ b/docs/graph-model.md
@@ -22,6 +22,7 @@ Config source: [lib/config/species.ts](../lib/config/species.ts)
 - Persisted parent/child links are `composes` edges.
 - Child ordering is read from `node.metadata.playlist.entries`.
 - When playlist entries do not reference all compose-edge children, missing children are appended after playlist-derived ordering.
+- Root anchoring uses `project.root_node_id` when present; otherwise the canvas infers roots from nodes without compose parents.
 
 Source: [app/project/[id]/page.tsx](../app/project/[id]/page.tsx)
 

--- a/lib/data/types.ts
+++ b/lib/data/types.ts
@@ -62,6 +62,8 @@ export interface Project {
   id: string;
   title: string;
   description?: string;
+  /** Optional node id used as the primary canvas anchor/root. */
+  root_node_id?: string;
   /** ISO 8601 timestamp, e.g. "2024-01-01T00:00:00.000Z" */
   created_at: string;
   /** ISO 8601 timestamp, e.g. "2024-01-01T00:00:00.000Z" */

--- a/lib/utils/export.ts
+++ b/lib/utils/export.ts
@@ -38,12 +38,27 @@ function assertProjectBundleShape(value: unknown): asserts value is ProjectBundl
   if (typeof project.title !== "string" || !project.title.trim()) {
     throw new Error("Invalid JSON: project.title must be a non-empty string");
   }
+  if (project.root_node_id !== undefined && typeof project.root_node_id !== "string") {
+    throw new Error("Invalid JSON: project.root_node_id must be a string when provided");
+  }
 
   if (!Array.isArray(value.nodes)) {
     throw new Error("Invalid JSON: nodes must be an array");
   }
   if (!Array.isArray(value.edges)) {
     throw new Error("Invalid JSON: edges must be an array");
+  }
+
+  if (typeof project.root_node_id === "string") {
+    const nodeIds = new Set(
+      value.nodes
+        .filter(isRecord)
+        .map((node) => node.id)
+        .filter((id): id is string => typeof id === "string"),
+    );
+    if (!nodeIds.has(project.root_node_id)) {
+      throw new Error("Invalid JSON: project.root_node_id must reference an existing node id");
+    }
   }
 }
 

--- a/seed/pebbles.json
+++ b/seed/pebbles.json
@@ -1,5 +1,5 @@
 {
-  "project": {"id":"pebbles","title":"Pebbles","description":"An emotion journaling app for capturing and replaying personal moments.","created_at":"2024-01-01T00:00:00.000Z","updated_at":"2024-01-01T00:00:00.000Z"},
+  "project": {"id":"pebbles","title":"Pebbles","description":"An emotion journaling app for capturing and replaying personal moments.","root_node_id":"n-product","created_at":"2024-01-01T00:00:00.000Z","updated_at":"2024-01-01T00:00:00.000Z"},
   "nodes": [
     {"id":"n-product","project_id":"pebbles","species":"flow","title":"Pebbles","description":"A product graph of the Pebbles app, from tokens to scenarios.","status":"live","platforms":["ios","android"],"metadata":{"playlist":{"entries":[{"type":"flow","flow_id":"n-s1"},{"type":"flow","flow_id":"n-s2"},{"type":"flow","flow_id":"n-s3"},{"type":"flow","flow_id":"n-s4"}]}}},
     {"id":"n-s1","project_id":"pebbles","species":"flow","title":"Record a Pebble","description":"Guide the user through capturing an emotion and saving it as a pebble.","status":"development","platforms":["ios","android"],"metadata":{"playlist":{"entries":[{"type":"flow","flow_id":"n-f2"},{"type":"flow","flow_id":"n-f3"},{"type":"flow","flow_id":"n-f1"}]}}},


### PR DESCRIPTION
Fixes #114 

1. Added root_node_id to Project type in types.ts.
2. Enforced import validation for root_node_id in export.ts:
3. Type check when provided.
4. Existence check against node IDs.
5. Invalid explicit root now throws a validation error.
6. Updated canvas root resolution in [app/project/[id]/page.tsx](app/project/[id]/page.tsx#L249):
7. Loads project bundle with useProject.
8. Resolves explicit root from project.root_node_id.
9. Uses explicit root as centered anchor at [app/project/[id]/page.tsx](app/project/[id]/page.tsx#L642).
10. Fans out top-level compose children from that anchor.
11. Preserves inferred-root fallback when root_node_id is missing at [app/project/[id]/page.tsx](app/project/[id]/page.tsx#L696).
12. Kept flow expansion behavior and added project loading gate at [app/project/[id]/page.tsx](app/project/[id]/page.tsx#L811).
13. Added seed field in pebbles.json with root_node_id set to n-product.
14. Updated docs:
15. data-layer.md
16. architecture.md
17. graph-model.md