### PR TITLE
prevent from recursive cycles

### DIFF
--- a/app/project/[id]/page.tsx
+++ b/app/project/[id]/page.tsx
@@ -18,6 +18,7 @@ import { useProject } from "@/lib/hooks/useProject";
 import { useKeyboardShortcuts } from "@/lib/hooks/useKeyboardShortcuts";
 import { downloadJson, exportProject } from "@/lib/utils/export";
 import { generateNodeId } from "@/lib/utils/id";
+import { wouldCreateCycle } from "@/lib/utils/cycle";
 import type { SpeciesId } from "@/lib/config/species";
 import type { Node as DataNode, Edge as DataEdge, PlaylistEntry } from "@/lib/data/types";
 import type { EdgeTypeId } from "@/lib/config/edge-types";
@@ -246,8 +247,9 @@ export default function ProjectCanvasPage() {
   const [exporting, setExporting] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
   const [exportWarning, setExportWarning] = useState<string | null>(null);
+  const [playlistError, setPlaylistError] = useState<string | null>(null);
 
-  const { nodes: dataNodes, loading: nodesLoading, updateNode, addNode, removeNodes } = useNodes(id);
+  const { nodes: dataNodes, loading: nodesLoading, updateNode, addNode, removeNode, removeNodes } = useNodes(id);
   const { edges: dataEdges, loading: edgesLoading, addEdge, removeEdge } = useEdges(id);
   const { project: projectBundle, loading: projectLoading } = useProject(id);
 
@@ -442,7 +444,9 @@ export default function ProjectCanvasPage() {
       const insertBeforeId = preset?.insertBeforeId;
       const newNodeId = generateNodeId(data.species);
 
-      await addNode({
+      setPlaylistError(null);
+
+      const createdNode = await addNode({
         id: newNodeId,
         project_id: id,
         title: data.title,
@@ -453,6 +457,20 @@ export default function ProjectCanvasPage() {
       });
 
       if (parentId) {
+        const parentNode = nodesById.get(parentId);
+        if (parentNode && parentNode.species === "flow" && data.species === "flow") {
+          const nodesForValidation = [
+            ...dataNodes.filter((node) => node.id !== createdNode.id),
+            createdNode,
+          ];
+
+          if (wouldCreateCycle(parentNode.id, createdNode.id, nodesForValidation)) {
+            await removeNode(createdNode.id);
+            setPlaylistError(`Cannot add Flow ${createdNode.id}: it would create a circular reference.`);
+            return;
+          }
+        }
+
         await addEdge({
           id: crypto.randomUUID(),
           project_id: id,
@@ -461,7 +479,6 @@ export default function ProjectCanvasPage() {
           edge_type: "composes",
         });
 
-        const parentNode = nodesById.get(parentId);
         if (parentNode) {
           const existingEntries = Array.isArray(parentNode.metadata?.playlist?.entries)
             ? [...parentNode.metadata.playlist.entries]
@@ -493,7 +510,7 @@ export default function ProjectCanvasPage() {
       setNewNodePreset(null);
       setNewNodeOpen(false);
     },
-    [addEdge, addNode, id, newNodePreset, nodesById, updateNode],
+    [addEdge, addNode, dataNodes, id, newNodePreset, nodesById, removeNode, updateNode],
   );
 
   const handleNodeClick = useCallback<NodeMouseHandler>((_event, xyNode) => {
@@ -832,6 +849,11 @@ export default function ProjectCanvasPage() {
           {exportError && (
             <span className="text-xs text-destructive" role="status" aria-live="polite">
               {exportError}
+            </span>
+          )}
+          {playlistError && (
+            <span className="text-xs text-destructive" role="status" aria-live="polite">
+              {playlistError}
             </span>
           )}
           <Button size="sm" variant="outline" onClick={handleExport} disabled={exporting}>

--- a/lib/data/local-provider.ts
+++ b/lib/data/local-provider.ts
@@ -1,5 +1,31 @@
 import type { DataProvider } from "./data-provider";
-import type { Node, Edge, ProjectBundle } from "./types";
+import type { Node, Edge, ProjectBundle, PlaylistEntry } from "./types";
+import { wouldCreateCycle } from "@/lib/utils/cycle";
+
+function collectReferencedFlowIds(entries: PlaylistEntry[]): string[] {
+  const result: string[] = [];
+
+  for (const entry of entries) {
+    if (entry.type === "flow") {
+      result.push(entry.flow_id);
+      continue;
+    }
+
+    if (entry.type === "condition") {
+      result.push(...collectReferencedFlowIds(entry.if_true));
+      result.push(...collectReferencedFlowIds(entry.if_false));
+      continue;
+    }
+
+    if (entry.type === "junction") {
+      for (const playlistCase of entry.cases) {
+        result.push(...collectReferencedFlowIds(playlistCase.entries));
+      }
+    }
+  }
+
+  return result;
+}
 
 const STORAGE_KEY = "arkaik:store";
 
@@ -163,7 +189,24 @@ export const localProvider: DataProvider = {
     if (!projectId) throw new Error(`Node ${id} not found`);
     const bundle = store.get(projectId)!;
     const idx = bundle.nodes.findIndex((n) => n.id === id);
-    bundle.nodes[idx] = { ...bundle.nodes[idx], ...patch };
+    const nextNode = { ...bundle.nodes[idx], ...patch };
+
+    if (nextNode.species === "flow") {
+      const entries = nextNode.metadata?.playlist?.entries;
+      if (Array.isArray(entries)) {
+        const nextNodes = [...bundle.nodes];
+        nextNodes[idx] = nextNode;
+        const candidateFlowIds = collectReferencedFlowIds(entries);
+
+        for (const candidateFlowId of candidateFlowIds) {
+          if (wouldCreateCycle(nextNode.id, candidateFlowId, nextNodes)) {
+            throw new Error(`Cannot add Flow ${candidateFlowId}: it would create a circular reference.`);
+          }
+        }
+      }
+    }
+
+    bundle.nodes[idx] = nextNode;
     persistStore(store);
     return bundle.nodes[idx];
   },

--- a/lib/utils/cycle.ts
+++ b/lib/utils/cycle.ts
@@ -1,0 +1,68 @@
+import type { Node, PlaylistEntry } from "@/lib/data/types";
+
+function collectReferencedFlowIds(entries: PlaylistEntry[]): string[] {
+  const result: string[] = [];
+
+  for (const entry of entries) {
+    if (entry.type === "flow") {
+      result.push(entry.flow_id);
+      continue;
+    }
+
+    if (entry.type === "condition") {
+      result.push(...collectReferencedFlowIds(entry.if_true));
+      result.push(...collectReferencedFlowIds(entry.if_false));
+      continue;
+    }
+
+    if (entry.type === "junction") {
+      for (const playlistCase of entry.cases) {
+        result.push(...collectReferencedFlowIds(playlistCase.entries));
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Returns true if adding `candidateId` to `flowId`'s playlist would create a cycle.
+ */
+export function wouldCreateCycle(
+  flowId: string,
+  candidateId: string,
+  allNodes: Node[],
+): boolean {
+  if (candidateId === flowId) return true;
+
+  const nodesById = new Map(allNodes.map((node) => [node.id, node]));
+  const candidate = nodesById.get(candidateId);
+  if (!candidate || candidate.species !== "flow") return false;
+
+  const visited = new Set<string>();
+  const stack = [candidateId];
+
+  while (stack.length > 0) {
+    const currentFlowId = stack.pop();
+    if (!currentFlowId) continue;
+    if (visited.has(currentFlowId)) continue;
+    visited.add(currentFlowId);
+
+    const currentFlow = nodesById.get(currentFlowId);
+    if (!currentFlow || currentFlow.species !== "flow") continue;
+
+    const entries = currentFlow.metadata?.playlist?.entries;
+    if (!Array.isArray(entries)) continue;
+
+    const referencedFlowIds = collectReferencedFlowIds(entries);
+    if (referencedFlowIds.includes(flowId)) return true;
+
+    for (const referencedFlowId of referencedFlowIds) {
+      if (!visited.has(referencedFlowId)) {
+        stack.push(referencedFlowId);
+      }
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
Fixes #117 

**What I changed**
1. Added reusable cycle detection utility:
cycle.ts

- Exports wouldCreateCycle(flowId, candidateId, allNodes)
- Handles:
  - Self-reference
  - Direct cycles
  - Transitive cycles
  - Recursive playlist branches (condition/junction)
- Ignores non-flow and missing candidate nodes as non-cycles, per issue design

2. Added provider-level hard validation:
local-provider.ts

- In updateNode, when a flow playlist is being written:
  - Extracts referenced flow IDs from playlist entries
  - Calls wouldCreateCycle for each referenced flow
  - Throws:
    Cannot add Flow F-xxx: it would create a circular reference.
- This future-proofs writes from any current/future UI path using provider updateNode

3. Added UI-side validation and user-visible error handling:
[app/project/[id]/page.tsx](app/project/[id]/page.tsx#L444)

- Imported and used wouldCreateCycle in handleAddNode
- Added page-level playlistError state and surfaced it in header alert area
- For attempted cyclic flow insertion:
  - Newly created node is rolled back via removeNode
  - User sees:
    Cannot add Flow F-xxx: it would create a circular reference.

**Validation run**
1. Build: passed
2. Lint: passed with warnings only (no errors)

Warnings reported were existing style/unused warnings, including:
- NodeDetailPanel.tsx
- local-provider.ts