### PR TITLE
handle recursive rendering

### DIFF
--- a/app/project/[id]/page.tsx
+++ b/app/project/[id]/page.tsx
@@ -24,6 +24,7 @@ import type { Node as DataNode, Edge as DataEdge, PlaylistEntry } from "@/lib/da
 import type { EdgeTypeId } from "@/lib/config/edge-types";
 import {
   addNodeToRollup,
+  computePlaylistRollup,
   createEmptyRollup,
   getEditablePlatformStatuses,
   getRollupDisplayStatus,
@@ -619,26 +620,14 @@ export default function ProjectCanvasPage() {
 
     const flowRollupCache = new Map<string, PlatformStatusRollup>();
 
-    const computeFlowRollup = (flowNodeId: string, visited: Set<string>): PlatformStatusRollup => {
+    const computeFlowRollup = (flowNodeId: string): PlatformStatusRollup => {
       const cached = flowRollupCache.get(flowNodeId);
       if (cached) return cached;
-      if (visited.has(flowNodeId)) return createEmptyRollup();
 
-      visited.add(flowNodeId);
-      const children = getOrderedChildren(flowNodeId);
-      const directViewRollup = children
-        .filter((child) => child.species === "view")
-        .reduce((rollup, child) => addNodeToRollup(rollup, child), createEmptyRollup());
-      const nestedFlowRollup = mergeRollups(
-        ...children
-          .filter((child) => child.species === "flow")
-          .map((child) => computeFlowRollup(child.id, visited)),
-      );
-      visited.delete(flowNodeId);
-
-      const combined = mergeRollups(directViewRollup, nestedFlowRollup);
-      flowRollupCache.set(flowNodeId, combined);
-      return combined;
+      const entries = getPlaylistEntries(flowNodeId);
+      const rollup = computePlaylistRollup(entries, nodesById);
+      flowRollupCache.set(flowNodeId, rollup);
+      return rollup;
     };
 
     const addDataNode = (node: DataNode, position: { x: number; y: number }, visualNodeId = node.id) => {
@@ -652,7 +641,7 @@ export default function ProjectCanvasPage() {
       } as Record<string, unknown>;
 
       if (node.species === "flow") {
-        const flowRollup = computeFlowRollup(node.id, new Set<string>());
+        const flowRollup = computeFlowRollup(node.id);
         baseData.status = getRollupDisplayStatus(flowRollup, node.status);
         baseData.platformRollup = flowRollup;
         baseData.expanded = expandedFlows.has(node.id);

--- a/lib/utils/platform-status.ts
+++ b/lib/utils/platform-status.ts
@@ -7,7 +7,7 @@ import {
   type CountedStatusPresetId,
   type StatusId,
 } from "@/lib/config/statuses";
-import type { Node, PlatformStatusMap } from "@/lib/data/types";
+import type { Node, PlaylistEntry, PlatformStatusMap } from "@/lib/data/types";
 
 export type PlatformStatusCounts = Partial<Record<PlatformId, Partial<Record<StatusId, number>>>>;
 export type PlatformTotals = Partial<Record<PlatformId, number>>;
@@ -151,4 +151,60 @@ export function getRollupDisplayStatus(
   }
 
   return fallbackStatus;
+}
+
+function computePlaylistRollupRecursive(
+  entries: PlaylistEntry[],
+  nodesById: ReadonlyMap<string, Pick<Node, "species" | "status" | "platforms" | "metadata">>,
+  visited: Set<string>,
+): PlatformStatusRollup {
+  let rollup = createEmptyRollup();
+
+  for (const entry of entries) {
+    if (entry.type === "view") {
+      const viewNode = nodesById.get(entry.view_id);
+      if (viewNode) {
+        rollup = addNodeToRollup(rollup, viewNode);
+      }
+      continue;
+    }
+
+    if (entry.type === "flow") {
+      if (!visited.has(entry.flow_id)) {
+        visited.add(entry.flow_id);
+        const flowNode = nodesById.get(entry.flow_id);
+        const subEntries = flowNode?.metadata?.playlist?.entries;
+        if (Array.isArray(subEntries)) {
+          rollup = mergeRollups(rollup, computePlaylistRollupRecursive(subEntries, nodesById, visited));
+        }
+        visited.delete(entry.flow_id);
+      }
+      continue;
+    }
+
+    if (entry.type === "condition") {
+      rollup = mergeRollups(
+        rollup,
+        computePlaylistRollupRecursive(entry.if_true, nodesById, visited),
+        computePlaylistRollupRecursive(entry.if_false, nodesById, visited),
+      );
+      continue;
+    }
+
+    if (entry.type === "junction") {
+      rollup = mergeRollups(
+        rollup,
+        ...entry.cases.map((c) => computePlaylistRollupRecursive(c.entries, nodesById, visited)),
+      );
+    }
+  }
+
+  return rollup;
+}
+
+export function computePlaylistRollup(
+  entries: PlaylistEntry[],
+  nodesById: ReadonlyMap<string, Pick<Node, "species" | "status" | "platforms" | "metadata">>,
+): PlatformStatusRollup {
+  return computePlaylistRollupRecursive(entries, nodesById, new Set());
 }


### PR DESCRIPTION
Fixes #121 

**platform-status.ts**
- Added `PlaylistEntry` to the import from `@/lib/data/types`
- Added private `computePlaylistRollupRecursive` that walks entry types: `view` → `addNodeToRollup`, `flow` → recurse into sub-flow's playlist with visited-set cycle guard, `condition` → merge both branches, `junction` → merge all cases
- Exported `computePlaylistRollup(entries, nodesById)` as the public API

**[app/project/[id]/page.tsx](app/project/%5Bid%5D/page.tsx#L621)**
- Added `computePlaylistRollup` to the `platform-status` import
- Replaced `computeFlowRollup`'s body (was using `getOrderedChildren` + species filters) with: read `getPlaylistEntries(flowNodeId)` → `computePlaylistRollup(entries, nodesById)` → cache + return
- Removed the `visited: Set<string>` parameter — cycle detection now lives entirely inside `computePlaylistRollup`