### PR TITLE
introduce playlist editor

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
 import "./globals.css";
 import { ThemeProvider } from "@/components/theme-provider";
+import { AppToaster } from "@/components/ui/toaster";
 
 export const metadata: Metadata = {
   title: "arkaik",
@@ -28,6 +29,7 @@ export default function RootLayout({
           disableTransitionOnChange
         >
           {children}
+          <AppToaster />
         </ThemeProvider>
       </body>
     </html>

--- a/app/project/[id]/page.tsx
+++ b/app/project/[id]/page.tsx
@@ -446,6 +446,22 @@ export default function ProjectCanvasPage() {
     setSelectedNode(targetNode);
   }, []);
 
+  const handleCreateNodeFromPanel = useCallback(
+    async (species: "flow" | "view", title: string) => {
+      const createdNode = await addNode({
+        id: generateNodeId(species),
+        project_id: id,
+        title,
+        species,
+        status: "idea",
+        platforms: [],
+      });
+
+      return createdNode;
+    },
+    [addNode, id],
+  );
+
   const handleAddChildNode = useCallback((parentId: string, childSpecies: SpeciesId) => {
     setNewNodePreset({ parentId, species: childSpecies });
     setNewNodeOpen(true);
@@ -1069,6 +1085,7 @@ export default function ProjectCanvasPage() {
         allNodes={dataNodes}
         allEdges={dataEdges}
         onNavigate={handleNavigate}
+        onCreateNode={handleCreateNodeFromPanel}
       />
       <NewNodeForm
         key={newNodePreset ? `preset-${newNodePreset.parentId}-${newNodePreset.species}` : "default"}

--- a/components/panels/NodeDetailPanel.tsx
+++ b/components/panels/NodeDetailPanel.tsx
@@ -27,6 +27,7 @@ import { PLATFORMS } from "@/lib/config/platforms";
 import { PLATFORM_DOT_STYLES, PLATFORM_LABELS } from "@/components/graph/nodes/node-styles";
 import { PlatformVariants } from "@/components/panels/PlatformVariants";
 import { PlatformGaugeList } from "@/components/graph/nodes/PlatformGaugeList";
+import { PlaylistEditor } from "@/components/panels/PlaylistEditor";
 import {
   addNodeToRollup,
   createEmptyRollup,
@@ -121,16 +122,17 @@ interface NodeDetailPanelProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   node?: Node;
-  onUpdate?: (id: string, patch: Partial<Omit<Node, "id" | "project_id">>) => void;
+  onUpdate?: (id: string, patch: Partial<Omit<Node, "id" | "project_id">>) => Promise<void> | void;
   onDelete?: (nodeId: string) => void;
   allNodes?: Node[];
   allEdges?: Edge[];
   onNavigate?: (node: Node) => void;
+  onCreateNode?: (species: "flow" | "view", title: string) => Promise<Node>;
 }
 
 interface NodeFieldsProps {
   node: Node;
-  onUpdate?: (id: string, patch: Partial<Omit<Node, "id" | "project_id">>) => void;
+  onUpdate?: (id: string, patch: Partial<Omit<Node, "id" | "project_id">>) => Promise<void> | void;
 }
 
 function NodeFields({ node, onUpdate }: NodeFieldsProps) {
@@ -324,7 +326,7 @@ function ConnectionItem({
 
 interface PlatformVariantsSectionProps {
   node: Node;
-  onUpdate?: (id: string, patch: Partial<Omit<Node, "id" | "project_id">>) => void;
+  onUpdate?: (id: string, patch: Partial<Omit<Node, "id" | "project_id">>) => Promise<void> | void;
 }
 
 function PlatformVariantsSection({ node, onUpdate }: PlatformVariantsSectionProps) {
@@ -383,6 +385,7 @@ export function NodeDetailPanel({
   allNodes,
   allEdges,
   onNavigate,
+  onCreateNode,
 }: NodeDetailPanelProps) {
   const speciesConfig = SPECIES.find((s) => s.id === node?.species);
   const speciesLabel = speciesConfig?.label ?? node?.species;
@@ -428,6 +431,15 @@ export function NodeDetailPanel({
                 node={node}
                 allNodes={allNodes}
                 allEdges={allEdges ?? []}
+              />
+            )}
+            {node.species === "flow" && allNodes && (
+              <PlaylistEditor
+                key={`playlist-${node.id}`}
+                node={node}
+                allNodes={allNodes}
+                onUpdate={onUpdate}
+                onCreateNode={onCreateNode}
               />
             )}
             {allNodes && allEdges && onNavigate && (

--- a/components/panels/NodeSearchCombobox.tsx
+++ b/components/panels/NodeSearchCombobox.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import type { Node as DataNode } from "@/lib/data/types";
+
+interface NodeSearchComboboxProps {
+  species: "view" | "flow";
+  allNodes: DataNode[];
+  onSelect: (nodeId: string) => void;
+  onCreate?: (title: string) => Promise<void> | void;
+  disabled?: boolean;
+}
+
+interface Candidate {
+  id: string;
+  title: string;
+  score: number;
+}
+
+function fuzzyScore(query: string, candidate: string): number {
+  const q = query.trim().toLowerCase();
+  if (!q) return 1;
+
+  const c = candidate.toLowerCase();
+  if (c === q) return 10_000;
+
+  let qIndex = 0;
+  let consecutive = 0;
+  let bestConsecutive = 0;
+  let firstMatchIndex = -1;
+
+  for (let i = 0; i < c.length && qIndex < q.length; i += 1) {
+    if (c[i] === q[qIndex]) {
+      if (firstMatchIndex < 0) firstMatchIndex = i;
+      qIndex += 1;
+      consecutive += 1;
+      bestConsecutive = Math.max(bestConsecutive, consecutive);
+      continue;
+    }
+
+    consecutive = 0;
+  }
+
+  if (qIndex !== q.length) return -1;
+
+  const startBonus = firstMatchIndex === 0 ? 100 : Math.max(0, 25 - firstMatchIndex);
+  const lengthPenalty = Math.max(0, c.length - q.length);
+  return 300 + bestConsecutive * 20 + startBonus - lengthPenalty;
+}
+
+export function NodeSearchCombobox({
+  species,
+  allNodes,
+  onSelect,
+  onCreate,
+  disabled,
+}: NodeSearchComboboxProps) {
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const [query, setQuery] = useState("");
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    function handlePointerDown(event: MouseEvent) {
+      if (!rootRef.current) return;
+      if (rootRef.current.contains(event.target as Node)) return;
+      setOpen(false);
+    }
+
+    document.addEventListener("mousedown", handlePointerDown);
+    return () => document.removeEventListener("mousedown", handlePointerDown);
+  }, []);
+
+  const candidates = useMemo(() => {
+    const scoped = allNodes
+      .filter((node) => node.species === species)
+      .map((node) => {
+        const searchable = `${node.id} ${node.title}`;
+        return {
+          id: node.id,
+          title: node.title,
+          score: fuzzyScore(query, searchable),
+        } satisfies Candidate;
+      })
+      .filter((candidate) => candidate.score >= 0)
+      .sort((a, b) => b.score - a.score || a.title.localeCompare(b.title));
+
+    return scoped.slice(0, 8);
+  }, [allNodes, query, species]);
+
+  const trimmed = query.trim();
+  const hasExactTitle = allNodes.some(
+    (node) => node.species === species && node.title.toLowerCase() === trimmed.toLowerCase(),
+  );
+  const canCreate = Boolean(trimmed) && Boolean(onCreate) && !hasExactTitle;
+
+  async function handleCreate() {
+    if (!onCreate || !trimmed || busy) return;
+    setBusy(true);
+    try {
+      await onCreate(trimmed);
+      setQuery("");
+      setOpen(false);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function handleSelect(nodeId: string) {
+    onSelect(nodeId);
+    setQuery("");
+    setOpen(false);
+  }
+
+  return (
+    <div ref={rootRef} className="relative w-full">
+      <input
+        type="text"
+        value={query}
+        placeholder={`Search ${species}s...`}
+        onChange={(event) => {
+          setQuery(event.target.value);
+          setOpen(true);
+        }}
+        onFocus={() => setOpen(true)}
+        disabled={disabled || busy}
+        className="border-input bg-transparent text-sm text-foreground leading-relaxed rounded-md border px-3 py-2 shadow-xs outline-none placeholder:text-muted-foreground focus:ring-[3px] focus:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 w-full"
+        aria-label={`Search existing ${species} nodes or create a new one`}
+      />
+      {open && (
+        <div className="absolute z-30 mt-1 w-full rounded-md border border-border bg-popover shadow-md">
+          <div className="max-h-60 overflow-y-auto p-1">
+            {candidates.length === 0 && !canCreate && (
+              <p className="px-2 py-2 text-xs text-muted-foreground">No matches.</p>
+            )}
+            {candidates.map((candidate) => (
+              <button
+                key={candidate.id}
+                type="button"
+                className="w-full rounded-sm px-2 py-1.5 text-left text-sm hover:bg-muted"
+                onClick={() => handleSelect(candidate.id)}
+              >
+                <span className="font-medium">{candidate.title}</span>
+                <span className="ml-2 text-xs text-muted-foreground">{candidate.id}</span>
+              </button>
+            ))}
+            {canCreate && (
+              <div className="border-t border-border mt-1 pt-1">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="w-full justify-start"
+                  onClick={handleCreate}
+                  disabled={busy}
+                >
+                  Create &quot;{trimmed}&quot;
+                </Button>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/panels/PlaylistEditor.tsx
+++ b/components/panels/PlaylistEditor.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { toast } from "sonner";
+import type { Node, PlaylistEntry } from "@/lib/data/types";
+import { PlaylistEntryList } from "@/components/panels/PlaylistEntryRow";
+
+interface PlaylistEditorProps {
+  node: Node;
+  allNodes: Node[];
+  onUpdate?: (id: string, patch: Partial<Omit<Node, "id" | "project_id">>) => Promise<void> | void;
+  onCreateNode?: (species: "flow" | "view", title: string) => Promise<Node>;
+}
+
+export function PlaylistEditor({ node, allNodes, onUpdate, onCreateNode }: PlaylistEditorProps) {
+  const entries = Array.isArray(node.metadata?.playlist?.entries)
+    ? node.metadata.playlist.entries
+    : [];
+
+  async function persistEntries(nextEntries: PlaylistEntry[]) {
+    if (!onUpdate) return;
+
+    try {
+      await onUpdate(node.id, {
+        metadata: {
+          ...node.metadata,
+          playlist: {
+            entries: nextEntries,
+          },
+        },
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unable to update playlist";
+      toast.error(message);
+    }
+  }
+
+  function handleCycleBlocked(candidateFlowId: string) {
+    toast.error(`Cannot add Flow ${candidateFlowId}: it would create a circular reference.`);
+  }
+
+  return (
+    <div className="px-6 flex flex-col gap-3">
+      <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Playlist</span>
+      <PlaylistEntryList
+        entries={entries}
+        onChange={persistEntries}
+        flowNodeId={node.id}
+        allNodes={allNodes}
+        onCycleBlocked={handleCycleBlocked}
+        onCreateNode={onCreateNode}
+      />
+    </div>
+  );
+}

--- a/components/panels/PlaylistEntryRow.tsx
+++ b/components/panels/PlaylistEntryRow.tsx
@@ -1,0 +1,386 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { ArrowDownIcon, ArrowUpIcon, PlusIcon, Trash2Icon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+import { wouldCreateCycle } from "@/lib/utils/cycle";
+import type { Node, PlaylistEntry } from "@/lib/data/types";
+import { NodeSearchCombobox } from "@/components/panels/NodeSearchCombobox";
+
+interface PlaylistEntryListProps {
+  entries: PlaylistEntry[];
+  onChange: (entries: PlaylistEntry[]) => Promise<void> | void;
+  flowNodeId: string;
+  allNodes: Node[];
+  onCycleBlocked: (candidateFlowId: string) => void;
+  onCreateNode?: (species: "flow" | "view", title: string) => Promise<Node>;
+  depth?: number;
+  heading?: string;
+}
+
+interface PlaylistEntryRowProps {
+  entry: PlaylistEntry;
+  index: number;
+  total: number;
+  flowNodeId: string;
+  allNodes: Node[];
+  onCycleBlocked: (candidateFlowId: string) => void;
+  onCreateNode?: (species: "flow" | "view", title: string) => Promise<Node>;
+  onChangeEntry: (entry: PlaylistEntry) => Promise<void> | void;
+  onRemove: () => Promise<void> | void;
+  onMove: (delta: -1 | 1) => Promise<void> | void;
+  depth: number;
+}
+
+function createRefEntry(species: "view" | "flow", id: string): PlaylistEntry {
+  if (species === "view") {
+    return { type: "view", view_id: id };
+  }
+
+  return { type: "flow", flow_id: id };
+}
+
+function branchIndentClass(depth: number): string {
+  if (depth <= 0) return "";
+  if (depth === 1) return "ml-4";
+  if (depth === 2) return "ml-8";
+  return "ml-10";
+}
+
+function AddEntryControls({
+  flowNodeId,
+  allNodes,
+  entries,
+  onChange,
+  onCycleBlocked,
+  onCreateNode,
+}: {
+  flowNodeId: string;
+  allNodes: Node[];
+  entries: PlaylistEntry[];
+  onChange: (entries: PlaylistEntry[]) => Promise<void> | void;
+  onCycleBlocked: (candidateFlowId: string) => void;
+  onCreateNode?: (species: "flow" | "view", title: string) => Promise<Node>;
+}) {
+  const [type, setType] = useState<PlaylistEntry["type"]>("view");
+  const [label, setLabel] = useState("");
+
+  async function pushEntry(entry: PlaylistEntry) {
+    await onChange([...entries, entry]);
+  }
+
+  async function handleSelectNode(nodeId: string) {
+    if (type === "flow" && wouldCreateCycle(flowNodeId, nodeId, allNodes)) {
+      onCycleBlocked(nodeId);
+      return;
+    }
+
+    if (type !== "view" && type !== "flow") return;
+    await pushEntry(createRefEntry(type, nodeId));
+  }
+
+  async function handleCreateNode(title: string) {
+    if (!onCreateNode) return;
+    if (type !== "view" && type !== "flow") return;
+
+    const created = await onCreateNode(type, title);
+    const nodesForValidation = [...allNodes.filter((node) => node.id !== created.id), created];
+
+    if (type === "flow" && wouldCreateCycle(flowNodeId, created.id, nodesForValidation)) {
+      onCycleBlocked(created.id);
+      return;
+    }
+
+    await pushEntry(createRefEntry(type, created.id));
+  }
+
+  async function handleAddStructured() {
+    const trimmed = label.trim();
+
+    if (type === "condition") {
+      await pushEntry({
+        type: "condition",
+        label: trimmed || "Condition",
+        if_true: [],
+        if_false: [],
+      });
+      setLabel("");
+      return;
+    }
+
+    if (type === "junction") {
+      await pushEntry({
+        type: "junction",
+        label: trimmed || "Junction",
+        cases: [{ label: "Case 1", entries: [] }],
+      });
+      setLabel("");
+    }
+  }
+
+  return (
+    <div className="border border-dashed border-border rounded-md p-3 flex flex-col gap-2">
+      <div className="grid gap-2 sm:grid-cols-[160px_1fr] sm:items-center">
+        <Select value={type} onValueChange={(value) => setType(value as PlaylistEntry["type"])}>
+          <SelectTrigger aria-label="Playlist entry type">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="view">View</SelectItem>
+            <SelectItem value="flow">Flow</SelectItem>
+            <SelectItem value="condition">Condition</SelectItem>
+            <SelectItem value="junction">Junction</SelectItem>
+          </SelectContent>
+        </Select>
+        {(type === "view" || type === "flow") && (
+          <NodeSearchCombobox
+            species={type}
+            allNodes={allNodes}
+            onSelect={handleSelectNode}
+            onCreate={onCreateNode ? handleCreateNode : undefined}
+          />
+        )}
+        {(type === "condition" || type === "junction") && (
+          <div className="flex items-center gap-2">
+            <Input
+              value={label}
+              onChange={(event) => setLabel(event.target.value)}
+              placeholder={type === "condition" ? "Condition label" : "Junction label"}
+              aria-label={type === "condition" ? "Condition label" : "Junction label"}
+            />
+            <Button type="button" size="sm" onClick={handleAddStructured}>
+              <PlusIcon className="size-4" />
+              Add
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function PlaylistEntryRow({
+  entry,
+  index,
+  total,
+  flowNodeId,
+  allNodes,
+  onCycleBlocked,
+  onCreateNode,
+  onChangeEntry,
+  onRemove,
+  onMove,
+  depth,
+}: PlaylistEntryRowProps) {
+  const nodesById = useMemo(() => new Map(allNodes.map((node) => [node.id, node])), [allNodes]);
+
+  const refNode = entry.type === "flow"
+    ? nodesById.get(entry.flow_id)
+    : entry.type === "view"
+      ? nodesById.get(entry.view_id)
+      : undefined;
+
+  return (
+    <div className={`rounded-md border border-border bg-card p-3 flex flex-col gap-2 ${branchIndentClass(depth)}`}>
+      <div className="flex items-start gap-2">
+        <span className="text-xs text-muted-foreground min-w-6">{index + 1}</span>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium capitalize">{entry.type}</p>
+          {(entry.type === "view" || entry.type === "flow") && (
+            <p className="text-xs text-muted-foreground truncate">
+              {refNode?.title ?? "Missing node"} <span className="ml-1">({entry.type === "view" ? entry.view_id : entry.flow_id})</span>
+            </p>
+          )}
+        </div>
+        <div className="flex items-center gap-1">
+          <Button type="button" size="icon" variant="ghost" disabled={index === 0} onClick={() => onMove(-1)}>
+            <ArrowUpIcon className="size-4" />
+          </Button>
+          <Button type="button" size="icon" variant="ghost" disabled={index >= total - 1} onClick={() => onMove(1)}>
+            <ArrowDownIcon className="size-4" />
+          </Button>
+          <Button type="button" size="icon" variant="ghost" className="text-destructive" onClick={() => void onRemove()}>
+            <Trash2Icon className="size-4" />
+          </Button>
+        </div>
+      </div>
+
+      {entry.type === "condition" && (
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center gap-2">
+            <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Label</span>
+            <Input
+              value={entry.label}
+              onChange={(event) => void onChangeEntry({ ...entry, label: event.target.value })}
+              aria-label="Condition label"
+            />
+          </div>
+          <PlaylistEntryList
+            heading="Yes"
+            entries={entry.if_true}
+            depth={depth + 1}
+            flowNodeId={flowNodeId}
+            allNodes={allNodes}
+            onCycleBlocked={onCycleBlocked}
+            onCreateNode={onCreateNode}
+            onChange={(next) => onChangeEntry({ ...entry, if_true: next })}
+          />
+          <PlaylistEntryList
+            heading="No"
+            entries={entry.if_false}
+            depth={depth + 1}
+            flowNodeId={flowNodeId}
+            allNodes={allNodes}
+            onCycleBlocked={onCycleBlocked}
+            onCreateNode={onCreateNode}
+            onChange={(next) => onChangeEntry({ ...entry, if_false: next })}
+          />
+        </div>
+      )}
+
+      {entry.type === "junction" && (
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center gap-2">
+            <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Label</span>
+            <Input
+              value={entry.label}
+              onChange={(event) => void onChangeEntry({ ...entry, label: event.target.value })}
+              aria-label="Junction label"
+            />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            {entry.cases.map((playlistCase, caseIndex) => (
+              <div key={`${caseIndex}-${playlistCase.label}`} className={`rounded-md border border-border p-2 flex flex-col gap-2 ${branchIndentClass(depth + 1)}`}>
+                <div className="flex items-center gap-2">
+                  <Input
+                    value={playlistCase.label}
+                    onChange={(event) => {
+                      const nextCases = entry.cases.map((item, idx) => {
+                        if (idx !== caseIndex) return item;
+                        return { ...item, label: event.target.value };
+                      });
+                      void onChangeEntry({ ...entry, cases: nextCases });
+                    }}
+                    aria-label={`Junction case ${caseIndex + 1} label`}
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="text-destructive"
+                    onClick={() => {
+                      const nextCases = entry.cases.filter((_, idx) => idx !== caseIndex);
+                      void onChangeEntry({ ...entry, cases: nextCases });
+                    }}
+                  >
+                    <Trash2Icon className="size-4" />
+                  </Button>
+                </div>
+                <PlaylistEntryList
+                  entries={playlistCase.entries}
+                  depth={depth + 2}
+                  flowNodeId={flowNodeId}
+                  allNodes={allNodes}
+                  onCycleBlocked={onCycleBlocked}
+                  onCreateNode={onCreateNode}
+                  onChange={(nextEntries) => {
+                    const nextCases = entry.cases.map((item, idx) => {
+                      if (idx !== caseIndex) return item;
+                      return { ...item, entries: nextEntries };
+                    });
+                    return onChangeEntry({ ...entry, cases: nextCases });
+                  }}
+                />
+              </div>
+            ))}
+          </div>
+
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => void onChangeEntry({
+              ...entry,
+              cases: [...entry.cases, { label: `Case ${entry.cases.length + 1}`, entries: [] }],
+            })}
+          >
+            <PlusIcon className="size-4" />
+            Add case
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function PlaylistEntryList({
+  entries,
+  onChange,
+  flowNodeId,
+  allNodes,
+  onCycleBlocked,
+  onCreateNode,
+  depth = 0,
+  heading,
+}: PlaylistEntryListProps) {
+  async function handleMove(index: number, delta: -1 | 1) {
+    const targetIndex = index + delta;
+    if (targetIndex < 0 || targetIndex >= entries.length) return;
+
+    const next = [...entries];
+    const [moved] = next.splice(index, 1);
+    next.splice(targetIndex, 0, moved);
+    await onChange(next);
+  }
+
+  async function handleRemove(index: number) {
+    await onChange(entries.filter((_, idx) => idx !== index));
+  }
+
+  async function handleReplace(index: number, entry: PlaylistEntry) {
+    const next = entries.map((item, idx) => (idx === index ? entry : item));
+    await onChange(next);
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {heading && <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">{heading}</p>}
+      {entries.length === 0 && (
+        <p className={`text-xs text-muted-foreground ${branchIndentClass(depth)}`}>No entries yet.</p>
+      )}
+      {entries.map((entry, index) => (
+        <PlaylistEntryRow
+          key={`${entry.type}-${index}`}
+          entry={entry}
+          index={index}
+          total={entries.length}
+          flowNodeId={flowNodeId}
+          allNodes={allNodes}
+          onCycleBlocked={onCycleBlocked}
+          onCreateNode={onCreateNode}
+          depth={depth}
+          onMove={(delta) => handleMove(index, delta)}
+          onRemove={() => handleRemove(index)}
+          onChangeEntry={(nextEntry) => handleReplace(index, nextEntry)}
+        />
+      ))}
+      <AddEntryControls
+        flowNodeId={flowNodeId}
+        allNodes={allNodes}
+        entries={entries}
+        onChange={onChange}
+        onCycleBlocked={onCycleBlocked}
+        onCreateNode={onCreateNode}
+      />
+    </div>
+  );
+}

--- a/components/ui/toaster.tsx
+++ b/components/ui/toaster.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { Toaster } from "sonner";
+
+export function AppToaster() {
+  return <Toaster position="top-right" richColors closeButton />;
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,7 +49,10 @@ components/
     StatusBadge.tsx         # Colored pill with status label
   panels/
     NewNodeForm.tsx         # Dialog form for creating a node with species-aware status/platform defaults
-    NodeDetailPanel.tsx     # Slide-in sheet: edit node fields, platform-specific statuses, and computed rollups
+    NodeDetailPanel.tsx     # Slide-in sheet: edit node fields, platform-specific statuses, computed rollups, and flow playlists
+    PlaylistEditor.tsx      # Flow-only playlist editor: add/remove/reorder and branch editing
+    PlaylistEntryRow.tsx    # Recursive playlist row renderer for condition/junction branches
+    NodeSearchCombobox.tsx  # Search-or-create selector for flow/view references
     PlatformVariants.tsx    # Platform tab switcher with per-platform status and notes
   ui/                       # shadcn/ui primitives (button, card, dialog, input, etc.)
 ```
@@ -98,6 +101,9 @@ Clicking any node opens a slide-in `Sheet` (`NodeDetailPanel`) with:
 - **Connections**: cross-layer nodes (data-model, api-endpoint) with click-to-navigate
 - **Platform Variants** (view only): per-platform status + notes stored in `node.metadata`
 - **Computed gauges** (`flow`): read-only per-platform rollups built from descendant views
+- **Playlist editor** (`flow`): ordered `metadata.playlist.entries` editing with add/remove/reorder and recursive condition/junction branch editing
+
+Flow playlist editing uses fuzzy search-or-create for `view` and `flow` entries. When adding a flow reference, cycle checks run before persisting and invalid inserts are blocked with toast feedback.
 
 Edits call `useNodes.updateNode` which flows through the `DataProvider`.
 

--- a/docs/data-layer.md
+++ b/docs/data-layer.md
@@ -174,6 +174,8 @@ NodeDetailPanel (title, description, platforms, metadata)
 Views store editable per-platform statuses in `node.metadata.platformStatuses`. When legacy data does not have that field yet, the UI derives platform statuses from `node.status` + `node.platforms` and writes the richer metadata shape back on the next edit.
 
 Flows do not expose an editable rollup status in UI. Flow cards and panel gauges compute status from descendant views in [app/project/[id]/page.tsx](../app/project/[id]/page.tsx) and [components/panels/NodeDetailPanel.tsx](../components/panels/NodeDetailPanel.tsx).
+ 
+ Flow playlist edits (`metadata.playlist.entries`) also originate from `NodeDetailPanel` via [components/panels/PlaylistEditor.tsx](../components/panels/PlaylistEditor.tsx). All playlist mutations use `useNodes.updateNode`, and provider-side validation blocks circular flow references before persistence.
 
 ## Migration Path
 

--- a/docs/graph-model.md
+++ b/docs/graph-model.md
@@ -32,6 +32,21 @@ Expanded flows render only `flow` and `view` children as in-canvas children.
 
 Source: [app/project/[id]/page.tsx](../app/project/[id]/page.tsx)
 
+### Playlist Entry Types
+
+`flow` nodes store ordered playlist data in `node.metadata.playlist.entries`.
+
+| Entry Type | Required Fields | Notes |
+|---|---|---|
+| `view` | `view_id` | Reference to an existing view node |
+| `flow` | `flow_id` | Reference to an existing flow node (cycle-checked before persist) |
+| `condition` | `label`, `if_true`, `if_false` | Two branch lists, each a recursive `PlaylistEntry[]` |
+| `junction` | `label`, `cases[]` | Each case has `label` + `entries: PlaylistEntry[]` |
+
+Editing source: [components/panels/PlaylistEditor.tsx](../components/panels/PlaylistEditor.tsx), [components/panels/PlaylistEntryRow.tsx](../components/panels/PlaylistEntryRow.tsx)
+
+Type source: [lib/data/types.ts](../lib/data/types.ts)
+
 ## Status Model
 
 Statuses are configured in:

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "next-themes": "^0.4.6",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0"
       },
       "devDependencies": {
@@ -80,6 +81,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2431,8 +2433,9 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2441,8 +2444,9 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2492,6 +2496,7 @@
       "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.1",
         "@typescript-eslint/types": "8.57.1",
@@ -3049,6 +3054,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3404,6 +3410,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3601,7 +3608,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-color": {
@@ -3661,6 +3668,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4110,6 +4118,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4295,6 +4304,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6070,6 +6080,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.0.tgz",
       "integrity": "sha512-NLBVrJy1pbV1Yn00L5sU4vFyAHt5XuSjzrNyFnxo6Com0M0KrL6hHM5B99dbqXb2bE9pm4Ow3Zl1xp6HVY9edQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "16.2.0",
         "@swc/helpers": "0.5.15",
@@ -6529,6 +6540,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6538,6 +6550,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7018,6 +7031,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -7305,6 +7328,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7467,6 +7491,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7794,6 +7819,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "next-themes": "^0.4.6",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #122 foundation and core UI behavior end-to-end.

**What I changed**
- Added flow playlist editing UI with recursive branch support.
- Added search-or-create selector with fuzzy matching for flow/view references.
- Added flow cycle prevention feedback via toast.
- Wired create-new-node from panel for flow/view entries.
- Updated docs for architecture, graph model, and data-layer mutation path.

**New components**
- PlaylistEditor.tsx
- PlaylistEntryRow.tsx
- NodeSearchCombobox.tsx
- toaster.tsx

**Integrated changes**
- Mounted playlist editor in flow detail panel: NodeDetailPanel.tsx
- Added panel node-creation callback and passed into detail panel: [app/project/[id]/page.tsx](app/project/[id]/page.tsx)
- Mounted global toaster: layout.tsx
- Added toast dependency: package.json, package-lock.json

**Docs updated**
- architecture.md
- graph-model.md
- data-layer.md

**Validation**
- Build passes: production compile + TypeScript succeeded.
- Lint has no new errors, only pre-existing warnings in:
1. [app/project/[id]/page.tsx](app/project/[id]/page.tsx)
2. NodeDetailPanel.tsx
3. local-provider.ts

**Notes**
- Reorder is implemented with up/down controls.
- Remove deletes playlist references only.
- Condition and junction nested editing is implemented recursively.
- Flow insertion checks cycles before writing and shows toast on block.