### PR TITLE
introduce invocation section in panel

### DIFF
--- a/components/panels/NodeDetailPanel.tsx
+++ b/components/panels/NodeDetailPanel.tsx
@@ -34,6 +34,7 @@ import {
   getEditablePlatformStatuses,
   mergeRollups,
 } from "@/lib/utils/platform-status";
+import { findWhereUsed } from "@/lib/utils/where-used";
 
 function collectReferencedNodeIds(entries: PlaylistEntry[]): string[] {
   const result: string[] = [];
@@ -262,6 +263,36 @@ function NodeFields({ node, onUpdate }: NodeFieldsProps) {
   );
 }
 
+interface InvocationSectionProps {
+  node: Node;
+  allNodes: Node[];
+  onNavigate: (node: Node) => void;
+}
+
+function InvocationSection({ node, allNodes, onNavigate }: InvocationSectionProps) {
+  const usages = findWhereUsed(node.id, allNodes);
+
+  if (usages.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="px-6 flex flex-col gap-2">
+      <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Invocation</span>
+      <div className="flex flex-col gap-0.5">
+        {usages.map((flow) => (
+          <ConnectionItem
+            key={flow.id}
+            badge={flow.id}
+            node={flow}
+            onNavigate={onNavigate}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
 interface ConnectionsSectionProps {
   node: Node;
   allNodes: Node[];
@@ -440,6 +471,14 @@ export function NodeDetailPanel({
                 allNodes={allNodes}
                 onUpdate={onUpdate}
                 onCreateNode={onCreateNode}
+              />
+            )}
+            {(node.species === "view" || node.species === "flow") && allNodes && onNavigate && (
+              <InvocationSection
+                key={`inv-${node.id}`}
+                node={node}
+                allNodes={allNodes}
+                onNavigate={onNavigate}
               />
             )}
             {allNodes && allEdges && onNavigate && (

--- a/lib/utils/where-used.ts
+++ b/lib/utils/where-used.ts
@@ -1,0 +1,30 @@
+import type { Node, PlaylistEntry } from "@/lib/data/types";
+
+function referencesNode(entries: PlaylistEntry[], targetId: string): boolean {
+  for (const entry of entries) {
+    if (entry.type === "view" && entry.view_id === targetId) return true;
+    if (entry.type === "flow" && entry.flow_id === targetId) return true;
+    if (entry.type === "condition") {
+      if (referencesNode(entry.if_true, targetId) || referencesNode(entry.if_false, targetId)) return true;
+    }
+    if (entry.type === "junction") {
+      for (const c of entry.cases) {
+        if (referencesNode(c.entries, targetId)) return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Returns all Flow nodes whose playlist references the given node id,
+ * including references nested inside condition branches and junction cases.
+ */
+export function findWhereUsed(nodeId: string, allNodes: Node[]): Node[] {
+  return allNodes.filter((node) => {
+    if (node.species !== "flow") return false;
+    const entries = node.metadata?.playlist?.entries;
+    if (!Array.isArray(entries)) return false;
+    return referencesNode(entries, nodeId);
+  });
+}


### PR DESCRIPTION
Fixes #123 

**New file: where-used.ts**
- `findWhereUsed(nodeId, allNodes)` — filters to Flow nodes, then recursively scans each flow's playlist entries (including `condition` branches and `junction` cases) to find any that reference the target id by `view_id` or `flow_id`.

**Updated: NodeDetailPanel.tsx**
- Imports `findWhereUsed`.
- New `InvocationSection` component (lines 266–295): calls `findWhereUsed`, renders nothing when empty, otherwise shows each referencing Flow as a clickable `ConnectionItem` row with the flow id as the badge and the title as the label. Clicking navigates the panel via the existing `onNavigate` callback.
- Rendered for `view` and `flow` species, positioned after PlaylistEditor (for flows) and before the cross-layer Connections section.
- PlaylistEditor, ComputedPlatformStatusSection, and ConnectionsSection are untouched.