### PR TITLE
introduce canvas search actions

### DIFF
--- a/app/project/[id]/page.tsx
+++ b/app/project/[id]/page.tsx
@@ -11,6 +11,7 @@ import { DeleteConfirmDialog } from "@/components/graph/DeleteConfirmDialog";
 import { ArkaikLogo } from "@/components/branding/ArkaikLogo";
 import { NodeDetailPanel } from "@/components/panels/NodeDetailPanel";
 import { NewNodeForm, type NewNodeFormData } from "@/components/panels/NewNodeForm";
+import { InsertBetweenDialog, type InsertEntryType } from "@/components/panels/InsertBetweenDialog";
 import { Button } from "@/components/ui/button";
 import { useNodes } from "@/lib/hooks/useNodes";
 import { useEdges } from "@/lib/hooks/useEdges";
@@ -261,6 +262,12 @@ export default function ProjectCanvasPage() {
   const [panelOpen, setPanelOpen] = useState(false);
   const [newNodeOpen, setNewNodeOpen] = useState(false);
   const [newNodePreset, setNewNodePreset] = useState<{ parentId: string; species: SpeciesId; insertBeforeId?: string } | null>(null);
+  const [insertBetweenOpen, setInsertBetweenOpen] = useState(false);
+  const [insertBetweenType, setInsertBetweenType] = useState<InsertEntryType>("view");
+  const [insertBetweenContext, setInsertBetweenContext] = useState<{
+    parentId: string;
+    insertBeforeId: string;
+  } | null>(null);
   const [exporting, setExporting] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
   const [exportWarning, setExportWarning] = useState<string | null>(null);
@@ -462,20 +469,141 @@ export default function ProjectCanvasPage() {
     [addNode, id],
   );
 
+  const handleInsertPlaylistEntry = useCallback(
+    async (parentId: string, entry: PlaylistEntry, insertBeforeId: string) => {
+      const parentNode = nodesById.get(parentId);
+      if (!parentNode || parentNode.species !== "flow") return false;
+
+      if (entry.type === "view" || entry.type === "flow") {
+        const nodeId = entry.type === "view" ? entry.view_id : entry.flow_id;
+
+        if (entry.type === "flow") {
+          if (wouldCreateCycle(parentNode.id, nodeId, dataNodes)) {
+            setPlaylistError(`Cannot add Flow ${nodeId}: it would create a circular reference.`);
+            return false;
+          }
+        }
+
+        const hasComposeEdge = dataEdges.some(
+          (edge) => edge.edge_type === "composes" && edge.source_id === parentId && edge.target_id === nodeId,
+        );
+
+        if (!hasComposeEdge) {
+          await addEdge({
+            id: crypto.randomUUID(),
+            project_id: id,
+            source_id: parentId,
+            target_id: nodeId,
+            edge_type: "composes",
+          });
+        }
+      }
+
+      const existingEntries = Array.isArray(parentNode.metadata?.playlist?.entries)
+        ? [...parentNode.metadata.playlist.entries]
+        : [];
+
+      const existingPlaylistIds = collectReferencedNodeIds(existingEntries);
+      const insertIndex = existingPlaylistIds.indexOf(insertBeforeId);
+
+      if (insertIndex >= 0) {
+        existingEntries.splice(insertIndex, 0, entry);
+      } else {
+        existingEntries.push(entry);
+      }
+
+      await updateNode(parentNode.id, {
+        metadata: {
+          ...parentNode.metadata,
+          playlist: {
+            entries: existingEntries,
+          },
+        },
+      });
+      return true;
+    },
+    [addEdge, dataEdges, dataNodes, id, nodesById, updateNode],
+  );
+
   const handleAddChildNode = useCallback((parentId: string, childSpecies: SpeciesId) => {
     setNewNodePreset({ parentId, species: childSpecies });
     setNewNodeOpen(true);
   }, []);
 
-  const handleInsertBetween = useCallback((sourceId: string, targetId: string, species: SpeciesId) => {
-    const sourceNodeId = getBaseNodeId(sourceId);
-    const targetNodeId = getBaseNodeId(targetId);
-    const srcParentId = composeParentByChild.get(sourceNodeId);
-    const tgtParentId = composeParentByChild.get(targetNodeId);
-    if (!srcParentId || srcParentId !== tgtParentId) return;
-    setNewNodePreset({ parentId: srcParentId, species, insertBeforeId: targetNodeId });
-    setNewNodeOpen(true);
-  }, [composeParentByChild]);
+  const handleInsertBetween = useCallback((parentFlowVisualId: string, targetEntryVisualId: string) => {
+    const parentId = getBaseNodeId(parentFlowVisualId);
+    const insertBeforeId = getBaseNodeId(targetEntryVisualId);
+    const parentNode = nodesById.get(parentId);
+    if (!parentNode || parentNode.species !== "flow") return;
+    setInsertBetweenType("view");
+    setInsertBetweenContext({ parentId, insertBeforeId });
+    setInsertBetweenOpen(true);
+  }, [nodesById]);
+
+  const handleInsertBetweenSelect = useCallback(async (nodeId: string) => {
+    if (!insertBetweenContext) return;
+    if (insertBetweenType !== "view" && insertBetweenType !== "flow") return;
+    const entry = createPlaylistEntryForSpecies(insertBetweenType, nodeId);
+    if (!entry) return;
+    setPlaylistError(null);
+    const inserted = await handleInsertPlaylistEntry(
+      insertBetweenContext.parentId,
+      entry,
+      insertBetweenContext.insertBeforeId,
+    );
+    if (inserted) {
+      setInsertBetweenOpen(false);
+      setInsertBetweenContext(null);
+    }
+  }, [handleInsertPlaylistEntry, insertBetweenContext, insertBetweenType]);
+
+  const handleInsertBetweenCreate = useCallback(async (title: string) => {
+    if (!insertBetweenContext) return;
+    if (insertBetweenType !== "view" && insertBetweenType !== "flow") return;
+    setPlaylistError(null);
+    const createdNode = await handleCreateNodeFromPanel(insertBetweenType, title);
+    const entry = createPlaylistEntryForSpecies(insertBetweenType, createdNode.id);
+    if (!entry) return;
+    const inserted = await handleInsertPlaylistEntry(
+      insertBetweenContext.parentId,
+      entry,
+      insertBetweenContext.insertBeforeId,
+    );
+    if (inserted) {
+      setInsertBetweenOpen(false);
+      setInsertBetweenContext(null);
+    }
+  }, [handleCreateNodeFromPanel, handleInsertPlaylistEntry, insertBetweenContext, insertBetweenType]);
+
+  const handleInsertBetweenStructured = useCallback(async (label: string) => {
+    if (!insertBetweenContext) return;
+    if (insertBetweenType !== "condition" && insertBetweenType !== "junction") return;
+
+    const entry: PlaylistEntry = insertBetweenType === "condition"
+      ? {
+          type: "condition",
+          label: label.trim() || "Condition",
+          if_true: [],
+          if_false: [],
+        }
+      : {
+          type: "junction",
+          label: label.trim() || "Junction",
+          cases: [{ label: "Case 1", entries: [] }],
+        };
+
+    setPlaylistError(null);
+    const inserted = await handleInsertPlaylistEntry(
+      insertBetweenContext.parentId,
+      entry,
+      insertBetweenContext.insertBeforeId,
+    );
+
+    if (inserted) {
+      setInsertBetweenOpen(false);
+      setInsertBetweenContext(null);
+    }
+  }, [handleInsertPlaylistEntry, insertBetweenContext, insertBetweenType]);
 
   const handleNewNodeOpenChange = useCallback((open: boolean) => {
     setNewNodeOpen(open);
@@ -614,7 +742,7 @@ export default function ProjectCanvasPage() {
       setPanelOpen(false);
     },
     onDelete: () => {
-      if (deleteNodeDialogOpen || deleteEdgeDialogOpen || newNodeOpen || edgeDialogOpen) return;
+      if (deleteNodeDialogOpen || deleteEdgeDialogOpen || newNodeOpen || insertBetweenOpen || edgeDialogOpen) return;
       if (!selectedNode) return;
       handleDeleteNodeRequest(selectedNode.id);
     },
@@ -889,8 +1017,8 @@ export default function ProjectCanvasPage() {
           const priorResult = previousResult;
           const edgeData = priorResult.entryNodeId && entryResult.entryNodeId
             ? {
-                insertLabel: "Insert a View",
-                onInsert: () => handleInsertBetween(priorResult.entryNodeId!, entryResult.entryNodeId!, "view"),
+                insertLabel: "Insert",
+                onInsert: () => handleInsertBetween(parentFlowVisualId, entryResult.entryNodeId!),
               }
             : undefined;
           connectIds(priorResult.endIds, entryResult.startIds, edgeData);
@@ -1093,6 +1221,19 @@ export default function ProjectCanvasPage() {
         onOpenChange={handleNewNodeOpenChange}
         onSubmit={handleAddNode}
         defaultValues={newNodePreset ?? undefined}
+      />
+      <InsertBetweenDialog
+        open={insertBetweenOpen}
+        onOpenChange={(open) => {
+          setInsertBetweenOpen(open);
+          if (!open) setInsertBetweenContext(null);
+        }}
+        entryType={insertBetweenType}
+        onEntryTypeChange={setInsertBetweenType}
+        allNodes={dataNodes}
+        onSelectNode={handleInsertBetweenSelect}
+        onCreateNode={handleInsertBetweenCreate}
+        onInsertStructured={handleInsertBetweenStructured}
       />
       <EdgeTypeDialog
         open={edgeDialogOpen}

--- a/components/graph/edges/ComposeEdge.tsx
+++ b/components/graph/edges/ComposeEdge.tsx
@@ -5,6 +5,10 @@ import { Button } from "@/components/ui/button";
 import { useToolbarHover } from "@/lib/hooks/useToolbarHover";
 
 interface ComposeEdgeData extends Record<string, unknown> {
+  insertActions?: Array<{
+    label: string;
+    onInsert: () => void;
+  }>;
   insertLabel?: string;
   label?: string;
   onInsert?: () => void;
@@ -22,6 +26,11 @@ export function ComposeEdge({
   const { isHovered, nodeProps: pathProps, toolbarProps: buttonProps } = useToolbarHover();
   const [edgePath, labelX, labelY] = getSmoothStepPath({ sourceX, sourceY, sourcePosition, targetX, targetY, targetPosition });
   const edgeData = data as ComposeEdgeData | undefined;
+  const insertActions = edgeData?.insertActions
+    ?? (edgeData?.onInsert
+      ? [{ label: edgeData.insertLabel ?? "Insert", onInsert: edgeData.onInsert }]
+      : []);
+  const hasInsertActions = insertActions.length > 0;
 
   return (
     <>
@@ -41,14 +50,14 @@ export function ComposeEdge({
         {...pathProps}
       />
 
-      {(edgeData?.label || (isHovered && edgeData?.onInsert)) && (
+      {(edgeData?.label || (isHovered && hasInsertActions)) && (
         <EdgeLabelRenderer>
           <>
             {edgeData?.label && (
               <div
                 style={{
                   position: "absolute",
-                  transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY - (edgeData.onInsert ? 16 : 0)}px)`,
+                  transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY - (hasInsertActions ? 16 : 0)}px)`,
                   pointerEvents: "none",
                 }}
                 className="rounded-full border bg-background/95 px-2 py-0.5 text-[11px] font-medium text-muted-foreground shadow-sm"
@@ -56,30 +65,34 @@ export function ComposeEdge({
                 {edgeData.label}
               </div>
             )}
-            {isHovered && edgeData?.onInsert && (
+            {isHovered && hasInsertActions && (
               <div
                 style={{
                   position: "absolute",
-                  transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY + (edgeData.label ? 14 : 0)}px)`,
+                  transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY + (edgeData?.label ? 14 : 0)}px)`,
                   pointerEvents: "all",
                 }}
                 {...buttonProps}
+                className="flex items-center gap-1"
               >
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="outline"
-                        size="icon"
-                        onClick={edgeData.onInsert}
-                        className="size-6 rounded-full"
-                      >
-                        <PlusIcon className="size-3" />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent side="top">{edgeData.insertLabel}</TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
+                {insertActions.map((action) => (
+                  <TooltipProvider key={action.label}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="outline"
+                          size="icon"
+                          onClick={action.onInsert}
+                          className="size-6 rounded-full"
+                          aria-label={action.label}
+                        >
+                          <PlusIcon className="size-3" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent side="top">{action.label}</TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                ))}
               </div>
             )}
           </>

--- a/components/panels/InsertBetweenDialog.tsx
+++ b/components/panels/InsertBetweenDialog.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import type { Node as DataNode } from "@/lib/data/types";
+import { NodeSearchCombobox } from "@/components/panels/NodeSearchCombobox";
+
+export type InsertEntryType = "view" | "flow" | "condition" | "junction";
+
+interface InsertBetweenDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  entryType: InsertEntryType;
+  onEntryTypeChange: (entryType: InsertEntryType) => void;
+  allNodes: DataNode[];
+  onSelectNode: (nodeId: string) => Promise<void> | void;
+  onCreateNode: (title: string) => Promise<void> | void;
+  onInsertStructured: (label: string) => Promise<void> | void;
+  disabled?: boolean;
+}
+
+export function InsertBetweenDialog({
+  open,
+  onOpenChange,
+  entryType,
+  onEntryTypeChange,
+  allNodes,
+  onSelectNode,
+  onCreateNode,
+  onInsertStructured,
+  disabled,
+}: InsertBetweenDialogProps) {
+  const [label, setLabel] = useState("");
+  const isNodeReference = entryType === "view" || entryType === "flow";
+
+  function handleInsertStructured() {
+    void onInsertStructured(label);
+    setLabel("");
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Insert between</DialogTitle>
+          <DialogDescription>
+            Choose what to insert, then select an existing node or create a new one inline.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Type</span>
+            <Select
+              value={entryType}
+              onValueChange={(value) => onEntryTypeChange(value as InsertEntryType)}
+              disabled={disabled}
+            >
+              <SelectTrigger aria-label="Insert type">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="view">View</SelectItem>
+                <SelectItem value="flow">Flow</SelectItem>
+                <SelectItem value="condition">Condition</SelectItem>
+                <SelectItem value="junction">Junction</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          {isNodeReference && (
+            <div className="flex flex-col gap-1.5">
+              <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                Search or create
+              </span>
+              <NodeSearchCombobox
+                species={entryType}
+                allNodes={allNodes}
+                onSelect={onSelectNode}
+                onCreate={onCreateNode}
+                disabled={disabled}
+              />
+            </div>
+          )}
+          {!isNodeReference && (
+            <div className="flex flex-col gap-2">
+              <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Label</span>
+              <div className="flex items-center gap-2">
+                <Input
+                  value={label}
+                  onChange={(event) => setLabel(event.target.value)}
+                  placeholder={entryType === "condition" ? "Condition label" : "Junction label"}
+                  aria-label={entryType === "condition" ? "Condition label" : "Junction label"}
+                  disabled={disabled}
+                />
+                <Button type="button" size="sm" onClick={handleInsertStructured} disabled={disabled}>
+                  Insert
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,6 +25,7 @@ The project page (`app/project/[id]/page.tsx`) is the core of the app. It:
 5. Renders the `Canvas` component with computed nodes and edges
 6. Opens `NodeDetailPanel` on node click for viewing/editing properties
 7. Opens `NewNodeForm` (Dialog) via a floating "New node" button for creating nodes
+8. Opens `InsertBetweenDialog` from compose-edge insert actions for search-or-create insertion in flow playlists
 
 ## Component Map
 
@@ -49,6 +50,7 @@ components/
     StatusBadge.tsx         # Colored pill with status label
   panels/
     NewNodeForm.tsx         # Dialog form for creating a node with species-aware status/platform defaults
+    InsertBetweenDialog.tsx # Dialog for insert-between actions: choose view/flow, search existing, or create inline
     NodeDetailPanel.tsx     # Slide-in sheet: edit node fields, platform-specific statuses, computed rollups, and flow playlists
     PlaylistEditor.tsx      # Flow-only playlist editor: add/remove/reorder and branch editing
     PlaylistEntryRow.tsx    # Recursive playlist row renderer for condition/junction branches
@@ -104,6 +106,8 @@ Clicking any node opens a slide-in `Sheet` (`NodeDetailPanel`) with:
 - **Playlist editor** (`flow`): ordered `metadata.playlist.entries` editing with add/remove/reorder and recursive condition/junction branch editing
 
 Flow playlist editing uses fuzzy search-or-create for `view` and `flow` entries. When adding a flow reference, cycle checks run before persisting and invalid inserts are blocked with toast feedback.
+
+Compose edges in expanded sequences expose a single insert action. It opens `InsertBetweenDialog`, where users choose `view`, `flow`, `condition`, or `junction`. For `view`/`flow`, the dialog reuses `NodeSearchCombobox` to select existing nodes or create new ones inline; for `condition`/`junction`, it inserts structured entries with sensible defaults. Node-reference inserts are placed at the correct playlist position and ensure the compose edge exists.
 
 Edits call `useNodes.updateNode` which flows through the `DataProvider`.
 


### PR DESCRIPTION
Fixes #124 

## Summary

Implemented issue #124 by replacing edge insert actions with a single-entry flow and moving type selection into an insert dialog.  
The insert flow now supports inserting **View**, **Flow**, **Condition**, or **Junction** between playlist entries.

## What changed

- Replaced the two edge insert buttons with one single insert button.
- Added an insert dialog that lets users choose entry type first:
  - View
  - Flow
  - Condition
  - Junction
- For View/Flow:
  - Search existing nodes via combobox
  - Or create inline, then insert
- For Condition/Junction:
  - Insert structured playlist entries with label/default structure
- Fixed insert click behavior so the dialog opens reliably from the active flow context.
- Kept insertion positioning logic (insert-before target) intact.
- Preserved flow cycle protection when inserting flow references.
- Ensured compose edges are created for node-reference inserts when missing.

## UX result

- One plus button on compose edges.
- Clicking always opens insert UI.
- One consistent “search-or-create / structured insert” workflow instead of separate edge buttons.

## Technical notes

- Added a dedicated insert dialog component and wired it into canvas page state/handlers.
- Refactored playlist insertion into a shared helper that supports both node references and structured entries.
- Updated edge rendering to support the single-button interaction model.

## Validation

- Production build passes successfully.
- TypeScript checks pass.
- No reported compile/runtime errors after refactor.

## Docs

- Architecture documentation updated to reflect:
  - single insert action on compose edges
  - insert dialog support for View/Flow/Condition/Junction