### PR TITLE
Features/147 collapse flows

### DIFF
--- a/app/project/[id]/page.tsx
+++ b/app/project/[id]/page.tsx
@@ -32,9 +32,9 @@ import {
   createEmptyRollup,
   getEditablePlatformStatuses,
   getRollupDisplayStatus,
-  mergeRollups,
   type PlatformStatusRollup,
 } from "@/lib/utils/platform-status";
+import { computeElkLayout } from "@/lib/utils/elk-layout";
 
 const SPECIES_TO_NODE_TYPE: Record<SpeciesId, string> = {
   flow: "flow",
@@ -44,15 +44,6 @@ const SPECIES_TO_NODE_TYPE: Record<SpeciesId, string> = {
 };
 
 const FLOW_CHILD_SPECIES = new Set<SpeciesId>(["flow", "view"]);
-const ROOT_FLOW_SPACING = 360;
-const ROOT_ANCHOR_Y = 270;
-const FLOW_CHILD_Y_SPACING = 180;
-const PLAYLIST_DOWN_OFFSET = 240;
-const PLAYLIST_RIGHT_OFFSET = 420;
-const PLAYLIST_HORIZONTAL_SPACING = 320;
-
-const COLLISION_PADDING = 24;
-const MAX_COLLISION_ITERATIONS = 30;
 
 interface RenderSequenceResult {
   startIds: string[];
@@ -109,164 +100,6 @@ function createPlaylistEntryForSpecies(species: SpeciesId, nodeId: string): Play
   }
 
   return null;
-}
-
-interface LayoutSize {
-  width: number;
-  height: number;
-}
-
-interface LayoutRule {
-  fixed?: boolean;
-  axis?: "both" | "x" | "y";
-  clampX?: [number, number];
-  clampY?: [number, number];
-}
-
-function horizontalPositions(
-  cx: number,
-  cy: number,
-  count: number,
-  spacing: number,
-): { x: number; y: number }[] {
-  if (count === 0) return [];
-  const totalWidth = (count - 1) * spacing;
-  const startX = cx - totalWidth / 2;
-  return Array.from({ length: count }, (_, i) => ({
-    x: startX + i * spacing,
-    y: cy,
-  }));
-}
-
-function verticalPositions(
-  cx: number,
-  cy: number,
-  count: number,
-  spacing = FLOW_CHILD_Y_SPACING,
-): { x: number; y: number }[] {
-  if (count === 0) return [];
-  const totalHeight = (count - 1) * spacing;
-  const startY = cy - totalHeight / 2;
-  return Array.from({ length: count }, (_, i) => ({
-    x: cx,
-    y: startY + i * spacing,
-  }));
-}
-
-function verticalStackPositions(
-  cx: number,
-  startY: number,
-  count: number,
-  spacing = FLOW_CHILD_Y_SPACING,
-): { x: number; y: number }[] {
-  if (count === 0) return [];
-  return Array.from({ length: count }, (_, i) => ({
-    x: cx,
-    y: startY + i * spacing,
-  }));
-}
-
-function getNodeSize(nodeType?: string): LayoutSize {
-  switch (nodeType) {
-    case "flow":
-      return { width: 240, height: 136 };
-    case "view":
-      return { width: 224, height: 140 };
-    case "dataModel":
-    case "apiEndpoint":
-      return { width: 192, height: 92 };
-    default:
-      return { width: 180, height: 100 };
-  }
-}
-
-function resolveNodeCollisions(nodes: Node[], rules: Map<string, LayoutRule>): Node[] {
-  if (nodes.length < 2) return nodes;
-
-  const positions = new Map(nodes.map((node) => [node.id, { ...node.position }]));
-  const sizes = new Map(nodes.map((node) => [node.id, getNodeSize(node.type)]));
-  const orderedIds = [...nodes].map((node) => node.id).sort((a, b) => a.localeCompare(b));
-
-  const applyAxis = (axis: LayoutRule["axis"], x: number, y: number) => {
-    if (axis === "x") return { x, y: 0 };
-    if (axis === "y") return { x: 0, y };
-    return { x, y };
-  };
-
-  const clampPosition = (id: string) => {
-    const rule = rules.get(id);
-    const pos = positions.get(id);
-    if (!rule || !pos) return;
-
-    if (rule.clampX) {
-      pos.x = Math.max(rule.clampX[0], Math.min(rule.clampX[1], pos.x));
-    }
-    if (rule.clampY) {
-      pos.y = Math.max(rule.clampY[0], Math.min(rule.clampY[1], pos.y));
-    }
-  };
-
-  for (let i = 0; i < MAX_COLLISION_ITERATIONS; i += 1) {
-    let hadCollision = false;
-
-    for (let aIndex = 0; aIndex < orderedIds.length; aIndex += 1) {
-      const aId = orderedIds[aIndex];
-      const aPos = positions.get(aId);
-      const aSize = sizes.get(aId);
-      if (!aPos || !aSize) continue;
-
-      for (let bIndex = aIndex + 1; bIndex < orderedIds.length; bIndex += 1) {
-        const bId = orderedIds[bIndex];
-        const bPos = positions.get(bId);
-        const bSize = sizes.get(bId);
-        if (!bPos || !bSize) continue;
-
-        const ax = aPos.x + aSize.width / 2;
-        const ay = aPos.y + aSize.height / 2;
-        const bx = bPos.x + bSize.width / 2;
-        const by = bPos.y + bSize.height / 2;
-
-        const dx = bx - ax;
-        const dy = by - ay;
-        const overlapX = (aSize.width + bSize.width) / 2 + COLLISION_PADDING - Math.abs(dx);
-        const overlapY = (aSize.height + bSize.height) / 2 + COLLISION_PADDING - Math.abs(dy);
-
-        if (overlapX <= 0 || overlapY <= 0) continue;
-        hadCollision = true;
-
-        const aRule = rules.get(aId) ?? {};
-        const bRule = rules.get(bId) ?? {};
-        const aFixed = Boolean(aRule.fixed);
-        const bFixed = Boolean(bRule.fixed);
-
-        const moveX = overlapX <= overlapY;
-        const directionX = dx >= 0 ? 1 : -1;
-        const directionY = dy >= 0 ? 1 : -1;
-        const pushX = moveX ? (overlapX / (aFixed || bFixed ? 1 : 2)) * directionX : 0;
-        const pushY = !moveX ? (overlapY / (aFixed || bFixed ? 1 : 2)) * directionY : 0;
-
-        if (!aFixed) {
-          const delta = applyAxis(aRule.axis, -pushX, -pushY);
-          aPos.x += delta.x;
-          aPos.y += delta.y;
-          clampPosition(aId);
-        }
-        if (!bFixed) {
-          const delta = applyAxis(bRule.axis, pushX, pushY);
-          bPos.x += delta.x;
-          bPos.y += delta.y;
-          clampPosition(bId);
-        }
-      }
-    }
-
-    if (!hadCollision) break;
-  }
-
-  return nodes.map((node) => {
-    const position = positions.get(node.id);
-    return position ? { ...node, position } : node;
-  });
 }
 
 export default function ProjectCanvasPage() {
@@ -381,19 +214,6 @@ export default function ProjectCanvasPage() {
     return collectReferencedNodeIds(getPlaylistEntries(nodeId));
   }, [getPlaylistEntries]);
 
-  const getOrderedChildren = useCallback((parentId: string): DataNode[] => {
-    const edgeChildIds = composeChildIdsByParent.get(parentId) ?? [];
-    const playlist = getPlaylist(parentId);
-
-    const orderedIds = [
-      ...playlist,
-      ...edgeChildIds.filter((childId) => !playlist.includes(childId)),
-    ];
-
-    return orderedIds
-      .map((childId) => nodesById.get(childId))
-      .filter((child): child is DataNode => Boolean(child));
-  }, [composeChildIdsByParent, getPlaylist, nodesById]);
 
   useEffect(() => {
     setExpandedFlows((prev) => {
@@ -1030,8 +850,9 @@ export default function ProjectCanvasPage() {
     },
   });
 
-  const { nodes, edges } = useMemo(() => {
-    const layoutRules = new Map<string, LayoutRule>();
+  // Build graph topology — ELK will compute positions asynchronously
+  const graphData = useMemo(() => {
+    const origin = { x: 0, y: 0 };
     const visibleNodes: Node[] = [];
     const visibleEdges: Edge[] = [];
     const visibleNodeIds = new Set<string>();
@@ -1052,7 +873,7 @@ export default function ProjectCanvasPage() {
       return rollup;
     };
 
-    const addDataNode = (node: DataNode, position: { x: number; y: number }, visualNodeId = node.id) => {
+    const addDataNode = (node: DataNode, visualNodeId = node.id) => {
       if (visibleNodeIds.has(visualNodeId)) return;
 
       const baseData = {
@@ -1084,7 +905,7 @@ export default function ProjectCanvasPage() {
       visibleNodes.push({
         id: visualNodeId,
         type: SPECIES_TO_NODE_TYPE[node.species],
-        position,
+        position: origin,
         data: baseData,
       });
       visibleNodeIds.add(visualNodeId);
@@ -1095,7 +916,6 @@ export default function ProjectCanvasPage() {
     const addSyntheticBranchNode = (
       syntheticId: string,
       label: string,
-      position: { x: number; y: number },
       kind: "condition" | "junction",
       summary: string,
     ) => {
@@ -1104,7 +924,7 @@ export default function ProjectCanvasPage() {
       visibleNodes.push({
         id: syntheticId,
         type: "flow",
-        position,
+        position: origin,
         data: {
           label,
           status: "idea",
@@ -1116,7 +936,6 @@ export default function ProjectCanvasPage() {
         },
       });
       visibleNodeIds.add(syntheticId);
-      layoutRules.set(syntheticId, { axis: "both" });
     };
 
     const uniqueIds = (ids: string[]) => [...new Set(ids)];
@@ -1153,34 +972,8 @@ export default function ProjectCanvasPage() {
       }
     };
 
-    const getChildAnchor = (position: { x: number; y: number }, childDepth: number) => {
-      if (childDepth <= 2 || childDepth % 2 === 0) {
-        return { x: position.x, y: position.y + PLAYLIST_DOWN_OFFSET };
-      }
-
-      return { x: position.x + PLAYLIST_RIGHT_OFFSET, y: position.y };
-    };
-
-    const getSequencePositions = (
-      anchor: { x: number; y: number },
-      depth: number,
-      count: number,
-    ) => {
-      if (depth % 2 === 1) {
-        return horizontalPositions(
-          anchor.x,
-          anchor.y,
-          count,
-          depth === 1 ? ROOT_FLOW_SPACING : PLAYLIST_HORIZONTAL_SPACING,
-        );
-      }
-
-      return verticalStackPositions(anchor.x, anchor.y, count, FLOW_CHILD_Y_SPACING);
-    };
-
     const renderSequence = (
       entries: PlaylistEntry[],
-      anchor: { x: number; y: number },
       depth: number,
       flowTrail: Set<string>,
       contextKey: string,
@@ -1190,13 +983,11 @@ export default function ProjectCanvasPage() {
         return { startIds: [], endIds: [] };
       }
 
-      const positions = getSequencePositions(anchor, depth, entries.length);
       let sequenceStartIds: string[] = [];
       let previousResult: RenderSequenceResult | null = null;
 
       const renderEntry = (
         entry: PlaylistEntry,
-        position: { x: number; y: number },
         entryIndex: number,
         entryContextKey: string,
       ): RenderSequenceResult => {
@@ -1205,8 +996,7 @@ export default function ProjectCanvasPage() {
           if (!viewNode) return { startIds: [], endIds: [] };
 
           const viewVisualId = createVisualNodeId(viewNode.id, parentFlowVisualId, entryIndex);
-          addDataNode(viewNode, position, viewVisualId);
-          layoutRules.set(viewVisualId, { axis: "both" });
+          addDataNode(viewNode, viewVisualId);
           return { startIds: [viewVisualId], endIds: [viewVisualId], entryNodeId: viewVisualId };
         }
 
@@ -1215,20 +1005,23 @@ export default function ProjectCanvasPage() {
           if (!flowNode) return { startIds: [], endIds: [] };
 
           const flowVisualId = createVisualNodeId(flowNode.id, parentFlowVisualId, entryIndex);
-          addDataNode(flowNode, position, flowVisualId);
-          layoutRules.set(flowVisualId, { axis: "both" });
+          addDataNode(flowNode, flowVisualId);
+
+          let flowEndIds = [flowVisualId];
 
           if (expandedFlows.has(flowNode.id) && !renderedExpandedFlows.has(flowVisualId) && !flowTrail.has(flowNode.id)) {
             renderedExpandedFlows.add(flowVisualId);
             const nextTrail = new Set(flowTrail);
             nextTrail.add(flowNode.id);
             const flowEntries = getPlaylistEntries(flowNode.id);
-            const childAnchor = getChildAnchor(position, depth + 1);
-            const childSequence = renderSequence(flowEntries, childAnchor, depth + 1, nextTrail, `${entryContextKey}:flow`, flowVisualId);
+            const childSequence = renderSequence(flowEntries, depth + 1, nextTrail, `${entryContextKey}:flow`, flowVisualId);
             connectIds([flowVisualId], childSequence.startIds);
+            if (childSequence.endIds.length > 0) {
+              flowEndIds = childSequence.endIds;
+            }
           }
 
-          return { startIds: [flowVisualId], endIds: [flowVisualId], entryNodeId: flowVisualId };
+          return { startIds: [flowVisualId], endIds: flowEndIds, entryNodeId: flowVisualId };
         }
 
         const branchId = `branch-${entryContextKey}`;
@@ -1242,13 +1035,10 @@ export default function ProjectCanvasPage() {
         addSyntheticBranchNode(
           branchId,
           entry.label,
-          position,
           entry.type,
           branches.map((branch) => branch.label).join(" / "),
         );
 
-        const branchAnchor = getChildAnchor(position, depth + 1);
-        const branchPositions = getSequencePositions(branchAnchor, depth + 1, branches.length);
         const branchEndIds: string[] = [];
 
         branches.forEach((branch, index) => {
@@ -1259,7 +1049,6 @@ export default function ProjectCanvasPage() {
 
           const branchSequence = renderSequence(
             branch.entries,
-            branchPositions[index] ?? branchAnchor,
             depth + 1,
             flowTrail,
             `${entryContextKey}:${index}`,
@@ -1282,7 +1071,7 @@ export default function ProjectCanvasPage() {
 
       for (let index = 0; index < entries.length; index += 1) {
         const entry = entries[index];
-        const entryResult = renderEntry(entry, positions[index] ?? anchor, index, `${contextKey}:${index}`);
+        const entryResult = renderEntry(entry, index, `${contextKey}:${index}`);
         if (entryResult.startIds.length === 0) {
           continue;
         }
@@ -1313,36 +1102,29 @@ export default function ProjectCanvasPage() {
       };
     };
 
+    // Data-layer nodes (data-model, api-endpoint)
     const dataLayerNodes = dataNodes.filter((node) => node.species === "data-model" || node.species === "api-endpoint");
-    const dataLayerPositions = verticalPositions(160, 760, dataLayerNodes.length, 120);
-    dataLayerNodes.forEach((node, index) => {
-      addDataNode(node, dataLayerPositions[index] ?? { x: 160, y: 760 + index * 120 });
-      layoutRules.set(node.id, { axis: "both" });
+    dataLayerNodes.forEach((node) => {
+      addDataNode(node);
     });
 
+    // Flow/view tree
     if (explicitRootNode) {
-      const rootPosition = { x: 900, y: ROOT_ANCHOR_Y };
-      addDataNode(explicitRootNode, rootPosition);
-      layoutRules.set(explicitRootNode.id, { axis: "both", fixed: true });
+      addDataNode(explicitRootNode);
 
       const rootChildren = (composeChildIdsByParent.get(explicitRootNode.id) ?? [])
         .map((childId) => nodesById.get(childId))
         .filter((child): child is DataNode => Boolean(child))
         .filter((child) => child.species === "flow");
-      const rootAnchor = getChildAnchor(rootPosition, 1);
-      const rootChildPositions = getSequencePositions(rootAnchor, 1, rootChildren.length);
 
-      rootChildren.forEach((child, index) => {
-        const childPosition = rootChildPositions[index] ?? rootAnchor;
-        addDataNode(child, childPosition);
-        layoutRules.set(child.id, { axis: "both" });
+      rootChildren.forEach((child) => {
+        addDataNode(child);
         addComposeEdge(explicitRootNode.id, child.id);
 
         if (expandedFlows.has(child.id)) {
           renderedExpandedFlows.add(child.id);
           const childSequence = renderSequence(
             getPlaylistEntries(child.id),
-            getChildAnchor(childPosition, 2),
             2,
             new Set([child.id]),
             `root:${child.id}`,
@@ -1356,7 +1138,6 @@ export default function ProjectCanvasPage() {
         renderedExpandedFlows.add(explicitRootNode.id);
         const rootSequence = renderSequence(
           getPlaylistEntries(explicitRootNode.id),
-          getChildAnchor(rootPosition, 2),
           2,
           new Set([explicitRootNode.id]),
           `root-self:${explicitRootNode.id}`,
@@ -1366,19 +1147,14 @@ export default function ProjectCanvasPage() {
       }
     } else {
       const rootNodes = dataNodes.filter((node) => !composeParentByChild.has(node.id) && FLOW_CHILD_SPECIES.has(node.species));
-      const rootAnchor = { x: 900, y: ROOT_ANCHOR_Y };
-      const rootPositions = getSequencePositions(getChildAnchor(rootAnchor, 1), 1, rootNodes.length);
 
-      rootNodes.forEach((rootNode, index) => {
-        const position = rootPositions[index] ?? rootAnchor;
-        addDataNode(rootNode, position);
-        layoutRules.set(rootNode.id, { axis: "both" });
+      rootNodes.forEach((rootNode) => {
+        addDataNode(rootNode);
 
         if (rootNode.species === "flow" && expandedFlows.has(rootNode.id)) {
           renderedExpandedFlows.add(rootNode.id);
           const rootSequence = renderSequence(
             getPlaylistEntries(rootNode.id),
-            getChildAnchor(position, 2),
             2,
             new Set([rootNode.id]),
             `fallback:${rootNode.id}`,
@@ -1389,6 +1165,7 @@ export default function ProjectCanvasPage() {
       });
     }
 
+    // Cross-layer edges (calls, displays, queries)
     const renderedEdgePairs = new Set(visibleEdges.map((edge) => `${edge.source}:${edge.target}`));
     const EDGE_TYPE_MAP: Record<string, string> = {
       composes: "compose",
@@ -1420,8 +1197,7 @@ export default function ProjectCanvasPage() {
       }
     }
 
-    const collisionFreeNodes = resolveNodeCollisions(visibleNodes, layoutRules);
-    return { nodes: collisionFreeNodes, edges: visibleEdges };
+    return { nodes: visibleNodes, edges: visibleEdges };
   }, [
     explicitRootNode,
     composeChildIdsByParent,
@@ -1430,12 +1206,39 @@ export default function ProjectCanvasPage() {
     dataNodes,
     expandedFlows,
     getPlaylistEntries,
-    getOrderedChildren,
     handleAddChildNode,
     handleInsertBetween,
     nodesById,
     toggleFlow,
   ]);
+
+  // Run ELK layout asynchronously whenever the graph topology changes
+  const [layoutedNodes, setLayoutedNodes] = useState<Node[]>([]);
+  const [layoutReady, setLayoutReady] = useState(false);
+
+  useEffect(() => {
+    if (graphData.nodes.length === 0) {
+      setLayoutedNodes([]);
+      setLayoutReady(true);
+      return;
+    }
+
+    let cancelled = false;
+
+    computeElkLayout(graphData.nodes, graphData.edges).then((result) => {
+      if (!cancelled) {
+        setLayoutedNodes(result.nodes);
+        setLayoutReady(true);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [graphData]);
+
+  const nodes = layoutReady ? layoutedNodes : graphData.nodes;
+  const edges = graphData.edges;
 
   if (nodesLoading || edgesLoading || projectLoading) {
     return (

--- a/components/graph/nodes/FlowNode.tsx
+++ b/components/graph/nodes/FlowNode.tsx
@@ -44,7 +44,8 @@ export function FlowNode({ data }: NodeProps) {
           </button>
         </NodeToolbar>
       )}
-      <Handle type="target" position={Position.Top} className="opacity-0" />
+      <Handle type="target" position={Position.Top} id="top" className="opacity-0" />
+      <Handle type="target" position={Position.Left} id="left" className="opacity-0" />
       <div
         role={isInteractive ? "button" : "group"}
         tabIndex={isInteractive ? 0 : -1}
@@ -102,7 +103,7 @@ export function FlowNode({ data }: NodeProps) {
           <PlatformGaugeList rollup={platformRollup} platforms={platforms.length > 0 ? platforms : PLATFORMS.map((platform) => platform.id)} compact />
         )}
       </div>
-      <Handle type="source" position={Position.Bottom} className="opacity-0" />
+      <Handle type="source" position={Position.Bottom} id="bottom" className="opacity-0" />
       <Handle type="source" position={Position.Right} id="right" className="opacity-0" />
     </>
   );

--- a/components/graph/nodes/ViewNode.tsx
+++ b/components/graph/nodes/ViewNode.tsx
@@ -16,7 +16,8 @@ export function ViewNode({ data }: NodeProps) {
 
   return (
     <>
-      <Handle type="target" position={Position.Left} className="opacity-0" />
+      <Handle type="target" position={Position.Top} id="top" className="opacity-0" />
+      <Handle type="target" position={Position.Left} id="left" className="opacity-0" />
       <div className={`relative ${ghostClass.wrapper}`}>
         <div
           role="img"
@@ -33,7 +34,8 @@ export function ViewNode({ data }: NodeProps) {
           )}
         </div>
       </div>
-      <Handle type="source" position={Position.Right} className="opacity-0" />
+      <Handle type="source" position={Position.Bottom} id="bottom" className="opacity-0" />
+      <Handle type="source" position={Position.Right} id="right" className="opacity-0" />
     </>
   );
 }

--- a/docs/graph-model.md
+++ b/docs/graph-model.md
@@ -28,7 +28,19 @@ Source: [app/project/[id]/page.tsx](../app/project/[id]/page.tsx)
 
 ### Flow Children
 
-All flows start collapsed. Any visible flow can be expanded in-canvas. Top-level expansion (root flow and/or direct flow children of `project.root_node_id`, or inferred root flows when no explicit root exists) is accordion-style: opening one top-level flow collapses any other top-level flow already open. Expanded flows render only `flow` and `view` children as in-canvas children.
+All flows start collapsed. Any visible flow can be expanded in-canvas. Top-level expansion (root flow and/or direct flow children of `project.root_node_id`, or inferred root flows when no explicit root exists) is accordion-style: opening one top-level flow collapses any other top-level flow already open.
+
+Expanded flow children follow a strict alternating drill layout:
+
+- Root children are rendered horizontally below the root.
+- Level 2 children are rendered vertically below each level 1 node.
+- Level 3 children are rendered horizontally below each level 2 node.
+- The pattern continues alternating by depth.
+- Vertical drill segments always use top/bottom handles for both `flow` and `view` nodes.
+
+Layout is computed by **elkjs** (Eclipse Layout Kernel, layered algorithm). The page builds a flat list of nodes and compose edges with `position: {x:0, y:0}`, then an async `useEffect` calls `computeElkLayout()` which runs the ELK layered algorithm and returns positioned nodes.
+
+Layout source: [lib/utils/elk-layout.ts](../lib/utils/elk-layout.ts)
 
 Source: [app/project/[id]/page.tsx](../app/project/[id]/page.tsx)
 

--- a/lib/utils/elk-layout.ts
+++ b/lib/utils/elk-layout.ts
@@ -1,0 +1,87 @@
+import ELK, { type ElkNode, type ElkExtendedEdge } from "elkjs/lib/elk.bundled.js";
+import type { Node, Edge } from "@xyflow/react";
+
+const elk = new ELK();
+
+/** Size lookup matching getNodeSize in the page — keep in sync. */
+function getNodeSize(nodeType?: string): { width: number; height: number } {
+  switch (nodeType) {
+    case "flow":
+      return { width: 240, height: 136 };
+    case "view":
+      return { width: 224, height: 140 };
+    case "dataModel":
+    case "apiEndpoint":
+      return { width: 192, height: 92 };
+    default:
+      return { width: 180, height: 100 };
+  }
+}
+
+export interface ElkLayoutOptions {
+  /** Direction for the top-level layout. Default: "DOWN". */
+  direction?: "DOWN" | "RIGHT";
+}
+
+/**
+ * Run ELK layered layout on a flat list of React Flow nodes and edges.
+ *
+ * Returns a new array of nodes with updated positions.
+ * Edges are returned unchanged (React Flow re-routes them).
+ */
+export async function computeElkLayout(
+  nodes: Node[],
+  edges: Edge[],
+  options: ElkLayoutOptions = {},
+): Promise<{ nodes: Node[]; edges: Edge[] }> {
+  const direction = options.direction ?? "DOWN";
+
+  const elkNodes: ElkNode[] = nodes.map((node) => {
+    const size = getNodeSize(node.type);
+    return {
+      id: node.id,
+      width: size.width,
+      height: size.height,
+    };
+  });
+
+  const elkEdges: ElkExtendedEdge[] = edges
+    .filter((edge) => edge.type === "compose")
+    .map((edge) => ({
+      id: edge.id,
+      sources: [edge.source],
+      targets: [edge.target],
+    }));
+
+  const graph: ElkNode = {
+    id: "root",
+    layoutOptions: {
+      "elk.algorithm": "layered",
+      "elk.direction": direction,
+      "elk.spacing.nodeNode": "20",
+      "elk.layered.spacing.nodeNodeBetweenLayers": "40",
+      "elk.layered.spacing.edgeNodeBetweenLayers": "20",
+      "elk.edgeRouting": "ORTHOGONAL",
+      "elk.layered.nodePlacement.strategy": "NETWORK_SIMPLEX",
+      "elk.layered.crossingMinimization.strategy": "LAYER_SWEEP",
+      "elk.layered.crossingMinimization.forceNodeModelOrder": "true",
+      "elk.hierarchyHandling": "INCLUDE_CHILDREN",
+    },
+    children: elkNodes,
+    edges: elkEdges,
+  };
+
+  const layoutGraph = await elk.layout(graph);
+
+  const positionMap = new Map<string, { x: number; y: number }>();
+  for (const child of layoutGraph.children ?? []) {
+    positionMap.set(child.id, { x: child.x ?? 0, y: child.y ?? 0 });
+  }
+
+  const positionedNodes = nodes.map((node) => {
+    const position = positionMap.get(node.id);
+    return position ? { ...node, position } : node;
+  });
+
+  return { nodes: positionedNodes, edges };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@xyflow/react": "^12.10.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "elkjs": "^0.11.1",
         "geist": "^1.7.0",
         "lucide-react": "^0.577.0",
         "next": "16.2.0",
@@ -3890,6 +3891,12 @@
       "integrity": "sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/elkjs": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.11.1.tgz",
+      "integrity": "sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg==",
+      "license": "EPL-2.0"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@xyflow/react": "^12.10.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "elkjs": "^0.11.1",
     "geist": "^1.7.0",
     "lucide-react": "^0.577.0",
     "next": "16.2.0",


### PR DESCRIPTION
- Replaced ~400 lines of manual positioning code (static offsets, horizontalPositions, verticalStackPositions, getChildAnchor, getSequencePositions, resolveNodeCollisions, DrillAxis, LayoutRule) with a topology-only useMemo that builds nodes at {x:0, y:0} and edges without axis-aware handle assignment
- Added useState/useEffect that runs computeElkLayout() asynchronously whenever the graph shape changes
- Removed unused mergeRollups import and getOrderedChildren callback
- Added import for computeElkLayout
- elk-layout.ts — ELK layout utility (created in prior turn):

- Wraps elkjs layered algorithm with NETWORK_SIMPLEX node placement, LAYER_SWEEP crossing minimization, ORTHOGONAL edge routing
- Only compose edges participate in layout (cross-layer edges are free-floating)
- graph-model.md — Documented the ELK-based layout approach