### PR TITLE
fix map controls theme

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -109,3 +109,50 @@
     color: hsl(var(--foreground));
   }
 }
+
+@layer components {
+  .react-flow__controls {
+    border: 1px solid hsl(var(--border));
+    border-radius: var(--radius);
+    overflow: hidden;
+    box-shadow: 0 6px 16px hsl(240 10% 3.9% / 0.18);
+  }
+
+  .react-flow__controls-button {
+    background-color: hsl(var(--card));
+    border-bottom: 1px solid hsl(var(--border));
+    color: hsl(var(--foreground));
+  }
+
+  .react-flow__controls-button:hover {
+    background-color: hsl(var(--accent));
+  }
+
+  .react-flow__controls-button svg {
+    fill: currentColor;
+  }
+
+  .react-flow__controls-button:last-child {
+    border-bottom: 0;
+  }
+
+  .react-flow__minimap {
+    border: 1px solid hsl(var(--border));
+    border-radius: var(--radius);
+    overflow: hidden;
+  }
+
+  .dark .react-flow__controls {
+    box-shadow: 0 10px 24px hsl(0 0% 0% / 0.45);
+  }
+
+  .dark .react-flow__controls-button {
+    background-color: hsl(var(--card));
+    color: hsl(var(--foreground));
+    border-bottom-color: hsl(var(--border));
+  }
+
+  .dark .react-flow__controls-button:hover {
+    background-color: hsl(var(--accent));
+  }
+}

--- a/components/graph/Canvas.tsx
+++ b/components/graph/Canvas.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useCallback, useRef } from "react";
-import { ReactFlow, MiniMap, Controls, Background, type Node, type Edge, type NodeMouseHandler, type OnConnect, type EdgeMouseHandler, type ReactFlowInstance } from "@xyflow/react";
+import { useCallback, useMemo, useRef, type CSSProperties } from "react";
+import { ReactFlow, Controls, Background, type Node, type Edge, type NodeMouseHandler, type OnConnect, type EdgeMouseHandler, type ReactFlowInstance } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
+import { useTheme } from "next-themes";
 import { FlowNode } from "./nodes/FlowNode";
 import { ViewNode } from "./nodes/ViewNode";
 import { DataModelNode } from "./nodes/DataModelNode";
@@ -10,6 +11,7 @@ import { ApiEndpointNode } from "./nodes/ApiEndpointNode";
 import { ComposeEdge } from "./edges/ComposeEdge";
 import { CrossLayerEdge } from "./edges/CrossLayerEdge";
 import { FloatingDottedEdge } from "./edges/FloatingDottedEdge";
+import { Minimap } from "../layout/Minimap";
 
 const nodeTypes = {
   flow: FlowNode,
@@ -36,6 +38,22 @@ interface CanvasProps {
 
 export function Canvas({ nodes, edges, onNodeClick, onConnect, onEdgeClick }: CanvasProps) {
   const reactFlowRef = useRef<ReactFlowInstance<Node, Edge> | null>(null);
+  const { resolvedTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
+
+  const flowStyle = useMemo(() => {
+    return {
+      "--xy-controls-button-background-color": "hsl(var(--card))",
+      "--xy-controls-button-background-color-hover": "hsl(var(--accent))",
+      "--xy-controls-button-color": "hsl(var(--foreground))",
+      "--xy-controls-button-color-hover": "hsl(var(--foreground))",
+      "--xy-controls-button-border-color": "hsl(var(--border))",
+      "--xy-controls-box-shadow": isDark ? "0 10px 24px hsl(0 0% 0% / 0.45)" : "0 6px 16px hsl(240 10% 3.9% / 0.18)",
+      "--xy-minimap-background-color": "hsl(var(--card))",
+      "--xy-minimap-mask-stroke-color": isDark ? "#60a5fa" : "#3b82f6",
+      "--xy-minimap-mask-stroke-width": "1.5",
+    } as CSSProperties;
+  }, [isDark]);
 
   const handleInit = useCallback((instance: ReactFlowInstance<Node, Edge>) => {
     reactFlowRef.current = instance;
@@ -64,6 +82,8 @@ export function Canvas({ nodes, edges, onNodeClick, onConnect, onEdgeClick }: Ca
         edges={edges}
         nodeTypes={nodeTypes}
         edgeTypes={edgeTypes}
+        colorMode={isDark ? "dark" : "light"}
+        style={flowStyle}
         fitView
         onInit={handleInit}
         onNodeClick={handleNodeClick}
@@ -71,7 +91,7 @@ export function Canvas({ nodes, edges, onNodeClick, onConnect, onEdgeClick }: Ca
         onEdgeClick={onEdgeClick}
       >
         <Controls />
-        <MiniMap />
+        <Minimap />
         <Background />
       </ReactFlow>
     </div>

--- a/components/layout/Minimap.tsx
+++ b/components/layout/Minimap.tsx
@@ -1,7 +1,20 @@
 "use client";
 
 import { MiniMap as ReactFlowMinimap } from "@xyflow/react";
+import { useTheme } from "next-themes";
 
 export function Minimap() {
-  return <ReactFlowMinimap />;
+  const { resolvedTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
+
+  return (
+    <ReactFlowMinimap
+      bgColor={isDark ? "#111827" : "#f8fafc"}
+      nodeColor={isDark ? "#93c5fd" : "#1d4ed8"}
+      nodeStrokeColor={isDark ? "#bfdbfe" : "#2563eb"}
+      maskColor="transparent"
+      maskStrokeColor={isDark ? "#60a5fa" : "#3b82f6"}
+      nodeStrokeWidth={2}
+    />
+  );
 }


### PR DESCRIPTION
Fixes #151 

1. React Flow now receives explicit theme mode from next-themes
- Added theme detection and passed color mode directly in Canvas.tsx

2. React Flow control/minimap colors are now driven by XYFlow CSS variables on the React Flow root
- Added variable injection in Canvas.tsx
- This avoids stylesheet-order issues that were causing white controls to persist

3. MiniMap node/mask contrast was increased significantly
- Set high-contrast colors and transparent mask in Minimap.tsx
- Added node stroke width for visibility in Minimap.tsx