### PR TITLE
update docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,7 +7,8 @@ This project uses Next.js 16 with breaking changes. Read `node_modules/next/dist
 ## Architecture
 
 - Product graph browser built with React Flow on Next.js App Router
-- 8-level species hierarchy (token → product) + 2 parallel layers (data-model, api-endpoint)
+- 4-species model (`flow`, `view`, `data-model`, `api-endpoint`) with playlist-driven flow expansion
+- Project shell routes include both canvas and library (`/project/[id]/canvas`, `/project/[id]/library`)
 - Local-first data with provider abstraction (localStorage now, Supabase planned)
 - See `docs/` for detailed documentation
 
@@ -22,7 +23,7 @@ When reviewing or making changes:
 
 ## Conventions
 
-- State: local hooks (`useNodes`, `useEdges`, `useProject`, `useGraphNavigation`) — no global store
+- State: local hooks (`useNodes`, `useEdges`, `useProject`, `useProjects`, `useGraphNavigation`) — no global store
 - Styling: Tailwind + shadcn/ui + class-variance-authority
 - Config: typed const arrays in `lib/config/` — add new taxonomies there
 - Data: all mutations go through `DataProvider` interface in `lib/data/`

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,4 +6,4 @@
 - [Graph Model](graph-model.md) — 4-species taxonomy, composition model, statuses, platforms, edge types
 - [Data Layer](data-layer.md) — DataProvider interface, local storage, import/export
 - [Conventions](conventions.md) — Coding patterns, file organization, state management
-- [Vision](vision.md) — Full product vision and roadmap (8-level species model, planned features)
+- [Vision](vision.md) — Long-term product direction and roadmap ideas

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,7 +15,7 @@ app/
       layout.tsx        # Shared project shell with persistent sidebar + project switcher
       page.tsx          # Redirects to /project/[id]/canvas
       canvas/
-        page.tsx        # Main canvas — semantic zoom logic lives here
+        page.tsx        # Main canvas — playlist expansion and status rollups
       library/
         page.tsx        # Filterable gallery/directory node browser
 ```
@@ -84,7 +84,7 @@ app/project/[id]/layout.tsx (sidebar shell + route-aware navigation)
   ↕ (props)
 ProjectSidebar + ProjectSwitcher
   ↕ (route changes)
-app/project/[id]/canvas/page.tsx (semantic zoom + status rollup logic)
+app/project/[id]/canvas/page.tsx (playlist expansion + status rollup logic)
     ↕ (props)
 Canvas → ReactFlow → Custom Nodes/Edges
     ↕ (click events)
@@ -115,7 +115,7 @@ Route-aware active states + cross-project navigation
 
 All data mutations flow through the `DataProvider` interface (`lib/data/data-provider.ts`). The current implementation is `localProvider` backed by `localStorage`. The interface is designed for a future Supabase migration — swap the provider, keep the hooks and UI unchanged.
 
-## Semantic Zoom
+## Playlist Expansion
 
 The project page manages one expansion set as local `useState`:
 
@@ -149,6 +149,7 @@ Clicking any node opens a slide-in `Sheet` (`NodeDetailPanel`) with:
 
 - **Editable fields**: title, description, and species-aware status/platform controls
 - **Connections**: cross-layer nodes (data-model, api-endpoint) with click-to-navigate
+- **Where Used**: reverse reference list showing which flow playlists currently include the selected node
 - **Platform Variants** (view only): per-platform status + notes stored in `node.metadata`
 - **Computed gauges** (`flow`): read-only per-platform rollups built from descendant views
 - **Playlist editor** (`flow`): ordered `metadata.playlist.entries` editing with add/remove/reorder and recursive condition/junction branch editing
@@ -158,6 +159,24 @@ Flow playlist editing uses fuzzy search-or-create for `view` and `flow` entries.
 Compose edges in expanded sequences expose a single insert action. It opens `InsertBetweenDialog`, where users choose `view`, `flow`, `condition`, or `junction`. For `view`/`flow`, the dialog reuses `NodeSearchCombobox` to select existing nodes or create new ones inline; for `condition`/`junction`, it inserts structured entries with sensible defaults. Node-reference inserts are placed at the correct playlist position and ensure the compose edge exists.
 
 Edits call `useNodes.updateNode` which flows through the `DataProvider`.
+
+## Library
+
+The library route (`app/project/[id]/library/page.tsx`) is the project-wide browser for reusable nodes.
+
+- **Gallery view**: card layout using `NodeCard` for scanning titles, species/status badges, and flow playlist previews.
+- **Directory view**: sortable table using `NodeTable` for dense auditing (`id`, `title`, `species`, `status`, `used in`).
+- **Filter controls**: `LibraryFilterBar` owns species filtering and text search.
+
+Library interactions reuse the same edit/create surfaces as canvas (`NodeDetailPanel`, `NewNodeForm`) so data mutation paths stay identical.
+
+## Sidebar Navigation
+
+Project-level navigation is defined in `app/project/[id]/layout.tsx` and rendered by `ProjectSidebar` + `ProjectSwitcher`.
+
+- Sidebar links are route-aware (`canvas`, `library`) and preserve active state from pathname/search params.
+- The switcher supports cross-project navigation while keeping users in the closest equivalent destination.
+- Keeping navigation in the shared project layout avoids duplicated route chrome in child pages.
 
 ## Theming
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -23,6 +23,11 @@ docs/                   # This documentation
 
 - **No global store.** No Zustand, Redux, or Context-based state.
 - Reusable state logic lives in hooks: `useNodes`, `useEdges`, `useProject`, `useProjects`, `useGraphNavigation`.
+- Hook intent:
+  - `useNodes` and `useEdges` handle project graph CRUD.
+  - `useProject` handles project-level metadata (including `root_node_id` and card preferences).
+  - `useProjects` powers project lists/switching in route shell UI.
+  - `useGraphNavigation` remains a generic helper for graph navigation state when needed.
 - The project canvas page (`app/project/[id]/canvas/page.tsx`) uses `useNodes` and `useEdges` for data, and manages flow expansion as local `useState` (`expandedFlows`).
 - Data flows via props from the project page down to canvas components.
 - Route-shell concerns such as the project switcher and persistent sidebar should stay in the project layout and use route state plus lightweight hooks instead of introducing shared global state.

--- a/docs/data-layer.md
+++ b/docs/data-layer.md
@@ -135,7 +135,7 @@ Implemented in `lib/data/local-provider.ts`.
 - **Indexing:** Dual index maps — `nodeIndex` (node ID → project ID) and `edgeIndex` (edge ID → project ID) for fast lookups
 - **Persistence:** Auto-persists to `localStorage` on every mutation
 - **Cascade:** `deleteNode` also removes all edges referencing that node
-- **Normalization:** Legacy node fields (`parent_id`, `sort_order`, `position_x`, `position_y`) are stripped on load/import, and ordered `metadata.playlist.entries` values are hydrated from legacy data when present
+- **Normalization:** Legacy structural fields from pre-playlist storage are stripped on load/import, and ordered `metadata.playlist.entries` values are hydrated from legacy data when present
 
 ## Import / Export
 
@@ -162,7 +162,7 @@ Hooks in `lib/hooks/` provide React state wrappers around the provider:
 | `useProjects()` | `{ projects, loading }` | Load the active project list for shell navigation |
 | `useNodes(projectId)` | `{ nodes, loading, addNode, removeNode, updateNode }` | CRUD for nodes |
 | `useEdges(projectId)` | `{ edges, loading, addEdge, removeEdge }` | CRUD for edges |
-| `useGraphNavigation()` | `{ expandedNodeIds, zoomLevel, breadcrumbs, expand, collapse, navigateTo }` | Generic semantic zoom state |
+| `useGraphNavigation()` | `{ expandedNodeIds, zoomLevel, breadcrumbs, expand, collapse, navigateTo }` | Generic graph navigation state utility |
 
 The project canvas page (`app/project/[id]/canvas/page.tsx`) uses `useProject` for root-node anchoring and project-level card-style preferences, and still manages `expandedFlows` as local state.
 

--- a/docs/graph-model.md
+++ b/docs/graph-model.md
@@ -44,16 +44,20 @@ Library source:
 
 ## Composition Model
 
-### Parent/Child Links
+### Root Node
+
+- `project.root_node_id` is the explicit canvas anchor when present.
+- If `root_node_id` is not set, the canvas infers roots from nodes with no incoming `composes` edge.
+
+Source: [app/project/[id]/canvas/page.tsx](../app/project/[id]/canvas/page.tsx), [lib/data/types.ts](../lib/data/types.ts)
+
+### Playlist Expansion
 
 - Persisted parent/child links are `composes` edges.
 - Child ordering is read from `node.metadata.playlist.entries`.
 - When playlist entries do not reference all compose-edge children, missing children are appended after playlist-derived ordering.
-- Root anchoring uses `project.root_node_id` when present; otherwise the canvas infers roots from nodes without compose parents.
 
 Source: [app/project/[id]/canvas/page.tsx](../app/project/[id]/canvas/page.tsx)
-
-### Flow Children
 
 All flows start collapsed. Any visible flow can be expanded in-canvas. Top-level expansion (root flow and/or direct flow children of `project.root_node_id`, or inferred root flows when no explicit root exists) is accordion-style: opening one top-level flow collapses any other top-level flow already open.
 
@@ -70,6 +74,15 @@ Layout is computed by **elkjs** (Eclipse Layout Kernel, layered algorithm). The 
 Layout source: [lib/utils/elk-layout.ts](../lib/utils/elk-layout.ts)
 
 Source: [app/project/[id]/canvas/page.tsx](../app/project/[id]/canvas/page.tsx)
+
+### Node Reuse
+
+- `view` and `flow` nodes are reusable and can appear multiple times across playlists.
+- Reuse is many-to-many: a single node can be referenced by many flow playlists, and one flow playlist can reference many nodes.
+- The source of truth for sequence semantics is the playlist (`metadata.playlist.entries`), while `composes` edges provide structural connectivity.
+- The detail panel's where-used UI derives reverse references by scanning all flow playlists.
+
+Source: [components/panels/NodeDetailPanel.tsx](../components/panels/NodeDetailPanel.tsx), [lib/utils/where-used.ts](../lib/utils/where-used.ts), [lib/data/types.ts](../lib/data/types.ts)
 
 ### Playlist Entry Types
 
@@ -95,7 +108,7 @@ Statuses are configured in:
 Rollup behavior:
 
 - `view` is the only species with editable per-platform status values (`metadata.platformStatuses`).
-- `flow` status is computed for display by aggregating descendant views (including nested sub-flows).
+- `flow` status is computed for display by recursively walking playlist entries and aggregating descendant view platform statuses, including nested sub-flows and branch entries.
 - `data-model` and `api-endpoint` use single lifecycle status.
 
 Sources:

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,179 +1,74 @@
 # Vision
 
-> This document describes the full vision for arkaik — including features not yet implemented.  
-> For the current state, see [architecture.md](architecture.md) and [graph-model.md](graph-model.md).
+> This document describes long-term direction while staying aligned with the current architecture.
+> Source of truth for implemented behavior: [architecture.md](architecture.md), [graph-model.md](graph-model.md), and [data-layer.md](data-layer.md).
 
-## The Problem
+## Problem Statement
 
-Existing tools silo product knowledge: Jira for stories, Figma for screens, Notion for docs, dbdiagram for schemas, Swagger for APIs. No tool lets you **traverse across all these layers fluidly** — from a user story down to the API payload it touches, or from a database table up to which screens render its data, across platforms.
+Product knowledge is usually fragmented across planning docs, design files, API specs, and database tools. Teams lose time reconstructing dependencies between user-facing behavior, backend calls, and data storage.
 
-## What arkaik Is
+arkaik targets that gap with one navigable graph.
 
-**arkaik** is a **product graph browser**. Not a task tracker. Not a wiki. Not a design tool. It's a navigable, multi-dimensional map of a product's full anatomy — from pixels to payloads.
+## Product Direction
 
-### Who Is This For?
+arkaik is a local-first graph workspace for mapping how product behavior is built and reused.
 
-- Solo founders and indie devs who wear every hat
-- Small product teams where design, engineering, and data overlap
-- Anyone who needs to model the full vertical of a product in one place
+The current model centers on four species:
 
-### Core Principles
+- `flow`: ordered sequence container
+- `view`: reusable screen/page node
+- `data-model`: data entity node
+- `api-endpoint`: API contract node
 
-- **One graph, not many docs** — everything is a node, everything can be linked
-- **Opinionated ontology** — the tool *knows* what a flow, a component, a data model is
-- **Semantic zoom** — start at the product level, drill down to a color token
-- **Platform-aware** — first-class support for Web, iOS, Android variants
-- **Local-first** — works offline, data is yours, open-source friendly
+Flow behavior is playlist-driven (`metadata.playlist.entries`) and anchored by optional `project.root_node_id`.
 
-## The Species Model (Atomic Hierarchy)
+## UX Direction
 
-Inspired by Atomic Design, extended upward into flows, scenarios, and the product. Every entity in arkaik belongs to a **species** — a level in the composition hierarchy.
+### Playlist-Centric Exploration
 
-| Level | Species | Examples | Composes from |
-|---|---|---|---|
-| 0 | 🎨 Token | Color token, spacing value, translation key | — |
-| 1 | ◻️ State | Button:hover, Card:loading, Input:error | Tokens |
-| 2 | 🧩 Component | Button, Card, Input, Emotion Wheel | States |
-| 3 | 📐 Section | Card grid, Header bar, Navigation drawer | Components |
-| 4 | 📄 View | Pebble detail page, Emotion picker page | Sections |
-| 5 | 🔀 Flow | "Shape an emotion", "Relate souls" | Views |
-| 6 | 🎬 Scenario | "Record a full pebble" | Flows |
-| 7 | 📦 Product | Pebbles, teale | Scenarios |
+- Expand flows in place to reveal ordered playlist entries.
+- Support branching directly inside playlists via `condition` and `junction` entries.
+- Keep rendering readable with alternating drill layout and top-level accordion expansion.
 
-> **Current implementation:** Only levels 4–5 are implemented as `view` and `flow`. Levels 0–3 and 6–7 are planned. See [graph-model.md](graph-model.md) for the live species list.
+Implementation references: [app/project/[id]/canvas/page.tsx](../app/project/[id]/canvas/page.tsx), [lib/utils/elk-layout.ts](../lib/utils/elk-layout.ts)
 
-### Three Orthogonal Dimensions
+### Reuse-First Authoring
 
-Every node in the graph is described across three axes:
+- Enable many-to-many reuse of `view` and `flow` nodes across playlists.
+- Make reverse references visible in where-used UI.
+- Support insert-between and search-or-create flows directly from composition edges.
 
-1. **Species** — *what it is* (level in the hierarchy above)
-2. **Platform variant** — *where it lives* (Web, iOS, Android)
-3. **Lifecycle status** — *where it's at* (Idea → Live → Archived)
+Implementation references: [components/panels/NodeDetailPanel.tsx](../components/panels/NodeDetailPanel.tsx), [components/panels/InsertBetweenDialog.tsx](../components/panels/InsertBetweenDialog.tsx), [lib/utils/where-used.ts](../lib/utils/where-used.ts)
 
-### Parallel Layers: Data & API
+### Two Complementary Workspaces
 
-Alongside the UI species hierarchy, two parallel layers connect to it:
+- **Canvas route** for spatial graph editing and sequence expansion.
+- **Library route** for high-density browsing, filtering, and metadata audits.
+- **Sidebar shell** for stable in-project navigation between both modes.
 
-- **Data Models** — tables, fields, relations. Linked to components and views that *display* them.
-- **API Endpoints** — routes, methods, payloads, responses. Linked to data models they *query* and views that *call* them.
+Implementation references: [app/project/[id]/canvas/page.tsx](../app/project/[id]/canvas/page.tsx), [app/project/[id]/library/page.tsx](../app/project/[id]/library/page.tsx), [components/layout/ProjectSidebar.tsx](../components/layout/ProjectSidebar.tsx)
 
-## Interaction Model: Semantic Zoom
+## Platform And Status Direction
 
-### Level 0 — Product map
+- Keep per-platform status editing on `view` nodes.
+- Keep `flow` status as computed rollup from descendant views.
+- Continue exposing lifecycle state as a first-class visual signal in cards, panels, and table rows.
 
-Central node(s) = Products. Radiating out = Scenarios. Bird's-eye view, just names and status badges.
+Config sources: [lib/config/platforms.ts](../lib/config/platforms.ts), [lib/config/statuses.ts](../lib/config/statuses.ts)
 
-### Level 1 — Scenario anatomy
+## Data And Backend Direction
 
-Click a Scenario → it expands in-place. Flows that compose it, laid out as connected blocks.
+- Preserve the `DataProvider` abstraction to keep UI/hooks backend-agnostic.
+- Continue local-first operation with import/export.
+- Migrate to Supabase provider without changing UI contracts.
 
-### Level 2 — Flow anatomy (workflow view)
+Implementation references: [lib/data/data-provider.ts](../lib/data/data-provider.ts), [lib/data/local-provider.ts](../lib/data/local-provider.ts), [lib/utils/export.ts](../lib/utils/export.ts)
 
-Click a Flow → it expands into a flowchart:
+## Roadmap Themes
 
-- **View nodes** — if shared across all platforms: single node with stacked indicator. Click to unfold platform variants.
-- **Platform-specific nodes** — when a view differs per platform: 1–3 nodes, color-coded (Web, iOS, Android).
-- **Condition nodes** — diamonds between views: user action, data condition, branching arrows.
-- **Dead-end nodes** — error states, empty states, permission walls (dashed border).
-
-### Level 3 — View detail
-
-Click a view → side panel slides in:
-
-- Platform variants as tabs (mockup or placeholder note)
-- Linked components used in this view
-- Linked data models and API endpoints
-- Status badge
-
-### Key UX Patterns
-
-- **Breadcrumbs** — always visible: `Pebbles > Record a Pebble > Shape an Emotion > View 3`
-- **Minimap** — small overview in the corner
-- **Ghost nodes** — "Idea" status nodes render as dashed/faded
-- **Cross-layer shortcuts** — icon on any view node to jump to Data Model or API Endpoint
-
-## Architecture Diagram
-
-```mermaid
-graph TD
-    subgraph UI["🧬 UI Species Hierarchy"]
-        TOKEN["🎨 Token<br>color, spacing, translation key"]
-        STATE["◻️ State<br>button:hover, card:loading"]
-        COMPONENT["🧩 Component<br>Button, Card, Input"]
-        SECTION["📐 Section<br>Card Grid, Header Bar"]
-        VIEW["📄 View<br>Pebble Detail, Emotion Picker"]
-        FLOW["🔀 Flow<br>Shape an Emotion"]
-        SCENARIO["🎬 Scenario<br>Record a full Pebble"]
-        PRODUCT["📦 Product<br>Pebbles"]
-
-        TOKEN --> STATE
-        STATE --> COMPONENT
-        COMPONENT --> SECTION
-        SECTION --> VIEW
-        VIEW --> FLOW
-        FLOW --> SCENARIO
-        SCENARIO --> PRODUCT
-    end
-
-    subgraph PLATFORM["🌐 Platform Variants"]
-        WEB["Web"]
-        IOS["iOS"]
-        ANDROID["Android"]
-    end
-
-    COMPONENT -. "variant per platform" .-> PLATFORM
-    VIEW -. "variant per platform" .-> PLATFORM
-
-    subgraph DATA["📦 Data Models"]
-        TABLE["Table<br>events, pearls, souls"]
-        FIELD["Field<br>id, name, intensity"]
-        RELATION["Relation<br>event_pearl, event_souls"]
-        FIELD --> TABLE
-        TABLE --> RELATION
-    end
-
-    subgraph API["🔌 API Endpoints"]
-        ROUTE["Route<br>GET /pebbles/:id"]
-        PAYLOAD["Payload<br>request body"]
-        RESPONSE["Response<br>consolidated pebble"]
-        PAYLOAD --> ROUTE
-        ROUTE --> RESPONSE
-    end
-
-    COMPONENT -- "displays data from" --> TABLE
-    VIEW -- "calls" --> ROUTE
-    ROUTE -- "queries" --> TABLE
-```
-
-## Planned Data Model
-
-The full vision targets a Supabase-backed schema:
-
-```sql
--- Nodes: every entity in the graph
--- species: token | state | component | section | view | flow | scenario | product | data-model | api-endpoint
--- status: idea | backlog | prioritized | development | releasing | live | archived | blocked
-
-create table nodes (
-  id uuid primary key default gen_random_uuid(),
-  project_id uuid not null references projects(id) on delete cascade,
-  title text not null,
-  species text not null,
-  status text default 'idea',
-  platforms text[] default '{}',
-  description text,
-  metadata jsonb,
-  created_at timestamptz default now()
-);
-```
-
-> The current `localStorage` implementation already uses this shape — the migration path to Supabase does not require data transformation, only a provider swap. See [data-layer.md](data-layer.md#migration-path) for details.
-
-## Roadmap
-
-| Phase | Feature |
+| Horizon | Theme |
 |---|---|
-| Current | `flow` + `view` species, per-platform statuses, playlist composition, JSON import/export |
-| Near-term | Component and section species (levels 2–3) |
-| Mid-term | Token and state species (levels 0–1), Supabase backend |
-| Long-term | Scenario and product species (levels 6–7), multi-user, real-time sync |
+| Current | Playlist modeling, reusable nodes, route shell, library workflows |
+| Near-term | Better collaboration primitives and stronger validation tooling |
+| Mid-term | Supabase-backed provider parity with local-first behavior |
+| Long-term | Multi-user graph operations, branch-aware review workflows, and richer analytics |


### PR DESCRIPTION
Fixes #127 

### What changed

1. Updated the graph model doc to match playlist-first architecture:
- Added explicit Root node section for root_node_id behavior
- Replaced the old Flow Children section with Playlist Expansion framing
- Added Node reuse section (many-to-many via playlists, where-used concept)
- Clarified flow rollup as recursive playlist traversal

See: graph-model.md

2. Updated architecture documentation:
- Replaced Semantic Zoom wording with Playlist Expansion
- Updated route and data-flow language to match canvas + library shell
- Added explicit Library section
- Added explicit Sidebar Navigation section
- Added Where Used mention in Node Detail Panel

See: architecture.md

3. Updated data layer documentation:
- Removed explicit parent_id mention
- Kept type model centered on playlists/root_node_id
- Adjusted hook wording to generic graph navigation (not semantic zoom)

See: data-layer.md

4. Updated conventions documentation:
- Expanded hook descriptions to reflect current responsibilities (useNodes/useEdges/useProject/useProjects/useGraphNavigation)

See: conventions.md

5. Updated docs index wording:
- Removed old 8-level model phrasing from docs overview

See: README.md

6. Updated Copilot project instructions:
- Architecture now reflects 4-species playlist-driven model
- Added canvas + library route shell note
- Conventions now include useProjects in hook list

See: copilot-instructions.md

7. Rewrote vision doc to remove deprecated hierarchy references and align long-term direction with the current 4-species, playlist-driven architecture.

See: vision.md