### PR TITLE
Improve condition node visual design

### DIFF
--- a/app/project/[id]/canvas/page.tsx
+++ b/app/project/[id]/canvas/page.tsx
@@ -1148,7 +1148,11 @@ export default function ProjectCanvasPage() {
           );
 
           if (branchSequence.startIds.length > 0) {
-            connectIds([branchId], branchSequence.startIds, { label: branch.label });
+            const branchEdgeData: Record<string, unknown> = { label: branch.label };
+            if (entry.type === "condition") {
+              branchEdgeData.edgeColor = branch.label === "Yes" ? "green" : "yellow";
+            }
+            connectIds([branchId], branchSequence.startIds, branchEdgeData);
             branchEndIds.push(...branchSequence.endIds);
           } else {
             branchEndIds.push(branchId);

--- a/components/graph/edges/ComposeEdge.tsx
+++ b/components/graph/edges/ComposeEdge.tsx
@@ -12,6 +12,7 @@ interface ComposeEdgeData extends Record<string, unknown> {
   insertLabel?: string;
   label?: string;
   onInsert?: () => void;
+  edgeColor?: "green" | "yellow";
 }
 
 export function ComposeEdge({
@@ -26,6 +27,7 @@ export function ComposeEdge({
   const { isHovered, nodeProps: pathProps, toolbarProps: buttonProps } = useToolbarHover();
   const [edgePath, labelX, labelY] = getSmoothStepPath({ sourceX, sourceY, sourcePosition, targetX, targetY, targetPosition });
   const edgeData = data as ComposeEdgeData | undefined;
+  const edgeColor = edgeData?.edgeColor;
   const insertActions = edgeData?.insertActions
     ?? (edgeData?.onInsert
       ? [{ label: edgeData.insertLabel ?? "Insert", onInsert: edgeData.onInsert }]
@@ -38,6 +40,7 @@ export function ComposeEdge({
         d={edgePath}
         fill="none"
         strokeWidth={2}
+        style={edgeColor === "green" ? { stroke: "#22c55e" } : edgeColor === "yellow" ? { stroke: "#eab308" } : undefined}
         className="react-flow__edge-path"
         {...pathProps}
       />
@@ -60,7 +63,7 @@ export function ComposeEdge({
                   transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY - (hasInsertActions ? 16 : 0)}px)`,
                   pointerEvents: "none",
                 }}
-                className="rounded-full border bg-background/95 px-2 py-0.5 text-[11px] font-medium text-muted-foreground shadow-sm"
+                className={`rounded-full border bg-background/95 px-2 py-0.5 text-[11px] font-medium shadow-sm ${edgeColor === "green" ? "text-green-500 border-green-500/30" : edgeColor === "yellow" ? "text-yellow-500 border-yellow-500/30" : "text-muted-foreground"}`}
               >
                 {edgeData.label}
               </div>

--- a/components/graph/nodes/FlowNode.tsx
+++ b/components/graph/nodes/FlowNode.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Handle, Position, NodeToolbar, type NodeProps } from "@xyflow/react";
-import { ChevronDown, ChevronRight, Info, PlusCircle } from "lucide-react";
+import { ChevronDown, ChevronRight, Info, PlusCircle, Split } from "lucide-react";
 import type { StatusId } from "@/lib/config/statuses";
 import type { PlatformId } from "@/lib/config/platforms";
 import type { PlatformStatusRollup } from "@/lib/utils/platform-status";
@@ -27,6 +27,7 @@ export function FlowNode({ data }: NodeProps) {
   const ghostClass = STATUS_GHOST_STYLES[status];
   const { isHovered, nodeProps, toolbarProps } = useToolbarHover();
   const isBranch = renderVariant === "branch";
+  const isConditionBranch = isBranch && branchKind === "condition";
   const isInteractive = Boolean(onToggle);
 
   return (
@@ -46,7 +47,20 @@ export function FlowNode({ data }: NodeProps) {
       )}
       <Handle type="target" position={Position.Top} id="top" className="opacity-0" />
       <Handle type="target" position={Position.Left} id="left" className="opacity-0" />
-      <div
+      {isConditionBranch ? (
+        <div
+          role="group"
+          aria-label={label}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-background border-2 border-dashed border-yellow-400 dark:border-yellow-500 shadow-sm"
+          {...nodeProps}
+        >
+          <Split className="w-3.5 h-3.5 shrink-0 text-yellow-500 dark:text-yellow-400" />
+          <span className="text-sm font-medium leading-tight whitespace-nowrap text-foreground">
+            {label}
+          </span>
+        </div>
+      ) : (
+        <div
         role={isInteractive ? "button" : "group"}
         tabIndex={isInteractive ? 0 : -1}
         aria-label={label}
@@ -103,6 +117,7 @@ export function FlowNode({ data }: NodeProps) {
           <PlatformGaugeList rollup={platformRollup} platforms={platforms.length > 0 ? platforms : PLATFORMS.map((platform) => platform.id)} compact />
         )}
       </div>
+      )}
       <Handle type="source" position={Position.Bottom} id="bottom" className="opacity-0" />
       <Handle type="source" position={Position.Right} id="right" className="opacity-0" />
     </>


### PR DESCRIPTION
Fixes #156 

Redesigns the condition branch node on the canvas to be more semantically distinct from regular flow nodes:

- Condition node now renders as a compact content-hugging pill (no fixed-width card), with a `Split` icon and a yellow dashed border — no fade, no "condition" subtitle, no platform gauge.
- "Yes" branch edges are colored green, "No" branch edges are colored yellow (both the line and the label).