### PR TITLE
Add screenshot upload support to platform variants

### DIFF
--- a/components/panels/NodeDetailPanel.tsx
+++ b/components/panels/NodeDetailPanel.tsx
@@ -344,14 +344,16 @@ interface PlatformVariantsSectionProps {
 function PlatformVariantsSection({ node, onUpdate }: PlatformVariantsSectionProps) {
   const rawNotes = (node.metadata?.platformNotes ?? {}) as Partial<Record<PlatformId, string>>;
   const rawStatuses = getEditablePlatformStatuses(node);
+  const rawScreenshots = (node.metadata?.platformScreenshots ?? {}) as Partial<Record<PlatformId, string>>;
   const [notes, setNotes] = useState<Partial<Record<PlatformId, string>>>(rawNotes);
   const [statuses, setStatuses] = useState(rawStatuses);
+  const [screenshots, setScreenshots] = useState<Partial<Record<PlatformId, string>>>(rawScreenshots);
 
   function handleNotesChange(platform: PlatformId, value: string) {
     const next = { ...notes, [platform]: value };
     setNotes(next);
     onUpdate?.(node.id, {
-      metadata: { ...node.metadata, platformNotes: next, platformStatuses: statuses },
+      metadata: { ...node.metadata, platformNotes: next, platformStatuses: statuses, platformScreenshots: screenshots },
     });
   }
 
@@ -367,7 +369,20 @@ function PlatformVariantsSection({ node, onUpdate }: PlatformVariantsSectionProp
     }
     setStatuses(next);
     onUpdate?.(node.id, {
-      metadata: { ...node.metadata, platformStatuses: next, platformNotes: notes },
+      metadata: { ...node.metadata, platformStatuses: next, platformNotes: notes, platformScreenshots: screenshots },
+    });
+  }
+
+  function handleScreenshotChange(platform: PlatformId, value: string | undefined) {
+    const next = { ...screenshots };
+    if (value === undefined) {
+      delete next[platform];
+    } else {
+      next[platform] = value;
+    }
+    setScreenshots(next);
+    onUpdate?.(node.id, {
+      metadata: { ...node.metadata, platformScreenshots: next, platformNotes: notes, platformStatuses: statuses },
     });
   }
 
@@ -377,8 +392,10 @@ function PlatformVariantsSection({ node, onUpdate }: PlatformVariantsSectionProp
       <PlatformVariants
         statuses={statuses}
         notes={notes}
+        screenshots={screenshots}
         onStatusChange={handleStatusChange}
         onNotesChange={handleNotesChange}
+        onScreenshotChange={handleScreenshotChange}
       />
     </div>
   );

--- a/components/panels/PlatformVariants.tsx
+++ b/components/panels/PlatformVariants.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import type { PlatformId } from "@/lib/config/platforms";
 import { PLATFORMS } from "@/lib/config/platforms";
 import {
@@ -19,23 +19,63 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { ImagePlus, X } from "lucide-react";
+
+const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2 MB
+
+function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(new Error("Failed to read file"));
+    reader.readAsDataURL(file);
+  });
+}
 
 export interface PlatformVariantsProps {
   statuses?: PlatformStatusMap;
   notes?: Partial<Record<PlatformId, string>>;
+  screenshots?: Partial<Record<PlatformId, string>>;
   onStatusChange?: (platform: PlatformId, value: StatusId | undefined) => void;
   onNotesChange?: (platform: PlatformId, value: string) => void;
+  onScreenshotChange?: (platform: PlatformId, value: string | undefined) => void;
 }
 
 export function PlatformVariants({
   statuses = {},
   notes = {},
+  screenshots = {},
   onStatusChange,
   onNotesChange,
+  onScreenshotChange,
 }: PlatformVariantsProps) {
   const [activeTab, setActiveTab] = useState<PlatformId>(PLATFORMS[0].id);
+  const [dragOver, setDragOver] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const currentStatus = statuses[activeTab];
   const currentNotes = notes[activeTab] ?? "";
+  const currentScreenshot = screenshots[activeTab];
+
+  async function handleFile(file: File) {
+    if (!file.type.startsWith("image/")) return;
+    if (file.size > MAX_FILE_SIZE) return;
+    const dataUrl = await readFileAsDataUrl(file);
+    onScreenshotChange?.(activeTab, dataUrl);
+  }
+
+  function handleDrop(e: React.DragEvent) {
+    e.preventDefault();
+    setDragOver(false);
+    const file = e.dataTransfer.files[0];
+    if (file) void handleFile(file);
+  }
+
+  function handleFileInput(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (file) void handleFile(file);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  }
 
   return (
     <div className="flex flex-col gap-3">
@@ -113,6 +153,63 @@ export function PlatformVariants({
             placeholder={`Notes for ${PLATFORM_LABELS[activeTab]}…`}
             rows={3}
             className="border-input bg-transparent text-sm text-foreground leading-relaxed resize-none rounded-md border px-3 py-2 outline-none placeholder:text-muted-foreground focus:ring-[3px] focus:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50"
+          />
+        </div>
+        <div className="flex flex-col gap-1.5">
+          <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+            Screenshot
+          </label>
+          {currentScreenshot ? (
+            <div className="relative group">
+              <img
+                src={currentScreenshot}
+                alt={`Screenshot for ${PLATFORM_LABELS[activeTab]}`}
+                className="max-h-40 w-full object-contain rounded-md border border-border"
+              />
+              <Button
+                variant="ghost"
+                size="icon"
+                className="absolute top-1 right-1 size-6 opacity-0 group-hover:opacity-100 transition-opacity bg-background/80 cursor-pointer"
+                aria-label="Remove screenshot"
+                onClick={() => onScreenshotChange?.(activeTab, undefined)}
+              >
+                <X className="size-3.5" />
+              </Button>
+            </div>
+          ) : (
+            <div
+              role="button"
+              tabIndex={0}
+              onClick={() => fileInputRef.current?.click()}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  fileInputRef.current?.click();
+                }
+              }}
+              onDragOver={(e) => {
+                e.preventDefault();
+                setDragOver(true);
+              }}
+              onDragLeave={() => setDragOver(false)}
+              onDrop={handleDrop}
+              className={`flex flex-col items-center justify-center gap-1.5 rounded-md border border-dashed px-3 py-4 text-xs text-muted-foreground cursor-pointer transition-colors ${
+                dragOver
+                  ? "border-foreground bg-muted"
+                  : "border-border hover:border-muted-foreground"
+              }`}
+            >
+              <ImagePlus className="size-5" />
+              <span>Drop an image or click to upload</span>
+              <span className="text-[10px]">Max 2 MB</span>
+            </div>
+          )}
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={handleFileInput}
           />
         </div>
       </div>

--- a/lib/data/types.ts
+++ b/lib/data/types.ts
@@ -15,6 +15,8 @@ export type EdgeType = EdgeTypeId;
 export type PlatformStatusMap = Partial<Record<PlatformId, StatusId>>;
 /** Freeform per-platform notes used by the detail panel. */
 export type PlatformNotesMap = Partial<Record<PlatformId, string>>;
+/** Per-platform screenshot stored as base64 data URI. */
+export type PlatformScreenshotsMap = Partial<Record<PlatformId, string>>;
 
 export type PlaylistEntry =
   | { type: "view"; view_id: string }
@@ -36,6 +38,7 @@ export interface NodeMetadata extends Record<string, unknown> {
   playlist?: FlowPlaylist;
   platformNotes?: PlatformNotesMap;
   platformStatuses?: PlatformStatusMap;
+  platformScreenshots?: PlatformScreenshotsMap;
 }
 
 export interface Node {


### PR DESCRIPTION
## Summary
This PR adds the ability to upload and manage screenshots for each platform variant in the detail panel. Users can now attach images to platform variants via drag-and-drop or file selection, with automatic conversion to base64 data URIs for storage.

## Key Changes
- **PlatformVariants Component**: Added screenshot upload UI with drag-and-drop support
  - New file input handler with image validation (max 2 MB, image files only)
  - Visual feedback for drag-over state
  - Display of uploaded screenshots with remove button
  - Conversion of image files to base64 data URLs for storage
  
- **NodeDetailPanel**: Integrated screenshot management into platform variants section
  - Added state management for screenshots per platform
  - Connected screenshot changes to node metadata updates
  - Ensured screenshots persist alongside existing status and notes data

- **Type Definitions**: Extended metadata types to support screenshots
  - Added `PlatformScreenshotsMap` type for per-platform screenshot storage
  - Updated `NodeMetadata` interface to include `platformScreenshots` field

## Implementation Details
- Screenshots are stored as base64 data URIs in the metadata, enabling self-contained data without external file references
- File validation includes type checking (image/* only) and size limit enforcement (2 MB max)
- The upload UI uses a dashed border drop zone with icon and instructions, matching the existing design language
- Keyboard accessibility is maintained with proper focus handling and Enter/Space key support for the drop zone

https://claude.ai/code/session_0128Sec3XvJSSkGQuF7ntFEP