### PR TITLE
Add platform screenshot support to view nodes

### DIFF
--- a/app/project/[id]/canvas/page.tsx
+++ b/app/project/[id]/canvas/page.tsx
@@ -988,6 +988,7 @@ export default function ProjectCanvasPage() {
         baseData.apiOutbound = apiRelations.outbound;
         baseData.viewCardVariant = viewCardVariant;
         baseData.coverUrl = coverUrl;
+        baseData.platformScreenshots = metadata.platformScreenshots;
         baseData.onOpenDetails = () => {
           setSelectedNode(node);
           setPanelOpen(true);

--- a/components/graph/nodes/ViewNode.tsx
+++ b/components/graph/nodes/ViewNode.tsx
@@ -4,7 +4,7 @@ import { Handle, Position, type NodeProps } from "@xyflow/react";
 import { CloudDownload, CloudUpload, Info } from "lucide-react";
 import type { StatusId } from "@/lib/config/statuses";
 import type { PlatformId } from "@/lib/config/platforms";
-import type { PlatformStatusMap } from "@/lib/data/types";
+import type { PlatformStatusMap, PlatformScreenshotsMap } from "@/lib/data/types";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { STATUS_GHOST_STYLES, STATUS_ICONS, STATUS_LABELS, STATUS_STYLES, PLATFORM_ICONS, PLATFORM_LABELS } from "./node-styles";
@@ -89,7 +89,6 @@ function PlatformStatusIcon({ platform, status }: { platform: PlatformId; status
         <div className="flex flex-col gap-1.5">
           <p className="text-sm font-semibold">{PLATFORM_LABELS[platform]}</p>
           <p className="text-xs text-muted-foreground">Status: {STATUS_LABELS[status]}</p>
-          <p className="text-xs text-muted-foreground">Screenshot support coming soon.</p>
         </div>
       </PopoverContent>
     </Popover>
@@ -112,6 +111,10 @@ export function ViewNode({ data }: NodeProps) {
   const apiInbound = (data.apiInbound as ViewApiRelation[] | undefined) ?? [];
   const apiOutbound = (data.apiOutbound as ViewApiRelation[] | undefined) ?? [];
   const coverUrl = typeof data.coverUrl === "string" ? data.coverUrl : undefined;
+  const platformScreenshots = (data.platformScreenshots as PlatformScreenshotsMap | undefined) ?? {};
+  const firstScreenshot = platforms.reduce<string | undefined>(
+    (found, p) => found ?? platformScreenshots[p], undefined,
+  );
   const onOpenDetails = data.onOpenDetails as (() => void) | undefined;
   const ghostClass = STATUS_GHOST_STYLES[status];
   const showLargeVariant = viewCardVariant === "large";
@@ -150,12 +153,12 @@ export function ViewNode({ data }: NodeProps) {
             )}
           </div>
 
-          {showLargeVariant && coverUrl && (
+          {showLargeVariant && (firstScreenshot || coverUrl) && (
             <div
               role="img"
-              aria-label={`${label} cover`}
+              aria-label={`${label} ${firstScreenshot ? "screenshot" : "cover"}`}
               className="h-28 overflow-hidden rounded-md border border-border bg-muted bg-cover bg-center"
-              style={{ backgroundImage: `url(${coverUrl})` }}
+              style={{ backgroundImage: `url(${firstScreenshot ?? coverUrl})` }}
             />
           )}
 
@@ -178,7 +181,18 @@ export function ViewNode({ data }: NodeProps) {
             </div>
           )}
 
-          {!showLargeVariant && <div className="h-2" />}
+          {!showLargeVariant && (
+            firstScreenshot ? (
+              <div
+                role="img"
+                aria-label={`${label} screenshot`}
+                className="h-24 overflow-hidden rounded-md border border-border bg-muted bg-cover bg-center"
+                style={{ backgroundImage: `url(${firstScreenshot})` }}
+              />
+            ) : (
+              <div className="h-2" />
+            )
+          )}
 
           <div className="mt-auto flex items-center justify-between gap-3">
             {hasAnyApi ? (

--- a/lib/utils/elk-layout.ts
+++ b/lib/utils/elk-layout.ts
@@ -3,13 +3,30 @@ import type { Node, Edge } from "@xyflow/react";
 
 const elk = new ELK();
 
-/** Size lookup matching getNodeSize in the page — keep in sync. */
-function getNodeSize(nodeType?: string): { width: number; height: number } {
-  switch (nodeType) {
+/** Size lookup matching rendered node dimensions — keep in sync with components. */
+function getNodeSize(node: Node): { width: number; height: number } {
+  switch (node.type) {
     case "flow":
       return { width: 240, height: 136 };
-    case "view":
-      return { width: 224, height: 140 };
+    case "view": {
+      const data = node.data as Record<string, unknown>;
+      const isLarge = data.viewCardVariant === "large";
+      const platforms = (data.platforms as string[] | undefined) ?? [];
+      const screenshots = data.platformScreenshots as Record<string, string> | undefined;
+      const hasScreenshot = screenshots != null && Object.values(screenshots).some(Boolean);
+      const hasCover = typeof data.coverUrl === "string";
+      const hasImage = hasScreenshot || hasCover;
+
+      if (isLarge) {
+        // base: py-3(24) + title(28) + gap(12) + platformList(platforms*24 + gaps) + footer(36) + border(4)
+        const platformListHeight = platforms.length > 0 ? platforms.length * 24 + 8 : 0;
+        const imageHeight = hasImage ? 112 + 12 : 0; // h-28 + gap-3
+        return { width: 260, height: 104 + platformListHeight + imageHeight };
+      }
+      // compact: py-3(24) + title(28) + gap(12) + spacer/screenshot + gap(12) + footer(36) + border(4)
+      const screenshotHeight = hasScreenshot ? 96 : 8; // h-24 vs h-2
+      return { width: 224, height: 116 + screenshotHeight };
+    }
     case "dataModel":
     case "apiEndpoint":
       return { width: 192, height: 92 };
@@ -37,7 +54,7 @@ export async function computeElkLayout(
   const direction = options.direction ?? "DOWN";
 
   const elkNodes: ElkNode[] = nodes.map((node) => {
-    const size = getNodeSize(node.type);
+    const size = getNodeSize(node);
     return {
       id: node.id,
       width: size.width,


### PR DESCRIPTION
## Summary
This PR adds support for displaying platform-specific screenshots in view nodes, replacing the "coming soon" placeholder message with actual screenshot functionality.

## Key Changes
- **Import new type**: Added `PlatformScreenshotsMap` type import to ViewNode component
- **Remove placeholder**: Deleted the "Screenshot support coming soon" message from the platform status popover
- **Add screenshot data**: Integrated `platformScreenshots` data from node metadata into ViewNode
- **Display logic**: 
  - For large variant: Display first available platform screenshot, falling back to cover image
  - For compact variant: Display first available platform screenshot as a smaller image, or empty spacer if none available
- **Accessibility**: Updated aria-labels to distinguish between screenshots and cover images
- **Data flow**: Pass `platformScreenshots` from canvas page metadata to node data

## Implementation Details
- Screenshots are prioritized over cover images when available
- The first screenshot found across all platforms is used (determined by platform order)
- Both large and compact card variants now support screenshot display with appropriate sizing
- Maintains backward compatibility by falling back to cover URL when no screenshots are available

https://claude.ai/code/session_01NwS5bgNwiHnbdkyYqwiASV