### PR TITLE
Add screenshot preview dialog with platform navigation

### DIFF
--- a/app/project/[id]/canvas/page.tsx
+++ b/app/project/[id]/canvas/page.tsx
@@ -9,6 +9,7 @@ import { Canvas } from "@/components/graph/Canvas";
 import { EdgeTypeDialog } from "@/components/graph/EdgeTypeDialog";
 import { DeleteConfirmDialog } from "@/components/graph/DeleteConfirmDialog";
 import { NodeDetailPanel } from "@/components/panels/NodeDetailPanel";
+import { ShotPreviewDialog } from "@/components/panels/ShotPreviewDialog";
 import { NewNodeForm, type NewNodeFormData } from "@/components/panels/NewNodeForm";
 import { InsertBetweenDialog, type InsertEntryType } from "@/components/panels/InsertBetweenDialog";
 import { Button } from "@/components/ui/button";
@@ -24,6 +25,7 @@ import { assertProjectBundleShape, downloadJson, exportProject, importProject, n
 import { generateNodeId } from "@/lib/utils/id";
 import { wouldCreateCycle } from "@/lib/utils/cycle";
 import type { SpeciesId } from "@/lib/config/species";
+import type { PlatformId } from "@/lib/config/platforms";
 import type { Node as DataNode, Edge as DataEdge, PlaylistEntry, ProjectBundle } from "@/lib/data/types";
 import type { EdgeTypeId } from "@/lib/config/edge-types";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
@@ -119,6 +121,8 @@ export default function ProjectCanvasPage() {
   const [expandedFlows, setExpandedFlows] = useState<Set<string>>(new Set());
   const [selectedNode, setSelectedNode] = useState<DataNode | null>(null);
   const [panelOpen, setPanelOpen] = useState(false);
+  const [zoomNode, setZoomNode] = useState<DataNode | null>(null);
+  const [zoomPlatform, setZoomPlatform] = useState<PlatformId | undefined>(undefined);
   const [newNodeOpen, setNewNodeOpen] = useState(false);
   const [newNodePreset, setNewNodePreset] = useState<{ parentId: string; species: SpeciesId; insertBeforeId?: string } | null>(null);
   const [insertBetweenOpen, setInsertBetweenOpen] = useState(false);
@@ -993,6 +997,10 @@ export default function ProjectCanvasPage() {
           setSelectedNode(node);
           setPanelOpen(true);
         };
+        baseData.onZoomShot = () => {
+          setZoomNode(node);
+          setZoomPlatform(undefined);
+        };
       }
 
       visibleNodes.push({
@@ -1408,6 +1416,16 @@ export default function ProjectCanvasPage() {
         allEdges={dataEdges}
         onNavigate={handleNavigate}
         onCreateNode={handleCreateNodeFromPanel}
+        onZoomShot={(node, platform) => {
+          setZoomNode(node);
+          setZoomPlatform(platform);
+        }}
+      />
+      <ShotPreviewDialog
+        open={zoomNode !== null}
+        onOpenChange={(open) => { if (!open) setZoomNode(null); }}
+        node={zoomNode ?? undefined}
+        initialPlatform={zoomPlatform}
       />
       <Sheet open={rawOpen} onOpenChange={handleRawOpenChange}>
         <SheetContent className="w-full sm:max-w-3xl">

--- a/components/graph/nodes/ViewNode.tsx
+++ b/components/graph/nodes/ViewNode.tsx
@@ -116,6 +116,7 @@ export function ViewNode({ data }: NodeProps) {
     (found, p) => found ?? platformScreenshots[p], undefined,
   );
   const onOpenDetails = data.onOpenDetails as (() => void) | undefined;
+  const onZoomShot = data.onZoomShot as (() => void) | undefined;
   const ghostClass = STATUS_GHOST_STYLES[status];
   const showLargeVariant = viewCardVariant === "large";
   const hasInboundApi = apiInbound.length > 0;
@@ -157,8 +158,9 @@ export function ViewNode({ data }: NodeProps) {
             <div
               role="img"
               aria-label={`${label} ${firstScreenshot ? "screenshot" : "cover"}`}
-              className="h-28 overflow-hidden rounded-md border border-border bg-muted bg-cover bg-center"
+              className={`h-28 overflow-hidden rounded-md border border-border bg-muted bg-cover bg-center ${onZoomShot ? "cursor-zoom-in" : ""}`}
               style={{ backgroundImage: `url(${firstScreenshot ?? coverUrl})` }}
+              onClick={onZoomShot ? (event) => { event.stopPropagation(); onZoomShot(); } : undefined}
             />
           )}
 
@@ -186,8 +188,9 @@ export function ViewNode({ data }: NodeProps) {
               <div
                 role="img"
                 aria-label={`${label} screenshot`}
-                className="h-24 overflow-hidden rounded-md border border-border bg-muted bg-cover bg-center"
+                className={`h-24 overflow-hidden rounded-md border border-border bg-muted bg-cover bg-center ${onZoomShot ? "cursor-zoom-in" : ""}`}
                 style={{ backgroundImage: `url(${firstScreenshot})` }}
+                onClick={onZoomShot ? (event) => { event.stopPropagation(); onZoomShot(); } : undefined}
               />
             ) : (
               <div className="h-2" />

--- a/components/panels/NodeDetailPanel.tsx
+++ b/components/panels/NodeDetailPanel.tsx
@@ -121,6 +121,7 @@ interface NodeDetailPanelProps {
   allEdges?: Edge[];
   onNavigate?: (node: Node) => void;
   onCreateNode?: (species: "flow" | "view", title: string) => Promise<Node>;
+  onZoomShot?: (node: Node, platform: PlatformId) => void;
 }
 
 interface NodeFieldsProps {
@@ -339,9 +340,10 @@ function ConnectionItem({
 interface PlatformVariantsSectionProps {
   node: Node;
   onUpdate?: (id: string, patch: Partial<Omit<Node, "id" | "project_id">>) => Promise<void> | void;
+  onZoomShot?: (platform: PlatformId) => void;
 }
 
-function PlatformVariantsSection({ node, onUpdate }: PlatformVariantsSectionProps) {
+function PlatformVariantsSection({ node, onUpdate, onZoomShot }: PlatformVariantsSectionProps) {
   const rawNotes = (node.metadata?.platformNotes ?? {}) as Partial<Record<PlatformId, string>>;
   const rawStatuses = getEditablePlatformStatuses(node);
   const rawScreenshots = (node.metadata?.platformScreenshots ?? {}) as Partial<Record<PlatformId, string>>;
@@ -396,6 +398,7 @@ function PlatformVariantsSection({ node, onUpdate }: PlatformVariantsSectionProp
         onStatusChange={handleStatusChange}
         onNotesChange={handleNotesChange}
         onScreenshotChange={handleScreenshotChange}
+        onZoomShot={onZoomShot}
       />
     </div>
   );
@@ -422,6 +425,7 @@ export function NodeDetailPanel({
   allEdges,
   onNavigate,
   onCreateNode,
+  onZoomShot,
 }: NodeDetailPanelProps) {
   void onDelete;
   const speciesConfig = SPECIES.find((s) => s.id === node?.species);
@@ -467,6 +471,7 @@ export function NodeDetailPanel({
                 key={`pv-${node.id}`}
                 node={node}
                 onUpdate={onUpdate}
+                onZoomShot={onZoomShot ? (platform) => onZoomShot(node, platform) : undefined}
               />
             )}
             {node.species === "flow" && allNodes && (

--- a/components/panels/PlatformVariants.tsx
+++ b/components/panels/PlatformVariants.tsx
@@ -40,6 +40,7 @@ export interface PlatformVariantsProps {
   onStatusChange?: (platform: PlatformId, value: StatusId | undefined) => void;
   onNotesChange?: (platform: PlatformId, value: string) => void;
   onScreenshotChange?: (platform: PlatformId, value: string | undefined) => void;
+  onZoomShot?: (platform: PlatformId) => void;
 }
 
 export function PlatformVariants({
@@ -49,6 +50,7 @@ export function PlatformVariants({
   onStatusChange,
   onNotesChange,
   onScreenshotChange,
+  onZoomShot,
 }: PlatformVariantsProps) {
   const [activeTab, setActiveTab] = useState<PlatformId>(PLATFORMS[0].id);
   const [dragOver, setDragOver] = useState(false);
@@ -164,7 +166,8 @@ export function PlatformVariants({
               <img
                 src={currentScreenshot}
                 alt={`Screenshot for ${PLATFORM_LABELS[activeTab]}`}
-                className="max-h-40 w-full object-contain rounded-md border border-border"
+                className={`max-h-40 w-full object-contain rounded-md border border-border ${onZoomShot ? "cursor-zoom-in" : ""}`}
+                onClick={onZoomShot ? () => onZoomShot(activeTab) : undefined}
               />
               <Button
                 variant="ghost"

--- a/components/panels/ShotPreviewDialog.tsx
+++ b/components/panels/ShotPreviewDialog.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useState } from "react";
 import {
   Dialog,
   DialogPortal,
-  DialogOverlay,
   DialogTitle,
 } from "@/components/ui/dialog";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
@@ -102,7 +101,7 @@ export function ShotPreviewDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogPortal>
-        <DialogOverlay />
+        <DialogPrimitive.Overlay className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80" />
         <DialogPrimitive.Content
           data-slot="dialog-content"
           className={cn(

--- a/components/panels/ShotPreviewDialog.tsx
+++ b/components/panels/ShotPreviewDialog.tsx
@@ -3,9 +3,11 @@
 import { useCallback, useEffect, useState } from "react";
 import {
   Dialog,
-  DialogContent,
+  DialogPortal,
+  DialogOverlay,
   DialogTitle,
 } from "@/components/ui/dialog";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
 import {
   PLATFORM_ICONS,
   PLATFORM_LABELS,
@@ -16,8 +18,9 @@ import {
 import { PLATFORMS, type PlatformId } from "@/lib/config/platforms";
 import type { StatusId } from "@/lib/config/statuses";
 import type { Node, PlatformScreenshotsMap, PlatformStatusMap, PlatformNotesMap } from "@/lib/data/types";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronLeft, ChevronRight, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 export interface ShotPreviewDialogProps {
   open: boolean;
@@ -94,143 +97,173 @@ export function ShotPreviewDialog({
 
   if (!node) return null;
 
+  const ActivePlatformIcon = PLATFORM_ICONS[activeTab];
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-5xl w-[90vw] max-h-[85vh] p-0 gap-0 overflow-hidden">
-        <DialogTitle className="sr-only">{node.title} — Screenshot Preview</DialogTitle>
+      <DialogPortal>
+        <DialogOverlay />
+        <DialogPrimitive.Content
+          data-slot="dialog-content"
+          className={cn(
+            "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed left-[50%] top-[50%] z-50 w-[90vw] max-w-5xl translate-x-[-50%] translate-y-[-50%] border shadow-lg duration-200 rounded-lg overflow-hidden",
+          )}
+        >
+          <DialogTitle className="sr-only">{node.title} — Screenshot Preview</DialogTitle>
 
-        <div className="flex flex-col md:flex-row h-full max-h-[85vh]">
-          {/* Main image area */}
-          <div className="relative flex flex-1 items-center justify-center bg-muted/30 min-h-[300px] md:min-h-0 p-6">
-            {currentScreenshot ? (
-              <img
-                src={currentScreenshot}
-                alt={`${node.title} — ${PLATFORM_LABELS[activeTab]} screenshot`}
-                className="max-h-[70vh] max-w-full object-contain rounded-md"
-              />
-            ) : (
-              <div className="flex flex-col items-center gap-2 text-muted-foreground">
-                <span className="text-sm">No screenshot for {PLATFORM_LABELS[activeTab]}</span>
-              </div>
-            )}
-
-            {/* Prev/Next arrows */}
-            {platformsWithShots.length > 1 && (
-              <>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="absolute left-2 top-1/2 -translate-y-1/2 size-8 rounded-full bg-background/80 backdrop-blur-sm cursor-pointer"
-                  onClick={goToPrev}
-                  aria-label="Previous platform"
-                >
-                  <ChevronLeft className="size-4" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="absolute right-2 top-1/2 -translate-y-1/2 size-8 rounded-full bg-background/80 backdrop-blur-sm cursor-pointer"
-                  onClick={goToNext}
-                  aria-label="Next platform"
-                >
-                  <ChevronRight className="size-4" />
-                </Button>
-              </>
-            )}
-          </div>
-
-          {/* Metadata sidebar */}
-          <div className="flex flex-col w-full md:w-72 border-t md:border-t-0 md:border-l border-border bg-background overflow-y-auto">
-            {/* Platform tabs */}
-            <div role="tablist" className="flex border-b border-border shrink-0">
-              {platforms.map((p) => {
-                const PlatformIcon = PLATFORM_ICONS[p];
-                const hasShot = Boolean(screenshots[p]);
-
-                return (
-                  <button
-                    key={p}
-                    type="button"
-                    role="tab"
-                    aria-selected={p === activeTab}
-                    onClick={() => setActiveTab(p)}
-                    className={`flex items-center gap-1.5 px-3 py-2.5 text-xs font-medium transition-colors border-b-2 -mb-px flex-1 justify-center ${
-                      p === activeTab
-                        ? "border-foreground text-foreground"
-                        : "border-transparent text-muted-foreground hover:text-foreground"
-                    } ${!hasShot ? "opacity-50" : ""}`}
-                  >
-                    <PlatformIcon className="size-3.5" />
-                    {PLATFORM_LABELS[p]}
-                  </button>
-                );
-              })}
-            </div>
-
-            {/* Metadata content */}
-            <div className="flex flex-col gap-4 p-4">
-              {/* Node title */}
-              <div>
-                <h3 className="text-sm font-semibold leading-tight">{node.title}</h3>
-              </div>
-
-              {/* Platform & Status */}
-              <div className="flex flex-col gap-2">
-                <div className="flex items-center justify-between">
-                  <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                    Status
-                  </span>
-                  <span className="inline-flex items-center gap-1.5 text-xs">
-                    <StatusIcon className={`size-3.5 ${statusStyles.badge}`} />
-                    {STATUS_LABELS[currentStatus]}
-                  </span>
-                </div>
-              </div>
-
-              {/* Description */}
-              {node.description && (
-                <div className="flex flex-col gap-1.5">
-                  <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                    Description
-                  </span>
-                  <p className="text-xs text-foreground leading-relaxed">
-                    {node.description}
-                  </p>
+          <div className="flex flex-col md:flex-row max-h-[85vh]">
+            {/* Main image area */}
+            <div className="relative flex flex-1 items-center justify-center bg-muted/30 min-h-[300px] md:min-h-0 p-6">
+              {currentScreenshot ? (
+                <img
+                  src={currentScreenshot}
+                  alt={`${node.title} — ${PLATFORM_LABELS[activeTab]} screenshot`}
+                  className="max-h-[70vh] max-w-full object-contain rounded-md"
+                />
+              ) : (
+                <div className="flex flex-col items-center gap-2 text-muted-foreground">
+                  <span className="text-sm">No screenshot for {PLATFORM_LABELS[activeTab]}</span>
                 </div>
               )}
 
-              {/* Platform notes */}
-              {currentNotes && (
-                <div className="flex flex-col gap-1.5">
-                  <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                    Notes
-                  </span>
-                  <p className="text-xs text-foreground leading-relaxed whitespace-pre-wrap">
-                    {currentNotes}
-                  </p>
-                </div>
-              )}
-
-              {/* Gallery indicator */}
+              {/* Prev/Next arrows */}
               {platformsWithShots.length > 1 && (
-                <div className="flex items-center justify-center gap-1.5 pt-2">
-                  {platformsWithShots.map((p) => (
-                    <button
-                      key={p}
-                      type="button"
-                      onClick={() => setActiveTab(p)}
-                      className={`size-1.5 rounded-full transition-colors ${
-                        p === activeTab ? "bg-foreground" : "bg-muted-foreground/30"
-                      }`}
-                      aria-label={`View ${PLATFORM_LABELS[p]} screenshot`}
-                    />
-                  ))}
-                </div>
+                <>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="absolute left-2 top-1/2 -translate-y-1/2 size-8 rounded-full bg-background/80 backdrop-blur-sm cursor-pointer"
+                    onClick={goToPrev}
+                    aria-label="Previous platform"
+                  >
+                    <ChevronLeft className="size-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="absolute right-2 top-1/2 -translate-y-1/2 size-8 rounded-full bg-background/80 backdrop-blur-sm cursor-pointer"
+                    onClick={goToNext}
+                    aria-label="Next platform"
+                  >
+                    <ChevronRight className="size-4" />
+                  </Button>
+                </>
               )}
             </div>
+
+            {/* Metadata sidebar */}
+            <div className="flex flex-col w-full md:w-72 border-t md:border-t-0 md:border-l border-border bg-background overflow-y-auto">
+              {/* Header with active platform + close button */}
+              <div className="flex items-center justify-between gap-2 px-4 py-3 border-b border-border shrink-0">
+                <span className="inline-flex items-center gap-2 text-sm font-medium">
+                  <ActivePlatformIcon className="size-4" />
+                  {PLATFORM_LABELS[activeTab]}
+                </span>
+                <DialogPrimitive.Close asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-7 shrink-0 text-muted-foreground cursor-pointer"
+                    aria-label="Close"
+                  >
+                    <X className="size-4" />
+                  </Button>
+                </DialogPrimitive.Close>
+              </div>
+
+              {/* Platform tabs */}
+              {platforms.length > 1 && (
+                <div role="tablist" className="flex border-b border-border shrink-0">
+                  {platforms.map((p) => {
+                    const PlatformIcon = PLATFORM_ICONS[p];
+                    const hasShot = Boolean(screenshots[p]);
+
+                    return (
+                      <button
+                        key={p}
+                        type="button"
+                        role="tab"
+                        aria-selected={p === activeTab}
+                        onClick={() => setActiveTab(p)}
+                        className={`flex items-center gap-1.5 px-3 py-2 text-xs font-medium transition-colors border-b-2 -mb-px flex-1 justify-center ${
+                          p === activeTab
+                            ? "border-foreground text-foreground"
+                            : "border-transparent text-muted-foreground hover:text-foreground"
+                        } ${!hasShot ? "opacity-50" : ""}`}
+                      >
+                        <PlatformIcon className="size-3.5" />
+                        {PLATFORM_LABELS[p]}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+
+              {/* Metadata content */}
+              <div className="flex flex-col gap-4 p-4">
+                {/* Node title */}
+                <div>
+                  <h3 className="text-sm font-semibold leading-tight">{node.title}</h3>
+                </div>
+
+                {/* Platform & Status */}
+                <div className="flex flex-col gap-2">
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                      Status
+                    </span>
+                    <span className="inline-flex items-center gap-1.5 text-xs">
+                      <StatusIcon className={`size-3.5 ${statusStyles.badge}`} />
+                      {STATUS_LABELS[currentStatus]}
+                    </span>
+                  </div>
+                </div>
+
+                {/* Description */}
+                {node.description && (
+                  <div className="flex flex-col gap-1.5">
+                    <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                      Description
+                    </span>
+                    <p className="text-xs text-foreground leading-relaxed">
+                      {node.description}
+                    </p>
+                  </div>
+                )}
+
+                {/* Platform notes */}
+                {currentNotes && (
+                  <div className="flex flex-col gap-1.5">
+                    <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                      Notes
+                    </span>
+                    <p className="text-xs text-foreground leading-relaxed whitespace-pre-wrap">
+                      {currentNotes}
+                    </p>
+                  </div>
+                )}
+
+                {/* Gallery indicator */}
+                {platformsWithShots.length > 1 && (
+                  <div className="flex items-center justify-center gap-1.5 pt-2">
+                    {platformsWithShots.map((p) => (
+                      <button
+                        key={p}
+                        type="button"
+                        onClick={() => setActiveTab(p)}
+                        className={`size-1.5 rounded-full transition-colors ${
+                          p === activeTab ? "bg-foreground" : "bg-muted-foreground/30"
+                        }`}
+                        aria-label={`View ${PLATFORM_LABELS[p]} screenshot`}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
           </div>
-        </div>
-      </DialogContent>
+        </DialogPrimitive.Content>
+      </DialogPortal>
     </Dialog>
   );
 }

--- a/components/panels/ShotPreviewDialog.tsx
+++ b/components/panels/ShotPreviewDialog.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  PLATFORM_ICONS,
+  PLATFORM_LABELS,
+  STATUS_ICONS,
+  STATUS_STYLES,
+  STATUS_LABELS,
+} from "@/components/graph/nodes/node-styles";
+import { PLATFORMS, type PlatformId } from "@/lib/config/platforms";
+import type { StatusId } from "@/lib/config/statuses";
+import type { Node, PlatformScreenshotsMap, PlatformStatusMap, PlatformNotesMap } from "@/lib/data/types";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export interface ShotPreviewDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  node?: Node;
+  initialPlatform?: PlatformId;
+}
+
+export function ShotPreviewDialog({
+  open,
+  onOpenChange,
+  node,
+  initialPlatform,
+}: ShotPreviewDialogProps) {
+  const platforms = node?.platforms ?? [];
+  const screenshots: PlatformScreenshotsMap = (node?.metadata?.platformScreenshots as PlatformScreenshotsMap) ?? {};
+  const platformStatuses: PlatformStatusMap = (node?.metadata?.platformStatuses as PlatformStatusMap) ?? {};
+  const platformNotes: PlatformNotesMap = (node?.metadata?.platformNotes as PlatformNotesMap) ?? {};
+
+  // Platforms that actually have a screenshot
+  const platformsWithShots = platforms.filter((p) => screenshots[p]);
+
+  const [activeTab, setActiveTab] = useState<PlatformId>(
+    initialPlatform ?? platformsWithShots[0] ?? platforms[0] ?? "web",
+  );
+
+  // Reset active tab when dialog opens with a new node/platform
+  useEffect(() => {
+    if (open) {
+      setActiveTab(
+        initialPlatform ?? platformsWithShots[0] ?? platforms[0] ?? "web",
+      );
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, node?.id, initialPlatform]);
+
+  const currentIndex = platformsWithShots.indexOf(activeTab);
+
+  const goToPrev = useCallback(() => {
+    if (platformsWithShots.length <= 1) return;
+    const prevIndex = currentIndex <= 0 ? platformsWithShots.length - 1 : currentIndex - 1;
+    setActiveTab(platformsWithShots[prevIndex]);
+  }, [currentIndex, platformsWithShots]);
+
+  const goToNext = useCallback(() => {
+    if (platformsWithShots.length <= 1) return;
+    const nextIndex = currentIndex >= platformsWithShots.length - 1 ? 0 : currentIndex + 1;
+    setActiveTab(platformsWithShots[nextIndex]);
+  }, [currentIndex, platformsWithShots]);
+
+  // Keyboard navigation
+  useEffect(() => {
+    if (!open) return;
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        goToPrev();
+      } else if (e.key === "ArrowRight") {
+        e.preventDefault();
+        goToNext();
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [open, goToPrev, goToNext]);
+
+  const currentScreenshot = screenshots[activeTab];
+  const currentStatus = platformStatuses[activeTab] ?? node?.status ?? ("idea" as StatusId);
+  const currentNotes = platformNotes[activeTab] ?? "";
+  const StatusIcon = STATUS_ICONS[currentStatus] ?? STATUS_ICONS.idea;
+  const statusStyles = STATUS_STYLES[currentStatus] ?? STATUS_STYLES.idea;
+
+  if (!node) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-5xl w-[90vw] max-h-[85vh] p-0 gap-0 overflow-hidden">
+        <DialogTitle className="sr-only">{node.title} — Screenshot Preview</DialogTitle>
+
+        <div className="flex flex-col md:flex-row h-full max-h-[85vh]">
+          {/* Main image area */}
+          <div className="relative flex flex-1 items-center justify-center bg-muted/30 min-h-[300px] md:min-h-0 p-6">
+            {currentScreenshot ? (
+              <img
+                src={currentScreenshot}
+                alt={`${node.title} — ${PLATFORM_LABELS[activeTab]} screenshot`}
+                className="max-h-[70vh] max-w-full object-contain rounded-md"
+              />
+            ) : (
+              <div className="flex flex-col items-center gap-2 text-muted-foreground">
+                <span className="text-sm">No screenshot for {PLATFORM_LABELS[activeTab]}</span>
+              </div>
+            )}
+
+            {/* Prev/Next arrows */}
+            {platformsWithShots.length > 1 && (
+              <>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="absolute left-2 top-1/2 -translate-y-1/2 size-8 rounded-full bg-background/80 backdrop-blur-sm cursor-pointer"
+                  onClick={goToPrev}
+                  aria-label="Previous platform"
+                >
+                  <ChevronLeft className="size-4" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="absolute right-2 top-1/2 -translate-y-1/2 size-8 rounded-full bg-background/80 backdrop-blur-sm cursor-pointer"
+                  onClick={goToNext}
+                  aria-label="Next platform"
+                >
+                  <ChevronRight className="size-4" />
+                </Button>
+              </>
+            )}
+          </div>
+
+          {/* Metadata sidebar */}
+          <div className="flex flex-col w-full md:w-72 border-t md:border-t-0 md:border-l border-border bg-background overflow-y-auto">
+            {/* Platform tabs */}
+            <div role="tablist" className="flex border-b border-border shrink-0">
+              {platforms.map((p) => {
+                const PlatformIcon = PLATFORM_ICONS[p];
+                const hasShot = Boolean(screenshots[p]);
+
+                return (
+                  <button
+                    key={p}
+                    type="button"
+                    role="tab"
+                    aria-selected={p === activeTab}
+                    onClick={() => setActiveTab(p)}
+                    className={`flex items-center gap-1.5 px-3 py-2.5 text-xs font-medium transition-colors border-b-2 -mb-px flex-1 justify-center ${
+                      p === activeTab
+                        ? "border-foreground text-foreground"
+                        : "border-transparent text-muted-foreground hover:text-foreground"
+                    } ${!hasShot ? "opacity-50" : ""}`}
+                  >
+                    <PlatformIcon className="size-3.5" />
+                    {PLATFORM_LABELS[p]}
+                  </button>
+                );
+              })}
+            </div>
+
+            {/* Metadata content */}
+            <div className="flex flex-col gap-4 p-4">
+              {/* Node title */}
+              <div>
+                <h3 className="text-sm font-semibold leading-tight">{node.title}</h3>
+              </div>
+
+              {/* Platform & Status */}
+              <div className="flex flex-col gap-2">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                    Status
+                  </span>
+                  <span className="inline-flex items-center gap-1.5 text-xs">
+                    <StatusIcon className={`size-3.5 ${statusStyles.badge}`} />
+                    {STATUS_LABELS[currentStatus]}
+                  </span>
+                </div>
+              </div>
+
+              {/* Description */}
+              {node.description && (
+                <div className="flex flex-col gap-1.5">
+                  <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                    Description
+                  </span>
+                  <p className="text-xs text-foreground leading-relaxed">
+                    {node.description}
+                  </p>
+                </div>
+              )}
+
+              {/* Platform notes */}
+              {currentNotes && (
+                <div className="flex flex-col gap-1.5">
+                  <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                    Notes
+                  </span>
+                  <p className="text-xs text-foreground leading-relaxed whitespace-pre-wrap">
+                    {currentNotes}
+                  </p>
+                </div>
+              )}
+
+              {/* Gallery indicator */}
+              {platformsWithShots.length > 1 && (
+                <div className="flex items-center justify-center gap-1.5 pt-2">
+                  {platformsWithShots.map((p) => (
+                    <button
+                      key={p}
+                      type="button"
+                      onClick={() => setActiveTab(p)}
+                      className={`size-1.5 rounded-full transition-colors ${
+                        p === activeTab ? "bg-foreground" : "bg-muted-foreground/30"
+                      }`}
+                      aria-label={`View ${PLATFORM_LABELS[p]} screenshot`}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
This PR adds a new `ShotPreviewDialog` component that provides a full-screen preview of node screenshots with platform-specific navigation and metadata display. Users can now click on screenshot thumbnails to open an expanded view with keyboard and button navigation between platforms.

## Key Changes
- **New `ShotPreviewDialog` component** (`components/panels/ShotPreviewDialog.tsx`):
  - Full-screen dialog for viewing screenshots with responsive layout
  - Platform tab navigation with visual indicators for platforms with screenshots
  - Keyboard navigation support (arrow keys) and button-based navigation (prev/next)
  - Displays platform-specific metadata including status, description, and notes
  - Gallery indicator dots for quick platform switching

- **Canvas page integration** (`app/project/[id]/canvas/page.tsx`):
  - Added state management for zoom dialog (`zoomNode`, `zoomPlatform`)
  - Wired up `onZoomShot` callbacks from both `ViewNode` and `NodeDetailPanel`
  - Integrated `ShotPreviewDialog` component with proper open/close handling

- **ViewNode screenshot interaction** (`components/graph/nodes/ViewNode.tsx`):
  - Added click handler to screenshot background image
  - Visual feedback with `cursor-zoom-in` on hover
  - Event propagation prevention to avoid triggering node selection

- **NodeDetailPanel enhancement** (`components/panels/NodeDetailPanel.tsx`):
  - Added `onZoomShot` callback prop
  - Passed callback through to `PlatformVariantsSection`

- **PlatformVariants component** (`components/panels/PlatformVariants.tsx`):
  - Added `onZoomShot` callback prop for screenshot zoom functionality
  - Wired up click handlers on screenshot thumbnails

## Implementation Details
- The dialog intelligently filters platforms to only show those with actual screenshots
- Maintains active platform state and resets when dialog opens with new node
- Supports both mouse navigation (buttons/tabs) and keyboard navigation (arrow keys)
- Responsive design adapts between mobile (stacked) and desktop (side-by-side) layouts
- Preserves platform-specific metadata (status, notes) when switching between platforms

https://claude.ai/code/session_01Ly49zs87Qdd9Qwp8GGjDts