### PR TITLE
Expand vision and add format/toolchain specifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,12 @@ See [`docs/`](docs/README.md) for detailed documentation:
 - [Graph Model](docs/graph-model.md) — 4-species taxonomy, composition, statuses, edge types
 - [Data Layer](docs/data-layer.md) — DataProvider interface, local storage, import/export
 - [Conventions](docs/conventions.md) — coding patterns, file organization, state management
-- [Vision](docs/vision.md) — full product vision and roadmap (8-level species model, semantic zoom, planned features)
+- [Vision](docs/vision.md) — product strategy: the four layers (format, toolchain, app, services), modes & tiers, roadmap
+- [Specs](docs/spec/bundle-format.md) — draft specifications for the bundle format v2, the event journal, and the toolchain
 
 ## Migration Path
+
+> Superseded by the phased roadmap in [docs/vision.md](docs/vision.md) (git-native toolchain first). Kept as the original engineering sketch of the backend evolution.
 
 | **Phase** | **What** | **How** |
 | --- | --- | --- |

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,15 @@
 - [Graph Model](graph-model.md) — 4-species taxonomy, composition model, statuses, platforms, edge types
 - [Data Layer](data-layer.md) — DataProvider interface, local storage, import/export
 - [Conventions](conventions.md) — Coding patterns, file organization, state management
-- [Vision](vision.md) — Long-term product direction and roadmap ideas
+- [Vision](vision.md) — Product strategy: the four layers, modes & tiers, format levels, roadmap
+
+## Specifications
+
+Normative (draft) specs for the arkaik format and tooling:
+
+- [Bundle Format v2](spec/bundle-format.md) — schema versioning, references, asset values, ID conventions, canonical serialization
+- [Journal & Events](spec/journal.md) — event vocabulary, JSONL sidecar, authority model, releases & projections
+- [Toolchain & Packaging](spec/toolchain.md) — npm workspace, `@arkaik/schema`, the `arkaik` CLI, skill distribution
 
 ## LLM & Prompt Surfaces
 

--- a/docs/spec/bundle-format.md
+++ b/docs/spec/bundle-format.md
@@ -1,0 +1,128 @@
+---
+title: "Spec: Bundle Format v2"
+navTitle: "Bundle Format"
+order: 1
+---
+
+# Bundle Format v2
+
+> Status: **Draft specification** — describes the target format. Implemented behavior is documented in [data-layer.md](../data-layer.md); the currently published contract is v1 at `public/schema/project-bundle.json`.
+> The key words MUST, MUST NOT, SHOULD, and MAY are to be interpreted as in RFC 2119.
+
+## Overview
+
+A **ProjectBundle** is the interchange unit of the arkaik format: one JSON document carrying a project, its nodes, and its edges. Version 2 makes the format *versioned* and *extensible* while keeping every v1 bundle valid.
+
+```ts
+interface ProjectBundle {
+  schema_version?: number;   // v2: contract version; absent means 1
+  project: Project;
+  nodes: Node[];
+  edges: Edge[];
+  journal?: JournalEvent[];  // v2: embedded interchange projection only — see spec/journal.md
+}
+```
+
+Node, Edge, Project, playlist, platform, and status semantics are unchanged from v1 — see [graph-model.md](../graph-model.md) and the type definitions in `lib/data/types.ts`. v2 is strictly additive.
+
+## Schema Versioning
+
+| Rule | Detail |
+|---|---|
+| Field | `schema_version` (integer) at the bundle root |
+| Absent | Consumers MUST treat a missing `schema_version` as `1` — every existing bundle remains valid |
+| Reading newer | A consumer encountering a version above what it supports SHOULD import what it understands and MUST preserve unknown fields on re-export (no silent stripping) |
+| Reading older | Consumers MUST migrate older versions through an explicit chain (today's implicit legacy handling in `normalizeBundle()`, `lib/data/local-provider.ts`, becomes step one of that chain) |
+| Bumping | The version increments only for changes that alter how existing fields must be interpreted. Purely additive optional fields do not require a bump — with one exception below |
+
+**Why v2 requires an explicit bump even though it is additive:** the published v1 JSON Schema declares `additionalProperties: false` on the bundle root and on `Project`. Any bundle carrying `schema_version`, `journal`, or `project.version` is *non-conformant to v1 by construction*. The v2 JSON Schema (generated from the canonical source, see [toolchain.md](toolchain.md)) relaxes this to "unknown fields are allowed and preserved."
+
+**Known consumer defect to fix before v2 ships:** `rewriteBundleProjectId` (`lib/utils/export.ts`) reconstructs imported bundles as `{ project, nodes, edges }` and silently drops any other top-level key when an imported project's ID collides locally. All import paths MUST round-trip unknown fields.
+
+## Project Additions
+
+```ts
+interface Project {
+  // ... unchanged v1 fields (id, title, description?, root_node_id?, metadata?, timestamps)
+  version?: string;          // v2, Level 1: current version label, e.g. "1.4.0" or "2026-07"
+}
+```
+
+`project.version` is the *current* version label of the mapped product (free-form string; semver recommended, not required). Version *history* lives in the journal as `release.tagged` events — a Level 1 bundle carries only the label.
+
+## References
+
+v2 adds typed external references to nodes, under `metadata.refs` (placed in `NodeMetadata` alongside `platformStatuses` and friends):
+
+```ts
+interface Ref {
+  id: string;                // unique within the node, kebab-case, e.g. "gh-142"
+  type: "figma" | "github-issue" | "gitlab-issue" | "linear-issue"
+      | "github-pr" | "gitlab-mr" | "url";
+  url: string;               // canonical external URL
+  title?: string;            // display label
+  external_status?: string;  // mirrored external state, verbatim (e.g. "open", "merged", "In Progress")
+  status_mapped?: StatusId;  // optional mapping of external_status into the arkaik lifecycle
+  platform?: PlatformId;     // optional scoping to one platform variant
+  synced_at?: string;        // ISO 8601 — when external_status was last mirrored
+}
+```
+
+| Rule | Detail |
+|---|---|
+| Mirroring | `external_status` is a *mirror*, never authoritative. Sync tooling (`arkaik sync`, server-side integrations) updates it and records `ref.status_changed` journal events |
+| Mapping | `status_mapped` never overwrites `node.status` automatically; it is advisory display data. Promoting it to the node's status is a deliberate (human or agent) act that produces a normal `node.status_changed` event |
+| Unknown types | Consumers MUST preserve refs with unrecognized `type` values and SHOULD render them as generic links |
+
+## Asset Values
+
+Anywhere the format carries an asset (today: `metadata.platformScreenshots`, a per-platform map — currently missing from the published schema and validator, a known drift to fix), the value MUST be one of three forms:
+
+| Form | Detection | Where the bytes live | Intended mode |
+|---|---|---|---|
+| Relative path | No URI scheme, no leading `/` | Resolved against the bundle file's directory (e.g. `assets/web/home.png` next to `docs/arkaik/bundle.json`) | Kommit (repo-hosted) |
+| Absolute URL | `https://` | Figma, arkaik bucket, user-owned Supabase bucket | Hosted modes |
+| Data URI | `data:` | Inline in the bundle | Lokal / legacy only — discouraged; subject to import size caps |
+
+Consumers that cannot resolve a form (the hosted app receiving a relative path, for instance) MUST degrade to a placeholder, never fail the import. `arkaik pack` converts between forms (inline or upload) when producing a self-contained interchange file. Journal events MUST NOT embed asset payloads.
+
+## Identifier Conventions
+
+IDs are deterministic and human-readable. This subsumes and canonicalizes the rules in `docs/arkaik-skill/references/schema.md`.
+
+| Entity | Convention | Example |
+|---|---|---|
+| Flow | `F-` + kebab-case of title | `F-onboarding` |
+| View | `V-` + kebab-case of title | `V-set-intensity` |
+| Data model | `DM-` + kebab-case of title | `DM-bounce` |
+| API endpoint | `API-` + kebab-case of title | `API-create-bounce` |
+| Edge | `e-{source_id}-{target_id}` | `e-V-home-API-list-bounces` |
+| Ref | free kebab-case, unique per node | `gh-142` |
+| Journal event | ULID | `01J9ZK4E4NVQ9K4YB2Q6WPXC1T` |
+
+| Rule | Detail |
+|---|---|
+| Collisions | When two titles kebab-case identically, disambiguate deterministically with a short semantic suffix or `-2`, `-3` counters. The known real-world case: conceptual model *Bounce* (`DM-bounce`) vs physical table *bounces* — both must never resolve to the same ID (a duplicate node ID breaks the graph render; the import guard must reject it) |
+| Renames | Changing a title does not require changing the ID. Changing an ID requires repointing every edge endpoint, the edge IDs themselves, playlist references, and `root_node_id` in the same change |
+| App divergence (defect) | The app currently violates these conventions: `lib/utils/id.ts` generates random UUID suffixes for nodes, and canvas-created edges use raw `crypto.randomUUID()`. Any repo bundle round-tripped through the app comes back non-conformant. Roadmap Phase 3 adopts deterministic IDs in the app |
+
+## Canonical Serialization
+
+So that bundles diff and merge cleanly in git, writers SHOULD emit canonical form; `arkaik validate --fix-format` (toolchain) normalizes it:
+
+- UTF-8, LF line endings, 2-space indentation, trailing newline
+- Top-level key order: `schema_version`, `project`, `nodes`, `edges`, `journal`
+- `nodes` and `edges` sorted by `id` (codepoint ascending)
+- Object keys in the field order defined by the schema
+
+Canonical form localizes concurrent edits to the same region only when they genuinely touch the same entity. It does not make snapshot merges conflict-free — concurrent edits to the same node still conflict, by design (see the authority model in [journal.md](journal.md)).
+
+## Conformance Levels
+
+| Level | Requirements |
+|---|---|
+| **0 — Static snapshot** | Valid `project`/`nodes`/`edges`; all v1 semantic rules (unique IDs, valid references, playlist coherence, no flow cycles) |
+| **1 — Versioned snapshot** | Level 0 + `schema_version` present + optional `project.version` |
+| **2 — Snapshot + journal** | Level 1 + a journal ([journal.md](journal.md)) whose latest state agrees with the snapshot under the cross-check rules |
+
+Every consumer MUST accept all three levels. Producers choose the level that fits their workflow.

--- a/docs/spec/journal.md
+++ b/docs/spec/journal.md
@@ -1,0 +1,107 @@
+---
+title: "Spec: Journal & Events"
+navTitle: "Journal & Events"
+order: 2
+---
+
+# Journal & Events
+
+> Status: **Draft specification** — describes the target format (Format Level 2, see [bundle-format.md](bundle-format.md)). Nothing in this document is implemented yet.
+> The key words MUST, MUST NOT, SHOULD, and MAY are to be interpreted as in RFC 2119.
+
+## Purpose
+
+The journal turns status from a mutable field that forgets into a tracked evolution. It is an **append-only log of typed events** recording how the product graph changed: status transitions, releases, ideas, requests, reference updates. From it, consumers derive the features a static snapshot cannot offer — per-node timelines, changelogs, release notes, and a backlog of ideas and requests.
+
+## Storage Shapes
+
+### Canonical (repo): JSONL sidecar
+
+In a repository (Kommit mode), the journal is a sidecar file next to the snapshot — never inside it. The snapshot stays small and the history cannot corrupt it.
+
+```
+docs/arkaik/
+  bundle.json                     # snapshot (Levels 0–2)
+  journal.jsonl                   # append-only, one event per line
+  journal/
+    archive-1.3.0.jsonl           # compacted history per release (optional)
+  assets/                         # repo-hosted asset files
+```
+
+`arkaik init` configures `.gitattributes`:
+
+```
+docs/arkaik/journal.jsonl merge=union
+```
+
+JSONL is the one shape where git's union merge is sound: one line = one self-contained event, concurrent appends merge automatically, and order is recoverable from the events themselves. A malformed line invalidates exactly one event — the validator reports the line number — and can never damage existing history or the snapshot. This is the property that makes agent writes safe: appending is structurally incapable of the corrupt-the-whole-JSON failure that whole-file regeneration invites.
+
+### Interchange: embedded `journal[]`
+
+When a single file is needed (drag-in import to the app, Publik, LLM output), `arkaik pack` embeds the journal as the bundle's optional `journal` array. This is a *projection for transport*, not a storage recommendation. Publik publishes without the journal by default — history stays private unless explicitly included.
+
+## Event Envelope
+
+One event is one JSON object:
+
+```ts
+interface JournalEvent {
+  id: string;      // ULID — sortable, collision-free without coordination
+  ts: string;      // ISO 8601 timestamp
+  actor?: string;  // who/what wrote it: "alexis", "claude-code", "arkaik-sync", "ci"
+  type: string;    // vocabulary below
+  // ...type-specific payload fields, flat on the object
+}
+```
+
+| Rule | Detail |
+|---|---|
+| Ordering | Consumers MUST order events by `ts`, tiebreaking by `id`. Files MAY contain out-of-order lines (union merge reorders); consumers MUST tolerate this |
+| Forward compatibility | Unknown `type` values and unknown fields MUST be preserved on rewrite and ignored on read. The vocabulary grows without version bumps; a per-event `v` field is reserved for the day an existing payload shape must change |
+| Payload discipline | Events MUST NOT embed asset payloads (screenshots, images). `node.updated` records changed field *paths* (and old/new values only for short scalar fields like `title`), never blob contents |
+| Project scope | Events carry no `project_id`; scope is implied by the file they live in / the bundle that embeds them |
+
+## Event Vocabulary (v1)
+
+| Type | Payload | Meaning |
+|---|---|---|
+| `node.created` | `node_id`, `species`, `title` | Node added to the graph |
+| `node.updated` | `node_id`, `fields[]`, optional `from`/`to` for scalars | Non-status fields changed |
+| `node.status_changed` | `node_id`, `from`, `to`, `platform?` | Lifecycle transition; `platform` present when a per-platform view status moved |
+| `node.deleted` | `node_id` | Node removed. **Implies** cascade removal of every edge referencing it — writers do not emit the cascaded `edge.removed` events, and consumers/validators MUST apply the cascade |
+| `edge.added` | `edge_id`, `source_id`, `target_id`, `edge_type` | Relationship created |
+| `edge.removed` | `edge_id` | Relationship removed (non-cascade) |
+| `release.tagged` | `version`, `notes?`, `platform?` | A version shipped. `platform` optional: absent = project-wide; present = that platform's release rhythm |
+| `idea.proposed` | `title`, `description?`, `node_id?` | An idea, before (or linked to) any node |
+| `request.filed` | `title`, `description?`, `source?`, `node_id?` | An external ask (user feedback, stakeholder request) |
+| `ref.added` | `node_id`, `ref_id`, `ref_type`, `url` | External reference attached |
+| `ref.removed` | `node_id`, `ref_id` | External reference detached |
+| `ref.status_changed` | `node_id`, `ref_id`, `from?`, `to`, `synced_at` | Mirrored external status moved (issue closed, PR merged) |
+
+## Authority & Consistency Model
+
+The journal is **not** event sourcing, and v1 makes no replay promises. The rules:
+
+1. **The snapshot is authoritative for current state. The journal is authoritative for history.**
+2. Writers (the skill, the CLI, later the app) **dual-write**: patch the snapshot *and* append the matching event in the same change.
+3. The validator cross-checks the two **by value, never by timestamp** (per-node timestamps don't exist and clocks lie): the last `node.status_changed.to` for a node must equal its current `status`; every node has a `node.created`; no event references a node or edge that never existed. Any mismatch is a validation error naming both sides.
+4. Divergence is repaired **explicitly**: `arkaik doctor` appends corrective events to make history consistent with the snapshot (the snapshot wins). Consumers MUST NOT silently re-project the snapshot from the journal — that would launder drift instead of surfacing it.
+
+## Releases, Compaction & Growth
+
+- `release.tagged` events are the version markers. The changelog between two versions is the ordered slice of events between their markers; a release note is that slice summarized (by template or by an agent), filtered to the platforms of the affected nodes when `platform` is used.
+- `arkaik release` tags the version, generates the release-note draft, and MAY **compact**: move the released slice from `journal.jsonl` to `journal/archive-{version}.jsonl`. Archives are part of history (projections may read them); the working journal stays small. Compaction differs from the changesets tool's model deliberately — changeset files are *consumed* at release, journal history is *kept*.
+- The hosted app stores journals under a separate storage key from the snapshot store, so history growth never inflates every snapshot write. App-side event *emission* is gated on the IndexedDB migration for the same reason (see the roadmap in [vision.md](../vision.md)).
+
+## Projections
+
+Projections are pure functions over (snapshot, journal) — the same pattern as the existing status rollups in `lib/utils/platform-status.ts`. Planned module: `lib/utils/journal.ts`.
+
+| Projection | Answers | Surface |
+|---|---|---|
+| Node timeline | "How did this view get to `live` on iOS?" | History section in the node detail panel |
+| Changelog | "What changed between 1.2 and 1.3?" | Project-level journal/changelog view |
+| Release notes | "What do we tell users shipped?" | Generated draft at `arkaik release` |
+| Backlog | "Which ideas and requests are open?" | Ideas/requests list (an `idea.proposed` is *open* until a linked node exists or a resolving event closes it) |
+
+A bundle without a journal simply renders none of these — the empty state, not an error. That is the whole backward-compatibility story.

--- a/docs/spec/toolchain.md
+++ b/docs/spec/toolchain.md
@@ -1,0 +1,76 @@
+---
+title: "Spec: Toolchain & Packaging"
+navTitle: "Toolchain"
+order: 3
+---
+
+# Toolchain & Packaging
+
+> Status: **Draft specification** — describes the target packages and CLI. Today the toolchain exists only as the copy-paste skill and standalone validator under `docs/arkaik-skill/`.
+> The key words MUST, SHOULD, and MAY are to be interpreted as in RFC 2119.
+
+## Why npm
+
+The toolchain's audience is product repositories and their CI — the same channel Storybook, Changesets, shadcn, and husky ship through. `npx arkaik <command>` works with zero install, and a dev dependency pins the version per repo. A system package manager (brew) targets machine-global binaries and misses both the per-repo pinning and the CI story; it is not planned.
+
+## Repository Layout
+
+The arkaik repo becomes an npm workspace. **The Next.js app stays at the repository root** — the `/docs` site and LLM routes read `docs/` and `README.md` from `process.cwd()` (`lib/utils/docs.ts`, `app/llms-full.txt/route.ts`), and the Vercel project is bound to the root; moving the app buys nothing and risks both.
+
+```
+/                        # the Next.js app, unchanged (AGPL-3.0)
+  package.json           # + "workspaces": ["packages/*"]
+  packages/
+    schema/              # @arkaik/schema (MIT)
+    cli/                 # arkaik (MIT) — depends on @arkaik/schema
+```
+
+The app consumes `@arkaik/schema` via `transpilePackages` in `next.config.ts` and a path mapping in `tsconfig.json`; `lib/data/types.ts` becomes a re-export so its ~23 importers don't churn.
+
+## `@arkaik/schema` — the Single Source of Truth
+
+The bundle contract currently lives in five places that drift independently (`lib/data/types.ts`, `public/schema/project-bundle.json`, `docs/arkaik-skill/references/schema.md`, `docs/arkaik-skill/scripts/validate-bundle.js`, `lib/prompts/blocks.ts`). This package collapses them.
+
+- **Canonical definition in code (zod):** the decisive reason is that the highest-value rules are *semantic graph rules* — duplicate IDs, dangling edge references, playlist↔composes coherence, flow cycles, species/edge-type semantics — which JSON Schema cannot express. A JSON-Schema-first pipeline would still need a hand-written semantic layer, leaving two sources of truth. Code is canonical; zod v4 generates the JSON Schema natively.
+- **Exports:** inferred TS types, enum ID lists (species, statuses, platforms, edge types — `lib/config/*` keeps labels/order/colors and derives IDs from here), `parseBundle()` (shape) and `validateBundle()` (shape + semantic rules, structured errors with paths/line numbers).
+- **Generated artifacts, committed, drift-checked in CI** (a regeneration diff fails the build):
+
+| Artifact | Replaces |
+|---|---|
+| `public/schema/project-bundle.json` (v2, `$id` + version) | Hand-maintained JSON Schema |
+| `validate-bundle.js` — esbuild-bundled, **zero-dependency**, runnable as `node validate-bundle.js <path>`, exit code 0/1 | Hand-written standalone validator |
+| Schema reference fragment injected into the skill's `references/schema.md` | Hand-typed interface listings |
+| Prompt generator schema/rules fragments (`lib/prompts/generated/`) | Hand-maintained `SCHEMA_BLOCK` and enum lists in `lib/prompts/blocks.ts` |
+
+The standalone validator artifact remains a first-class contract: agents operating in repos without node_modules MUST be able to gate on it with nothing but Node. `arkaik validate` and the artifact are builds of the same source — both exist, neither drifts.
+
+## `arkaik` — the CLI
+
+| Command | Does | Phase |
+|---|---|---|
+| `arkaik init` | Scaffold `docs/arkaik/` (bundle, journal, assets dir), write `.gitattributes` union-merge rule, install the agent skill into the repo's skills directory, optionally add a CI step. `--update` upgrades a previous install | 3 |
+| `arkaik validate [path]` | Shape + semantic + snapshot↔journal cross-checks ([journal.md](journal.md)); `--fix-format` rewrites to canonical serialization ([bundle-format.md](bundle-format.md)) | 3 |
+| `arkaik log [--node <id>]` | Human-readable journal: project changelog or per-node timeline | 3 |
+| `arkaik release <version> [--platform <p>]` | Append `release.tagged`, generate release-note draft from the slice since the last release, compact to `journal/archive-{version}.jsonl` | 3 |
+| `arkaik sync` | Mirror external ref status (GitHub/GitLab/Linear APIs, tokens from env), update `external_status`/`synced_at`, append `ref.status_changed` events | 3 |
+| `arkaik pack [--no-journal] [--inline-assets]` | Produce a single-file interchange bundle: embed the journal, inline or upload assets | 3 |
+| `arkaik open` | Validate, then hand off to arkaik.app import (packed bundle) | 3 |
+| `arkaik push` | Publish to Publik / a synced account project from the terminal or CI | 4 |
+| `arkaik dev` | Local viewer over the repo's bundle, Storybook-style. **Not committed:** requires the app's `/project/[id]` routing to become static-export compatible first; decided on its own merits in Phase 3 | 3–4 (decision) |
+
+## Skill Distribution
+
+The agent skill graduates from copy-paste (`docs/arkaik-skill/`) to a managed asset:
+
+| Property | Rule |
+|---|---|
+| Source | Lives in the arkaik repo (moving into `packages/cli` assets); its schema reference and validator are generated from `@arkaik/schema` |
+| Install | `arkaik init` writes it as `SKILL.md` (uppercase — required for discovery) into the consuming repo's skills directory |
+| Templating | The install is a render, not a copy: product name and bundle path are parameters (the current skill hardcodes Pebbles and `docs/arkaik/bundle.json`) |
+| Versioning | A version stamp in the skill frontmatter lets `arkaik init --update` upgrade cleanly instead of blind-overwriting local edits |
+| Skill v2 behavior | Dual-write per [journal.md](journal.md): surgical snapshot patches + appended events, validator as the hard gate — unchanged doctrine, new history duty |
+| Second channel | A Claude Code plugin (marketplace-installable) packaging the same generated assets, for users who prefer plugin management over `npx` |
+
+## Licensing
+
+`packages/schema`, `packages/cli`, and the skill assets ship under **MIT**; the app and services remain **AGPL-3.0**. Rationale and timing in [vision.md](../vision.md) — the split executes with the Phase 1 package extraction, while the repository still has a single copyright holder.

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -2,6 +2,7 @@
 
 > This document describes long-term direction while staying aligned with the current architecture.
 > Source of truth for implemented behavior: [architecture.md](architecture.md), [graph-model.md](graph-model.md), and [data-layer.md](data-layer.md).
+> Normative format and tooling specifications live in [spec/](spec/bundle-format.md).
 
 ## Problem Statement
 
@@ -9,152 +10,36 @@ Product knowledge is usually fragmented across planning docs, design files, API 
 
 arkaik targets that gap with one navigable graph.
 
-## Offering Model
+But a map that only shows the present is half a map. Product teams don't just ask *"what is the status of this screen?"* — they ask *"when did it ship?"*, *"what changed between v1.2 and v1.3?"*, *"which ideas are waiting?"*, *"what does the release note say?"*. Today's bundle is a static snapshot that answers only the first question.
 
-The arkaik offering is structured around **3 pricing tiers** visible on the pricing page, plus **3 complementary modes** that live outside the pricing table as entry points or power-user options.
+## Thesis: From Snapshot to Living Journal
 
-### The Full Picture
+The `ProjectBundle` evolves from a static export into a **living record of a product's anatomy over time**:
 
-```mermaid
-graph LR
-	subgraph OUTSIDE["Outside the pricing table"]
-		LOKAL["Lokal\\n'Try Lokal' button\\nNo account, sandbox"]
-		PUBLIK["Publik\\nPublish action from Lokal\\nShareable snapshot"]
-		INKOGNITO["Inkognito\\nBelow-the-fold CTA\\nSelf-hosted Supabase"]
-	end
+- The **snapshot** stays what it is today — the current state of the graph, importable as a single JSON file. A snapshot-only bundle remains valid forever.
+- An optional **journal** — an append-only log of typed events (status transitions, releases, ideas, requests, reference updates) — captures how the product got there.
+- **Projections** derived from the journal give users the features a static map cannot: per-node status timelines, changelogs between versions, release notes, and an ideas/requests backlog.
 
-	subgraph PRICING["Pricing table"]
-		SYNK["Synk\\nFree tier\\nAccount required"]
-		BASIK["Basik\\nFrom EUR0.99\\nPay-what-you-want"]
-		KLUB["Klub\\nPremium\\nFull features"]
-	end
+This is deliberately layered (see [Format Levels](#format-levels)): nobody is forced to adopt the journal, and the single-file import experience never degrades.
 
-	LOKAL -- "Sign up to keep your work" --> SYNK
-	LOKAL -- "Publish" --> PUBLIK
-	SYNK -- "Upgrade" --> BASIK
-	BASIK -- "Upgrade" --> KLUB
-	INKOGNITO -. "Power users" .-> LOKAL
-```
+The second half of the thesis: **arkaik is not just an app**. Its most committed users keep their product map *in their repository, next to their code*, maintained by coding agents as a side effect of development — that is exactly how arkaik itself uses the [agent skill](arkaik-skill/skill.md) with the Pebbles project. For them, the repo is the source of truth and arkaik.app is a lens. Serving that persona well requires treating the format and the tooling as products in their own right.
 
-## Complementary Modes (Outside Pricing)
+## The Four Layers
 
-### Lokal: The Sandbox
+arkaik is structured as four layers, each usable without the ones above it.
 
-Not a tier. A **Try Lokal** button next to Sign in on the landing page.
-
-- No account, no server, no sign-up
-- Full editor experience in browser storage (Dexie.js / IndexedDB)
-- Limited features (no AI, no assets, no version history)
-- Manual JSON export to save work
-- Clear warning that browser cache clearing can remove local data
-- Purpose: zero-friction entry point before account commitment
-- Conversion trigger: when users need backups, sharing, or more features, prompt Sign up to keep your work and migrate local data to account mode
-
-Current implementation references: [lib/data/local-provider.ts](../lib/data/local-provider.ts), [lib/utils/export.ts](../lib/utils/export.ts), [app/project/[id]/canvas/page.tsx](../app/project/[id]/canvas/page.tsx)
-
-### Publik: The Share Action
-
-Not a tier. A publish feature available from Lokal (and potentially paid tiers).
-
-- User clicks Publish on a project
-- arkaik stores a raw JSON snapshot and returns a shareable project ID URL (for example, `arkaik.app/p/abc123`)
-- Anyone with the URL can import and edit a copy locally
-- Owner key (UUID) is generated once at publish time and required to delete the snapshot
-- Publish flow includes a disclaimer that arkaik does not guarantee retention of published snapshots
-- Product framing: GitHub Gist for product graphs
-
-### Inkognito: The Sovereign Option
-
-Not a tier. A below-the-fold pricing-page CTA for power users.
-
-- Local-first operation backed by the user's own Supabase project
-- arkaik provides setup scripts, migration scripts, and documentation
-- Full features including asset uploads (to user-owned Supabase buckets)
-- No arkaik account required; AI features excluded
-- Target audience: developers prioritizing full data sovereignty
-- arkaik infra cost: zero
-- Schema migrations are user-managed, with release-aligned scripts provided by arkaik
-
-## Pricing Tiers
-
-|  | **Synk** | **Basik** | **Klub** |
+| Layer | What it is | License | Status |
 |---|---|---|---|
-| **Tagline** | Save your work | Own your workflow | Unlock everything |
-| **Price** | Free | From EUR0.99/mo | TBD |
-| **Account** | Required | Required | Required |
+| **1. Format** | The open, versioned `ProjectBundle` + journal + references specification | MIT (planned split) | Partial — v1 schema published at `public/schema/project-bundle.json`, unversioned; v2 specified in [spec/bundle-format.md](spec/bundle-format.md) |
+| **2. Toolchain** | An npm package: `arkaik` CLI (validate, init, log, release, sync, pack), the agent skill, a zero-dependency validator artifact | MIT (planned split) | Planned — today the skill is copy-paste (`docs/arkaik-skill/`) and the validator is standalone |
+| **3. App** | arkaik.app — the graph viewer/editor (hosted; later possibly a local viewer via static export) | AGPL-3.0 | Live — local-first via `localStorage`, no accounts |
+| **4. Services** | Sync, hosting, sharing, integrations: the Synk/Basik/Klub tiers, Publik snapshots, Inkognito BYO-Supabase | AGPL / commercial | Planned |
 
-### Storage And Sync
+Design rule: **each layer only depends on the layer below it.** The app renders anything that conforms to the format; the services sync anything the app can hold. A user can adopt the format with zero arkaik infrastructure (a JSON file in a repo), and every additional layer is opt-in convenience.
 
-|  | **Synk** | **Basik** | **Klub** |
-|---|---|---|---|
-| **Source of truth** | Browser (Dexie) | Browser (Dexie) | Browser (Dexie) |
-| **Server storage** | arkaik server (JSON backups) | arkaik Supabase (consolidated) | arkaik Supabase (consolidated) |
-| **Sync method** | Interval backup (~1 min) | Real-time sync | Real-time sync |
-| **Version history** | 7 days | 30 days | Unlimited |
-| **Data persistence** | Server backups | Server + local | Server + local |
+The npm channel is the standard for repo-native developer tooling — Storybook, Changesets, shadcn, and husky all live inside consuming repositories this way. A system package manager (brew) targets machine-global binaries and would miss the actual audience: JavaScript-adjacent product repos and their CI.
 
-### Features And Limits
-
-|  | **Synk** | **Basik** | **Klub** |
-|---|---|---|---|
-| **Entity limit** | ~250 synced | ~1,000 synced | Unlimited |
-| **Projects** | 1 | 3 | Unlimited |
-| **Asset uploads** | No | Limited (TBD) | Yes (arkaik bucket) |
-| **AI features** | No | No (or low credits) | Yes |
-| **Sharing** | JSON export + Publik | JSON export + Publik | JSON export + Publik + future collaboration |
-| **Import / Export** | Yes | Yes | Yes |
-
-### Infrastructure
-
-|  | **Synk** | **Basik** | **Klub** |
-|---|---|---|---|
-| **arkaik server** | Backup service only | Full Supabase | Full Supabase |
-| **Data responsibility** | Shared (best-effort backups) | arkaik-managed guarantees | arkaik-managed guarantees |
-| **arkaik infra cost** | Low | Medium | Medium to High |
-
-## Core Product Direction (Unchanged)
-
-The pricing and mode model above should preserve current graph and UX foundations.
-
-### Graph Model Continuity
-
-The core model remains centered on four species:
-
-- `flow`: ordered sequence container
-- `view`: reusable screen/page node
-- `data-model`: data entity node
-- `api-endpoint`: API contract node
-
-Flow behavior remains playlist-driven (`metadata.playlist.entries`) and can anchor from optional `project.root_node_id`.
-
-Config source: [lib/config/species.ts](../lib/config/species.ts)
-
-### UX Continuity
-
-- Keep canvas route for spatial graph editing and sequence expansion
-- Keep library route for dense browsing, filtering, and metadata audit workflows
-- Keep sidebar shell for stable in-project navigation between both modes
-- Keep reuse-first authoring with where-used visibility and insert-between operations
-
-Implementation references: [app/project/[id]/canvas/page.tsx](../app/project/[id]/canvas/page.tsx), [app/project/[id]/library/page.tsx](../app/project/[id]/library/page.tsx), [components/layout/ProjectSidebar.tsx](../components/layout/ProjectSidebar.tsx), [components/panels/NodeDetailPanel.tsx](../components/panels/NodeDetailPanel.tsx), [components/panels/InsertBetweenDialog.tsx](../components/panels/InsertBetweenDialog.tsx), [lib/utils/where-used.ts](../lib/utils/where-used.ts), [lib/utils/elk-layout.ts](../lib/utils/elk-layout.ts)
-
-### Platform And Status Continuity
-
-- Keep per-platform status editing on `view` nodes
-- Keep `flow` status as computed rollup from descendant views
-- Keep lifecycle state visible in cards, panels, and table rows
-
-Config sources: [lib/config/platforms.ts](../lib/config/platforms.ts), [lib/config/statuses.ts](../lib/config/statuses.ts)
-
-### Data Layer Continuity
-
-- Preserve the `DataProvider` abstraction so UI and hooks stay backend-agnostic
-- Continue local-first operation with import/export
-- Add tier-aware backend behavior without breaking existing contracts
-
-Implementation references: [lib/data/data-provider.ts](../lib/data/data-provider.ts), [lib/data/local-provider.ts](../lib/data/local-provider.ts), [lib/utils/export.ts](../lib/utils/export.ts)
-
-## User Journeys
+## Personas & Journeys
 
 ### Journey 1: Casual Explorer
 
@@ -181,11 +66,293 @@ Implementation references: [lib/data/data-provider.ts](../lib/data/data-provider
 2. User provisions Supabase and runs arkaik migration/setup scripts.
 3. User runs arkaik with full local-first behavior and no dependency on arkaik-hosted infrastructure.
 
+### Journey 5: Git-Native Builder (Kommit)
+
+The persona the current vision missed — and the one arkaik's own development embodies.
+
+1. Developer runs `npx arkaik init` in their product repo. It scaffolds `docs/arkaik/` (bundle + journal), installs the agent skill into the repo's skills directory, and configures merge attributes.
+2. Their coding agents maintain the map as a side effect of code changes: surgical patches to the snapshot, appended events to the journal, validator as a hard gate (optionally in CI).
+3. `arkaik sync` mirrors external status (GitHub/GitLab/Linear issues, PR/MRs) into the map's references.
+4. When they want to *see* the map, they open arkaik.app and import the packed bundle — or publish it via Publik / push it to a synced account project.
+5. `arkaik release` tags a version, generates release notes from the journal, and compacts history.
+
+The repo is the source of truth; every arkaik surface above it is a lens. Proposed working name for this mode, in the family of the others: **Kommit**.
+
+## Format Levels
+
+The format supports three adoption levels. Higher levels are strictly additive — every level remains valid indefinitely, and consumers must accept all of them. This answers the size concern directly: history never bloats the snapshot, because it never has to live inside it.
+
+| Level | What the user maintains | What it unlocks | Cost |
+|---|---|---|---|
+| **0 — Static snapshot** | `bundle.json` only (today's format) | The full current-state graph experience | None — this is today |
+| **1 — Versioned snapshot** | Snapshot + `schema_version` + release tags | Named versions, per-tier snapshot retention (the 7-day/30-day/unlimited version history of Synk/Basik/Klub), safe schema migrations | One integer field + tagging discipline |
+| **2 — Snapshot + journal** | Snapshot + append-only event journal (sidecar `journal.jsonl` in repos; embedded `journal[]` only as a single-file interchange projection) | Status timelines, changelog between versions, release notes, ideas & requests backlog | Dual-write discipline (automated by the skill/CLI) |
+
+Two authority rules keep the levels honest (normative details in [spec/journal.md](spec/journal.md)):
+
+- **The snapshot is authoritative for current state; the journal is authoritative for history.** The app never silently re-derives one from the other; the validator cross-checks them by value (for example, the last `node.status_changed.to` must match the node's current `status`).
+- **Unknown event types and unknown fields are preserved and ignored.** The event vocabulary can grow without breaking older consumers.
+
+Status stops being a mutable field that forgets, and becomes the *current value* of a tracked evolution: an idea is proposed (`idea.proposed`), becomes a node (`node.created`), moves through the lifecycle (`node.status_changed`), ships in a version (`release.tagged`), and appears in a generated release note — all without changing what a Level 0 user has to care about.
+
+## References, Assets & Integrations
+
+A product map that cannot point at the design file, the issue, or the pull request forces users back into the fragmentation arkaik exists to solve. The v2 format adds typed **references** on nodes (shape specified in [spec/bundle-format.md](spec/bundle-format.md)):
+
+| Ref type | Examples | Status mirroring |
+|---|---|---|
+| `figma` | Design file / frame preview links | None (link + optional cached thumbnail) |
+| `github-issue`, `gitlab-issue`, `linear-issue` | The ticket driving a node | External status mirrored, optionally mapped to the arkaik lifecycle |
+| `github-pr`, `gitlab-mr` | The code change implementing a node | Open / merged / closed mirrored |
+| `url` | Anything else (specs, dashboards) | None |
+
+**Status sync is a mode-appropriate concern, not one global mechanism:**
+
+- **Kommit:** `arkaik sync` reads refs, queries the external APIs with locally provided tokens (env vars in dev or CI), updates the mirrored status, and appends `ref.status_changed` events. Agents can do the same as part of the skill workflow. No arkaik server involved.
+- **Paid tiers (Klub first):** server-side integrations and webhooks keep refs fresh without a repo or CI — a natural premium surface.
+
+### Asset Policy
+
+Screenshots and previews are where storage gets critical, and the rule that keeps every mode coherent is: **the bundle carries references, not blobs.** An asset value is one of:
+
+| Form | Where the bytes live | Mode |
+|---|---|---|
+| Relative path (`assets/web/home.png`) | The user's repo, next to the bundle | Kommit |
+| Absolute URL | Figma, arkaik bucket (Basik/Klub), user-owned Supabase bucket (Inkognito) | All hosted modes |
+| Data URI | Inline in the bundle | Lokal / legacy only — discouraged |
+
+Today the app stores screenshots as base64 data URIs inside the bundle (`metadata.platformScreenshots`, written by `components/panels/NodeDetailPanel.tsx`). That is a size bomb: it presses against the 5 MB import cap, the 4 MB export warning, and the localStorage quota simultaneously, and it is the one place the current code and the published schema have already drifted apart. The v2 spec legitimizes all three forms; `arkaik pack` inlines or uploads assets when a self-contained interchange file is needed. Journal events never carry asset payloads — only the fact that an asset changed.
+
+## Modes & Tiers
+
+The offering remains **3 pricing tiers + complementary modes** outside the pricing table. Kommit joins the modes.
+
+### The Full Picture
+
+```mermaid
+graph LR
+	subgraph OUTSIDE["Outside the pricing table"]
+		LOKAL["Lokal\n'Try Lokal' button\nNo account, sandbox"]
+		PUBLIK["Publik\nPublish action\nShareable snapshot"]
+		KOMMIT["Kommit\nnpx arkaik init\nRepo as source of truth"]
+		INKOGNITO["Inkognito\nBelow-the-fold CTA\nSelf-hosted Supabase"]
+	end
+
+	subgraph PRICING["Pricing table"]
+		SYNK["Synk\nFree tier\nAccount required"]
+		BASIK["Basik\nFrom EUR0.99\nPay-what-you-want"]
+		KLUB["Klub\nPremium\nFull features"]
+	end
+
+	LOKAL -- "Sign up to keep your work" --> SYNK
+	LOKAL -- "Publish" --> PUBLIK
+	KOMMIT -- "arkaik push / Publish" --> PUBLIK
+	KOMMIT -. "Optional mirror" .-> SYNK
+	SYNK -- "Upgrade" --> BASIK
+	BASIK -- "Upgrade" --> KLUB
+	INKOGNITO -. "Power users" .-> LOKAL
+```
+
+### Complementary Modes (Outside Pricing)
+
+#### Lokal: The Sandbox
+
+Not a tier. A **Try Lokal** button next to Sign in on the landing page.
+
+- No account, no server, no sign-up
+- Full editor experience in browser storage — `localStorage` today (`lib/data/local-provider.ts`, key `arkaik:store`); an IndexedDB (Dexie.js) migration is planned and is a prerequisite for journal writes in the app (see Roadmap)
+- Limited features (no AI, no hosted assets, no version history)
+- Manual JSON export to save work
+- Clear warning that browser cache clearing can remove local data
+- Purpose: zero-friction entry point before account commitment
+- Conversion trigger: when users need backups, sharing, or more features, prompt Sign up to keep your work and migrate local data to account mode
+
+Current implementation references: `lib/data/local-provider.ts`, `lib/utils/export.ts`, `app/project/[id]/canvas/page.tsx`
+
+#### Kommit: The Git-Native Mode
+
+Not a tier. Entry point is the toolchain, not the website: `npx arkaik init`.
+
+- The bundle and journal live in the user's repository; coding agents and the CLI maintain them
+- The agent skill is installed and updated by the CLI (versioned, templated per project) instead of copy-pasted
+- Validation is a hard gate locally and in CI; external refs sync via `arkaik sync`
+- The app is a viewer: import a packed bundle, or connect via Publik/Synk when convenient
+- arkaik infra cost: zero; the entire mode ships under MIT so any company can adopt it
+
+Current implementation references: `docs/arkaik-skill/skill.md`, `docs/arkaik-skill/scripts/validate-bundle.js` (the copy-paste ancestors of this mode)
+
+#### Publik: The Share Action
+
+Not a tier. A publish feature available from Lokal, Kommit (`arkaik push`), and potentially paid tiers.
+
+- User clicks Publish on a project (or runs the CLI equivalent)
+- arkaik stores a raw JSON snapshot and returns a shareable project ID URL (for example, `arkaik.app/p/abc123`)
+- Anyone with the URL can import and edit a copy locally
+- Owner key (UUID) is generated once at publish time and required to delete the snapshot
+- Snapshots are published without the journal by default (`--no-journal` semantics); history stays private unless explicitly included
+- Publish flow includes a disclaimer that arkaik does not guarantee retention of published snapshots
+- Product framing: GitHub Gist for product graphs
+
+#### Inkognito: The Sovereign Option
+
+Not a tier. A below-the-fold pricing-page CTA for power users.
+
+- Local-first operation backed by the user's own Supabase project
+- arkaik provides setup scripts, migration scripts, and documentation
+- Full features including asset uploads (to user-owned Supabase buckets)
+- No arkaik account required; AI features excluded
+- Target audience: developers prioritizing full data sovereignty
+- arkaik infra cost: zero
+- Schema migrations are user-managed, with release-aligned scripts provided by arkaik — the `schema_version` field introduced at Format Level 1 is what makes these migrations tractable
+
+### Pricing Tiers
+
+|  | **Synk** | **Basik** | **Klub** |
+|---|---|---|---|
+| **Tagline** | Save your work | Own your workflow | Unlock everything |
+| **Price** | Free | From EUR0.99/mo | TBD |
+| **Account** | Required | Required | Required |
+
+#### Storage And Sync
+
+|  | **Synk** | **Basik** | **Klub** |
+|---|---|---|---|
+| **Source of truth** | Browser | Browser | Browser |
+| **Server storage** | arkaik server (JSON backups) | arkaik Supabase (consolidated) | arkaik Supabase (consolidated) |
+| **Sync method** | Interval backup (~1 min) | Real-time sync | Real-time sync |
+| **Version history** | 7 days | 30 days | Unlimited |
+| **Data persistence** | Server backups | Server + local | Server + local |
+
+Version history is where the format levels pay off for services: snapshot retention (Level 1) gives coarse restore points; the journal (Level 2) gives fine-grained timelines within them. Long term, the journal is the natural substrate for sync itself — append-only event streams merge far better than whole-snapshot diffs — but v1 sync makes no event-sourcing promises (see [spec/journal.md](spec/journal.md)).
+
+#### Features And Limits
+
+|  | **Synk** | **Basik** | **Klub** |
+|---|---|---|---|
+| **Entity limit** | ~250 synced | ~1,000 synced | Unlimited |
+| **Projects** | 1 | 3 | Unlimited |
+| **Asset uploads** | No | Limited (TBD) | Yes (arkaik bucket) |
+| **Integrations (server-side ref sync)** | No | No | Yes (GitHub, GitLab, Linear, Figma) |
+| **AI features** | No | No (or low credits) | Yes |
+| **Sharing** | JSON export + Publik | JSON export + Publik | JSON export + Publik + future collaboration |
+| **Import / Export** | Yes | Yes | Yes |
+
+#### Infrastructure
+
+|  | **Synk** | **Basik** | **Klub** |
+|---|---|---|---|
+| **arkaik server** | Backup service only | Full Supabase | Full Supabase |
+| **Data responsibility** | Shared (best-effort backups) | arkaik-managed guarantees | arkaik-managed guarantees |
+| **arkaik infra cost** | Low | Medium | Medium to High |
+
+## Open Source Strategy
+
+Current state: the whole repository, including the agent skill designed to be copied into other people's repos, is AGPL-3.0 (`LICENSE`).
+
+Decision: **split the licensing by layer.**
+
+- **MIT (or Apache-2.0): the format, schema, validator, CLI, and skill.** A format only wins by spreading, and the toolchain's entire adoption channel is *being pasted into other organizations' repositories* — many corporate policies reject AGPL dependencies outright. Copyleft on these layers would throttle exactly the growth they exist for.
+- **AGPL-3.0: the app and services.** This is the moat: anyone can self-host, nobody can run a closed-source arkaik.app clone.
+
+The split executes when the packages are physically extracted (`packages/schema`, `packages/cli` — Roadmap Phase 1). It should not wait longer than that: the repository currently has effectively a single copyright holder, which makes relicensing trivial today and progressively harder with every external contribution. `CONTRIBUTING.md` and `GOVERNANCE.md` stubs (Phase 0) will record which paths carry which license and how contributions are accepted.
+
+## Roadmap
+
+Sequencing principle: **git-native toolchain first.** It serves arkaik's own dogfooding workflow immediately, builds bottom-up adoption the way Storybook and Changesets did, and lets the SaaS tiers arrive later as convenience on top of a proven format — rather than a format invented under a SaaS deadline.
+
+### Phase 0 — Enablers
+
+- CI: lint, build, run the validator against all seeds (`seed/pebbles.json`, `seed/arkaik-self-map.json`, `public/schema/example-bundle.json`), fixture tests (valid/invalid bundles)
+- Fix `rewriteBundleProjectId` in `lib/utils/export.ts`, which silently drops unknown top-level bundle keys on import-ID collision — a landmine for any format extension
+- Align the `TASK_EXTEND` prompt in `lib/prompts/blocks.ts` with the skill's surgical-patch doctrine (it currently instructs LLMs to regenerate the full bundle)
+- License split decision recorded; `CONTRIBUTING.md` / `GOVERNANCE.md` stubs
+
+### Phase 1 — Single Source of Truth
+
+The bundle contract currently lives in five places that drift independently: `lib/data/types.ts`, `public/schema/project-bundle.json`, `docs/arkaik-skill/references/schema.md`, `docs/arkaik-skill/scripts/validate-bundle.js`, and `lib/prompts/blocks.ts` (drift is already real: `platformScreenshots` exists only in the first). Collapse them **before** the journal would make it six:
+
+- `packages/schema` (npm workspace; the root app stays put): zod-based canonical definition of types, enums, and the semantic graph rules (duplicate IDs, dangling edges, playlist coherence, cycles) that JSON Schema cannot express
+- Generated artifacts, committed and drift-checked in CI: the JSON Schema, a zero-dependency bundled `validate-bundle.js` (agents in repos without the CLI still need `node validate-bundle.js`), the skill's schema reference fragment, and the prompt generator's schema block
+- App consumes the package: `lib/data/types.ts` becomes a re-export; `assertProjectBundleShape` is replaced by real validation — closing the duplicate-node-ID class of import failures at the app door
+
+### Phase 2 — Format v2 & Journal Read Path
+
+- Bundle v2 per [spec/bundle-format.md](spec/bundle-format.md): `schema_version`, refs, asset value forms, optional embedded `journal[]`
+- Journal per [spec/journal.md](spec/journal.md): JSONL sidecar, union-merge gitattributes, event vocabulary
+- Skill v2: dual-write (patch snapshot + append events), templated per project, versioned frontmatter so `arkaik init --update` can upgrade it
+- App reads journals: per-node status timeline in the detail panel, changelog view — rendering only, no app-side event emission yet
+
+### Phase 3 — Toolchain & Write Path
+
+- `packages/cli`: `init`, `validate`, `log`, `release` (tagging, release notes, compaction), `sync`, `pack`, `open`; skill distribution as a Claude Code plugin as a second channel
+- Deterministic IDs adopted **in the app** for nodes and edges (today `lib/utils/id.ts` generates random UUID suffixes and canvas edges use raw UUIDs, so any app round-trip violates the conventions the skill enforces), plus canonical serialization (sorted keys/nodes/edges) so app exports diff cleanly in git
+- App-side event emission, gated on the IndexedDB (Dexie) migration — localStorage rewrites the whole store on every mutation and cannot absorb a growing journal
+- `arkaik dev` (local viewer) decision: requires making `/project/[id]` routing static-export friendly; evaluated on its own merits, not assumed
+
+### Phase 4 — Services Re-Based
+
+- Synk/Basik/Klub, Publik, and Inkognito as specified above, with snapshot retention + journal as the version-history substrate
+- Server-side integrations (ref status sync) as the Klub differentiator
+- Collaboration explorations on top of event streams
+
+## Core Product Direction (Unchanged)
+
+The strategy above must preserve the current graph and UX foundations.
+
+### Graph Model Continuity
+
+The core model remains centered on four species:
+
+- `flow`: ordered sequence container
+- `view`: reusable screen/page node
+- `data-model`: data entity node
+- `api-endpoint`: API contract node
+
+Flow behavior remains playlist-driven (`metadata.playlist.entries`) and can anchor from optional `project.root_node_id`.
+
+Config source: `lib/config/species.ts`
+
+### UX Continuity
+
+- Keep canvas route for spatial graph editing and sequence expansion
+- Keep library route for dense browsing, filtering, and metadata audit workflows
+- Keep sidebar shell for stable in-project navigation between both modes
+- Keep reuse-first authoring with where-used visibility and insert-between operations
+
+Implementation references: `app/project/[id]/canvas/page.tsx`, `app/project/[id]/library/page.tsx`, `components/layout/ProjectSidebar.tsx`, `components/panels/NodeDetailPanel.tsx`, `components/panels/InsertBetweenDialog.tsx`, `lib/utils/where-used.ts`, `lib/utils/elk-layout.ts`
+
+### Platform And Status Continuity
+
+- Keep per-platform status editing on `view` nodes
+- Keep `flow` status as computed rollup from descendant views
+- Keep lifecycle state visible in cards, panels, and table rows
+- The journal extends this model with history; it does not replace it. `release.tagged` events carry an optional `platform` so per-platform release rhythms (web weekly, iOS monthly) stay expressible
+
+Config sources: `lib/config/platforms.ts`, `lib/config/statuses.ts`
+
+### Data Layer Continuity
+
+- Preserve the `DataProvider` abstraction so UI and hooks stay backend-agnostic
+- Continue local-first operation with import/export
+- Add tier-aware backend behavior without breaking existing contracts
+
+Implementation references: `lib/data/data-provider.ts`, `lib/data/local-provider.ts`, `lib/utils/export.ts`
+
+### Non-Goals
+
+- Not a task tracker — refs *link to* issues and PRs; arkaik never becomes the place where they are managed
+- Not a wiki, not a design tool
+- No event-sourcing purism: the snapshot is never silently re-projected from the journal (see the authority rules in [spec/journal.md](spec/journal.md))
+
 ## Open Questions
 
 - [ ] Basik pricing model: fixed monthly versus pay-what-you-want
 - [ ] Entity limits: validate whether 250 (Synk) and 1,000 (Basik) match real project distributions
 - [ ] Publik moderation: define minimal report and takedown process for harmful content
 - [ ] Publik owner key UX: define recovery or account-link fallback when key is lost
-- [ ] Lokal to Synk migration: test Dexie-to-server migration early as the primary conversion funnel
+- [ ] Lokal to Synk migration: test browser-storage-to-server migration early as the primary conversion funnel
 - [ ] Inkognito migrations: commit to versioned migration artifacts from the first release
+- [ ] Screenshot policy in the interchange format: are data URIs tolerated forever (Lokal needs them) or eventually rejected above a size threshold?
+- [ ] Per-platform releases: is optional `platform` on `release.tagged` enough, or do platforms need independent version sequences?
+- [ ] Publik and journals: default-exclude is decided; is opt-in inclusion ever safe (history can leak internal names and dates)?
+- [ ] Kommit naming: confirm "Kommit" (working name) against the existing K-family


### PR DESCRIPTION
## Summary

This PR significantly expands the product vision document and introduces three new specification documents that formalize the arkaik format and tooling strategy. The changes articulate a layered architecture (format, toolchain, app, services), define the journal-based Format Level 2, and establish the roadmap for git-native development workflows.

## Key Changes

**Vision Document Expansion (`docs/vision.md`)**
- Reframed the offering from a simple pricing model to a **four-layer architecture**: Format (MIT), Toolchain (MIT), App (AGPL), and Services (AGPL/commercial)
- Introduced **Format Levels** (0: static snapshot, 1: versioned, 2: snapshot + journal) as strictly additive adoption tiers
- Added five user journeys: Casual Explorer, Sharer, Power User, Sovereign Developer, and **Kommit** (git-native builder)
- Detailed the **Kommit mode**: repository-as-source-of-truth with agent-maintained bundles, CLI tooling, and optional arkaik.app as a lens
- Expanded complementary modes (Lokal, Publik, Inkognito) with implementation references and clarified their relationship to pricing tiers
- Introduced **open source strategy**: split licensing by layer (MIT for format/toolchain, AGPL for app/services) to enable adoption in corporate environments
- Added a detailed **roadmap** with four phases: Enablers, Single Source of Truth, Format v2 & Journal Read Path, Toolchain & Write Path, and Services Re-Based

**New Specification Documents**
- `docs/spec/bundle-format.md`: Defines ProjectBundle v2 with schema versioning, references (typed external links), asset value forms (relative path, URL, data URI), identifier conventions, and canonical serialization rules
- `docs/spec/journal.md`: Specifies the append-only event journal (JSONL sidecar in repos, embedded array for interchange), event envelope, vocabulary (node/edge/release/idea/request/ref events), authority model (snapshot authoritative for current state, journal for history), and projections (timelines, changelogs, release notes)
- `docs/spec/toolchain.md`: Describes the npm workspace layout, `@arkaik/schema` package as the single source of truth (zod-based, generates JSON Schema and standalone validator), `arkaik` CLI commands (init, validate, log, release, sync, pack, open, push), and skill distribution strategy

**Documentation Updates**
- Updated `docs/README.md` to link the new specification documents
- Updated root `README.md` to reference the expanded vision and specifications

## Notable Implementation Details

- **Format versioning**: v2 bundles carry `schema_version` (absent = v1); unknown fields are preserved on re-export, enabling forward compatibility
- **Journal storage**: JSONL sidecar in repos with git union merge (one event per line, safe for concurrent appends); embedded `journal[]` array for single-file interchange
- **Authority model**: snapshot is authoritative for current state, journal for history; dual-write discipline (patch snapshot + append event) keeps them consistent; validator cross-checks by value
- **Asset handling**: three forms (relative path for repos, absolute URL for hosted, data URI for legacy) with graceful degradation when forms cannot be resolved
- **Identifier conventions**: deterministic, human-readable IDs (e.g., `F-onboarding`, `API-create-bounce`, `e-V-home-API-list-bounces`) with collision-handling rules
- **Licensing split**: format, schema, CLI, and skill are MIT; app and services are AGPL-3.0, enabling repo-native adoption without copyleft friction
- **Roadmap sequencing**: git-native toolchain first (bottom-up adoption), then SaaS tiers as convenience layers on proven format

The changes establish arkaik as a **format-first, layered system** where the repository is the source of truth and the app is an optional lens, rather than a SaaS-first product with a format as an afterthought.

https://claude.ai/code/session_01QpXVmp8QNHQF3s2cCvtead