### PR TITLE
Fix bundle rewrite to preserve all properties

### DIFF
--- a/lib/utils/export.ts
+++ b/lib/utils/export.ts
@@ -85,6 +85,7 @@ async function ensureUniqueProjectId(initialId: string): Promise<string> {
 
 function rewriteBundleProjectId(bundle: ProjectBundle, newProjectId: string): ProjectBundle {
   return {
+    ...bundle,
     project: { ...bundle.project, id: newProjectId },
     nodes: bundle.nodes.map((node) => ({ ...node, project_id: newProjectId })),
     edges: bundle.edges.map((edge) => ({ ...edge, project_id: newProjectId })),


### PR DESCRIPTION
## Summary
Fixed the `rewriteBundleProjectId` function to properly preserve all properties of the original bundle when rewriting project IDs.

## Key Changes
- Added spread operator (`...bundle`) to the return object to preserve all existing bundle properties
- This ensures that any properties beyond `project`, `nodes`, and `edges` are not lost during the rewrite operation

## Implementation Details
Previously, the function only explicitly returned `project`, `nodes`, and `edges` properties, which would drop any other properties that might exist on the bundle object. By spreading the original bundle first and then overriding the specific properties that need updating, we maintain backward compatibility and prevent accidental data loss.

https://claude.ai/code/session_019HLZkzqWZF4L3xXs1quMYZ