### PR TITLE
Extract schema definitions into shared package

### DIFF
--- a/lib/config/edge-types.ts
+++ b/lib/config/edge-types.ts
@@ -1,10 +1,12 @@
+import type { EdgeTypeId } from "@arkaik/schema";
+
 export const EDGE_TYPES = [
   { id: "composes", label: "Composes" },
   { id: "calls",    label: "Calls" },
   { id: "displays", label: "Displays" },
   { id: "queries",  label: "Queries" },
-] as const;
+] as const satisfies readonly { id: EdgeTypeId; label: string }[];
 
-export type EdgeTypeId = (typeof EDGE_TYPES)[number]["id"];
+export type { EdgeTypeId };
 /** @deprecated Use EdgeTypeId */
 export type EdgeType = EdgeTypeId;

--- a/lib/config/platforms.ts
+++ b/lib/config/platforms.ts
@@ -1,9 +1,11 @@
+import type { PlatformId } from "@arkaik/schema";
+
 export const PLATFORMS = [
   { id: "web",     label: "Web",     icon: "Monitor" },
   { id: "ios",     label: "iOS",     icon: "Apple" },
   { id: "android", label: "Android", icon: "Bot" },
-] as const;
+] as const satisfies readonly { id: PlatformId; label: string; icon: string }[];
 
-export type PlatformId = (typeof PLATFORMS)[number]["id"];
+export type { PlatformId };
 /** @deprecated Use PlatformId */
 export type Platform = PlatformId;

--- a/lib/config/species.ts
+++ b/lib/config/species.ts
@@ -1,10 +1,17 @@
+import type { SpeciesId } from "@arkaik/schema";
+
 export const SPECIES = [
   { id: "flow",       level: 1, label: "Flow",         description: "an ordered sequence of views and sub-flows" },
   { id: "view",       level: 0, label: "View",         description: "a reusable page or screen" },
   { id: "data-model", level: null, label: "Data Model",   description: "parallel layer: data model" },
   { id: "api-endpoint", level: null, label: "API Endpoint", description: "parallel layer: API endpoint" },
-] as const;
+] as const satisfies readonly {
+  id: SpeciesId;
+  level: number | null;
+  label: string;
+  description: string;
+}[];
 
-export type SpeciesId = (typeof SPECIES)[number]["id"];
+export type { SpeciesId };
 /** @deprecated Use SpeciesId */
 export type Species = SpeciesId;

--- a/lib/config/statuses.ts
+++ b/lib/config/statuses.ts
@@ -1,3 +1,5 @@
+import type { StatusId } from "@arkaik/schema";
+
 export const STATUSES = [
   { id: "idea",        label: "Idea",        order: 0 },
   { id: "backlog",     label: "Backlog",     order: 1 },
@@ -7,9 +9,9 @@ export const STATUSES = [
   { id: "live",        label: "Live",        order: 5 },
   { id: "archived",    label: "Archived",    order: 6 },
   { id: "blocked",     label: "Blocked",     order: 7 },
-] as const;
+] as const satisfies readonly { id: StatusId; label: string; order: number }[];
 
-export type StatusId = (typeof STATUSES)[number]["id"];
+export type { StatusId };
 /** @deprecated Use StatusId */
 export type Status = StatusId;
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   allowedDevOrigins: ["127.0.0.1"],
+  transpilePackages: ["@arkaik/schema"],
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "nextjs",
       "version": "0.1.0",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -60,6 +63,10 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@arkaik/schema": {
+      "resolved": "packages/schema",
+      "link": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -9710,10 +9717,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -9768,6 +9774,14 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "packages/schema": {
+      "name": "@arkaik/schema",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.4.3"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "nextjs",
   "version": "0.1.0",
   "private": true,
+  "workspaces": ["packages/*"],
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@arkaik/schema",
+  "version": "0.1.0",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "dependencies": {
+    "zod": "^4.4.3"
+  }
+}

--- a/packages/schema/src/bundle.ts
+++ b/packages/schema/src/bundle.ts
@@ -1,0 +1,138 @@
+import { z } from "zod";
+import {
+  EdgeTypeSchema,
+  PlatformSchema,
+  SpeciesSchema,
+  StatusSchema,
+  type EdgeTypeId,
+  type PlatformId,
+  type SpeciesId,
+  type StatusId,
+} from "./enums";
+import { FlowPlaylistSchema, type FlowPlaylist } from "./playlist";
+
+export type PlatformStatusMap = Partial<Record<PlatformId, StatusId>>;
+export const PlatformStatusMapSchema: z.ZodType<PlatformStatusMap> = z.partialRecord(
+  PlatformSchema,
+  StatusSchema,
+);
+
+export type PlatformNotesMap = Partial<Record<PlatformId, string>>;
+export const PlatformNotesMapSchema: z.ZodType<PlatformNotesMap> = z.partialRecord(
+  PlatformSchema,
+  z.string(),
+);
+
+/** Per-platform screenshot stored as base64 data URI. */
+export type PlatformScreenshotsMap = Partial<Record<PlatformId, string>>;
+export const PlatformScreenshotsMapSchema: z.ZodType<PlatformScreenshotsMap> = z.partialRecord(
+  PlatformSchema,
+  z.string(),
+);
+
+export interface NodeMetadata extends Record<string, unknown> {
+  stage?: string;
+  playlist?: FlowPlaylist;
+  platformNotes?: PlatformNotesMap;
+  platformStatuses?: PlatformStatusMap;
+  platformScreenshots?: PlatformScreenshotsMap;
+}
+
+export const NodeMetadataSchema: z.ZodType<NodeMetadata> = z
+  .object({
+    stage: z.string().optional(),
+    playlist: FlowPlaylistSchema.optional(),
+    platformNotes: PlatformNotesMapSchema.optional(),
+    platformStatuses: PlatformStatusMapSchema.optional(),
+    platformScreenshots: PlatformScreenshotsMapSchema.optional(),
+  })
+  .catchall(z.unknown());
+
+export interface Node {
+  id: string;
+  project_id: string;
+  species: SpeciesId;
+  title: string;
+  description?: string;
+  status: StatusId;
+  platforms: PlatformId[];
+  metadata?: NodeMetadata;
+}
+
+export const NodeSchema: z.ZodType<Node> = z.object({
+  id: z.string(),
+  project_id: z.string(),
+  species: SpeciesSchema,
+  title: z.string(),
+  description: z.string().optional(),
+  status: StatusSchema,
+  platforms: z.array(PlatformSchema),
+  metadata: NodeMetadataSchema.optional(),
+});
+
+export interface Edge {
+  id: string;
+  project_id: string;
+  source_id: string;
+  target_id: string;
+  edge_type: EdgeTypeId;
+  metadata?: Record<string, unknown>;
+}
+
+export const EdgeSchema: z.ZodType<Edge> = z.object({
+  id: z.string(),
+  project_id: z.string(),
+  source_id: z.string(),
+  target_id: z.string(),
+  edge_type: EdgeTypeSchema,
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+export interface ProjectMetadata extends Record<string, unknown> {
+  view_card_variant?: "compact" | "large";
+}
+
+export const ProjectMetadataSchema: z.ZodType<ProjectMetadata> = z
+  .object({
+    view_card_variant: z.enum(["compact", "large"]).optional(),
+  })
+  .catchall(z.unknown());
+
+export interface Project {
+  id: string;
+  title: string;
+  description?: string;
+  /** Optional node id used as the primary canvas anchor/root. */
+  root_node_id?: string;
+  /** Optional project-level UI settings and preferences. */
+  metadata?: ProjectMetadata;
+  /** ISO 8601 timestamp, e.g. "2024-01-01T00:00:00.000Z" */
+  created_at: string;
+  /** ISO 8601 timestamp, e.g. "2024-01-01T00:00:00.000Z" */
+  updated_at: string;
+  /** ISO 8601 timestamp when archived; null/undefined means active. */
+  archived_at?: string | null;
+}
+
+export const ProjectSchema: z.ZodType<Project> = z.object({
+  id: z.string(),
+  title: z.string(),
+  description: z.string().optional(),
+  root_node_id: z.string().optional(),
+  metadata: ProjectMetadataSchema.optional(),
+  created_at: z.string(),
+  updated_at: z.string(),
+  archived_at: z.string().nullable().optional(),
+});
+
+export interface ProjectBundle {
+  project: Project;
+  nodes: Node[];
+  edges: Edge[];
+}
+
+export const ProjectBundleSchema: z.ZodType<ProjectBundle> = z.object({
+  project: ProjectSchema,
+  nodes: z.array(NodeSchema),
+  edges: z.array(EdgeSchema),
+});

--- a/packages/schema/src/enums.ts
+++ b/packages/schema/src/enums.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+export const SPECIES_IDS = ["flow", "view", "data-model", "api-endpoint"] as const;
+export const SpeciesSchema = z.enum(SPECIES_IDS);
+export type SpeciesId = z.infer<typeof SpeciesSchema>;
+
+export const STATUS_IDS = [
+  "idea",
+  "backlog",
+  "prioritized",
+  "development",
+  "releasing",
+  "live",
+  "archived",
+  "blocked",
+] as const;
+export const StatusSchema = z.enum(STATUS_IDS);
+export type StatusId = z.infer<typeof StatusSchema>;
+
+export const PLATFORM_IDS = ["web", "ios", "android"] as const;
+export const PlatformSchema = z.enum(PLATFORM_IDS);
+export type PlatformId = z.infer<typeof PlatformSchema>;
+
+export const EDGE_TYPE_IDS = ["composes", "calls", "displays", "queries"] as const;
+export const EdgeTypeSchema = z.enum(EDGE_TYPE_IDS);
+export type EdgeTypeId = z.infer<typeof EdgeTypeSchema>;

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./enums";
+export * from "./playlist";
+export * from "./bundle";

--- a/packages/schema/src/playlist.ts
+++ b/packages/schema/src/playlist.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+
+export interface JunctionCase {
+  label: string;
+  entries: PlaylistEntry[];
+}
+
+export type PlaylistEntry =
+  | { type: "view"; view_id: string }
+  | { type: "flow"; flow_id: string }
+  | { type: "condition"; label: string; if_true: PlaylistEntry[]; if_false: PlaylistEntry[] }
+  | { type: "junction"; label: string; cases: JunctionCase[] };
+
+export const JunctionCaseSchema: z.ZodType<JunctionCase> = z.lazy(() =>
+  z.object({
+    label: z.string(),
+    entries: z.array(PlaylistEntrySchema),
+  }),
+);
+
+export const PlaylistEntrySchema: z.ZodType<PlaylistEntry> = z.lazy(() =>
+  z.discriminatedUnion("type", [
+    z.object({ type: z.literal("view"), view_id: z.string() }),
+    z.object({ type: z.literal("flow"), flow_id: z.string() }),
+    z.object({
+      type: z.literal("condition"),
+      label: z.string(),
+      if_true: z.array(PlaylistEntrySchema),
+      if_false: z.array(PlaylistEntrySchema),
+    }),
+    z.object({
+      type: z.literal("junction"),
+      label: z.string(),
+      cases: z.array(JunctionCaseSchema),
+    }),
+  ]),
+);
+
+export interface FlowPlaylist {
+  entries: PlaylistEntry[];
+}
+
+export const FlowPlaylistSchema: z.ZodType<FlowPlaylist> = z.object({
+  entries: z.array(PlaylistEntrySchema),
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["./*"],
+      "@arkaik/schema": ["./packages/schema/src/index.ts"]
     }
   },
   "include": [


### PR DESCRIPTION
## Summary
This PR extracts core schema definitions and type definitions into a new `@arkaik/schema` package, making them reusable across the monorepo. The existing type definitions in `lib/config/` are refactored to import from the centralized schema package instead of defining their own types.

## Key Changes
- **New `@arkaik/schema` package** with Zod-based schema definitions:
  - `enums.ts`: Enum definitions for Species, Status, Platform, and EdgeType with corresponding Zod schemas
  - `playlist.ts`: FlowPlaylist and PlaylistEntry types with recursive Zod schemas for complex nested structures
  - `bundle.ts`: Core domain models (Node, Edge, Project) and ProjectBundle with comprehensive metadata support
  
- **Refactored config files** to import types from `@arkaik/schema`:
  - `lib/config/species.ts`, `platforms.ts`, `statuses.ts`, `edge-types.ts` now import `SpeciesId`, `PlatformId`, `StatusId`, and `EdgeTypeId` from the schema package
  - Config arrays now use `satisfies` constraints to ensure type safety
  - Removed duplicate type definitions in favor of re-exports from schema package

- **Monorepo setup**:
  - Added `workspaces` configuration to root `package.json`
  - Updated `tsconfig.json` with path alias for `@arkaik/schema`
  - Configured Next.js to transpile the schema package

## Notable Implementation Details
- Zod schemas use `z.lazy()` for recursive types (PlaylistEntry, JunctionCase) to handle circular references
- Platform/Status/Notes maps use `z.partialRecord()` for flexible key-value structures
- NodeMetadata and ProjectMetadata use `.catchall(z.unknown())` to allow extensibility while maintaining type safety
- All enum types are derived from Zod schemas using `z.infer<typeof Schema>` pattern

https://claude.ai/code/session_01KYxonJCaio1EGe1R4Ggxcc