### PR TITLE
Consolidate domain types from @arkaik/schema package

### DIFF
--- a/app/project/[id]/canvas/page.tsx
+++ b/app/project/[id]/canvas/page.tsx
@@ -21,7 +21,7 @@ import { useNodes } from "@/lib/hooks/useNodes";
 import { useEdges } from "@/lib/hooks/useEdges";
 import { useProject } from "@/lib/hooks/useProject";
 import { useKeyboardShortcuts } from "@/lib/hooks/useKeyboardShortcuts";
-import { assertProjectBundleShape, downloadJson, exportProject, importProject, normalizeProjectTimestamps } from "@/lib/utils/export";
+import { parseAndValidateBundle, downloadJson, exportProject, importProject, normalizeProjectTimestamps } from "@/lib/utils/export";
 import { generateNodeId } from "@/lib/utils/id";
 import { wouldCreateCycle } from "@/lib/utils/cycle";
 import type { SpeciesId } from "@/lib/config/species";
@@ -742,11 +742,11 @@ export default function ProjectCanvasPage() {
       throw new Error(format === "json" ? "Invalid JSON syntax." : "Invalid YAML syntax.");
     }
 
-    assertProjectBundleShape(parsed);
+    const bundle = parseAndValidateBundle(parsed);
 
     return {
-      ...parsed,
-      project: normalizeProjectTimestamps(parsed.project),
+      ...bundle,
+      project: normalizeProjectTimestamps(bundle.project),
     };
   }, []);
 

--- a/lib/data/types.ts
+++ b/lib/data/types.ts
@@ -1,88 +1,36 @@
-import type { SpeciesId } from "@/lib/config/species";
-import type { StatusId } from "@/lib/config/statuses";
-import type { EdgeTypeId } from "@/lib/config/edge-types";
-import type { PlatformId } from "@/lib/config/platforms";
+/**
+ * Domain types for the app.
+ *
+ * These are re-exported from `@arkaik/schema` — the single source of truth for
+ * the ProjectBundle shape (zod schemas + inferred types). Re-exporting here,
+ * rather than declaring the shapes a second time, means the app and the schema
+ * package can never drift. See `docs/spec/toolchain.md` § @arkaik/schema.
+ *
+ * The `~23` existing importers of `@/lib/data/types` are unaffected: every name
+ * they consumed is still exported from this module.
+ */
+import type { SpeciesId, StatusId, PlatformId, EdgeTypeId } from "@arkaik/schema";
 
-/** Species of a node, derived from the SPECIES config. */
+export type {
+  PlatformStatusMap,
+  PlatformNotesMap,
+  PlatformScreenshotsMap,
+  PlaylistEntry,
+  JunctionCase,
+  FlowPlaylist,
+  NodeMetadata,
+  Node,
+  Edge,
+  Project,
+  ProjectMetadata,
+  ProjectBundle,
+} from "@arkaik/schema";
+
+/** Species of a node — the SPECIES config id union. */
 export type Species = SpeciesId;
-/** Lifecycle status of a node, derived from the STATUSES config. */
+/** Lifecycle status of a node — the STATUSES config id union. */
 export type Status = StatusId;
-/** Platform the node is available on, derived from the PLATFORMS config. */
+/** Platform the node is available on — the PLATFORMS config id union. */
 export type Platform = PlatformId;
-/** Relationship type between two nodes, derived from the EDGE_TYPES config. */
+/** Relationship type between two nodes — the EDGE_TYPES config id union. */
 export type EdgeType = EdgeTypeId;
-/** Per-platform status source of truth for step-like species. */
-export type PlatformStatusMap = Partial<Record<PlatformId, StatusId>>;
-/** Freeform per-platform notes used by the detail panel. */
-export type PlatformNotesMap = Partial<Record<PlatformId, string>>;
-/** Per-platform screenshot stored as base64 data URI. */
-export type PlatformScreenshotsMap = Partial<Record<PlatformId, string>>;
-
-export type PlaylistEntry =
-  | { type: "view"; view_id: string }
-  | { type: "flow"; flow_id: string }
-  | { type: "condition"; label: string; if_true: PlaylistEntry[]; if_false: PlaylistEntry[] }
-  | { type: "junction"; label: string; cases: JunctionCase[] };
-
-export interface JunctionCase {
-  label: string;
-  entries: PlaylistEntry[];
-}
-
-export interface FlowPlaylist {
-  entries: PlaylistEntry[];
-}
-
-export interface NodeMetadata extends Record<string, unknown> {
-  stage?: string;
-  playlist?: FlowPlaylist;
-  platformNotes?: PlatformNotesMap;
-  platformStatuses?: PlatformStatusMap;
-  platformScreenshots?: PlatformScreenshotsMap;
-}
-
-export interface Node {
-  id: string;
-  project_id: string;
-  species: Species;
-  title: string;
-  description?: string;
-  status: Status;
-  platforms: Platform[];
-  metadata?: NodeMetadata;
-}
-
-export interface Edge {
-  id: string;
-  project_id: string;
-  source_id: string;
-  target_id: string;
-  edge_type: EdgeType;
-  metadata?: Record<string, unknown>;
-}
-
-export interface Project {
-  id: string;
-  title: string;
-  description?: string;
-  /** Optional node id used as the primary canvas anchor/root. */
-  root_node_id?: string;
-  /** Optional project-level UI settings and preferences. */
-  metadata?: ProjectMetadata;
-  /** ISO 8601 timestamp, e.g. "2024-01-01T00:00:00.000Z" */
-  created_at: string;
-  /** ISO 8601 timestamp, e.g. "2024-01-01T00:00:00.000Z" */
-  updated_at: string;
-  /** ISO 8601 timestamp when archived; null/undefined means active. */
-  archived_at?: string | null;
-}
-
-export interface ProjectMetadata extends Record<string, unknown> {
-  view_card_variant?: "compact" | "large";
-}
-
-export interface ProjectBundle {
-  project: Project;
-  nodes: Node[];
-  edges: Edge[];
-}

--- a/lib/utils/export.ts
+++ b/lib/utils/export.ts
@@ -1,16 +1,16 @@
 import type { Project, ProjectBundle } from "@/lib/data/types";
+import { parseBundle, validateBundle, type ValidationFinding } from "@arkaik/schema";
 import { localProvider } from "@/lib/data/local-provider";
 
 const MAX_RECOMMENDED_EXPORT_BYTES = 4 * 1024 * 1024;
+
+/** Cap on findings named in a thrown message so a broken bundle stays readable. */
+const MAX_REPORTED_FINDINGS = 5;
 
 export interface ExportDownloadResult {
   filename: string;
   bytes: number;
   warning: string | null;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
 }
 
 function isValidIsoString(value: unknown): value is string {
@@ -27,52 +27,50 @@ export function normalizeProjectTimestamps(project: Project): Project {
   };
 }
 
-export function assertProjectBundleShape(value: unknown): asserts value is ProjectBundle {
-  if (!isRecord(value)) throw new Error("Invalid JSON: expected object root");
+/** Render a zod issue path (`["nodes", 3, "id"]`) as `nodes[3].id`. */
+function formatIssuePath(path: ReadonlyArray<PropertyKey>): string {
+  let out = "";
+  for (const key of path) {
+    if (typeof key === "number") out += `[${key}]`;
+    else out += out ? `.${String(key)}` : String(key);
+  }
+  return out || "(root)";
+}
 
-  const project = value.project;
-  if (!isRecord(project)) throw new Error("Invalid JSON: missing project object");
-  if (typeof project.id !== "string" || !project.id.trim()) {
-    throw new Error("Invalid JSON: project.id must be a non-empty string");
-  }
-  if (typeof project.title !== "string" || !project.title.trim()) {
-    throw new Error("Invalid JSON: project.title must be a non-empty string");
-  }
-  if (project.root_node_id !== undefined && typeof project.root_node_id !== "string") {
-    throw new Error("Invalid JSON: project.root_node_id must be a string when provided");
-  }
-  if (project.metadata !== undefined) {
-    if (!isRecord(project.metadata)) {
-      throw new Error("Invalid JSON: project.metadata must be an object when provided");
-    }
-    const viewCardVariant = project.metadata.view_card_variant;
-    if (
-      viewCardVariant !== undefined
-      && viewCardVariant !== "compact"
-      && viewCardVariant !== "large"
-    ) {
-      throw new Error("Invalid JSON: project.metadata.view_card_variant must be compact or large");
-    }
-  }
+/** Join a capped list of `path: message` parts, noting how many were elided. */
+function joinReported(parts: string[]): string {
+  const shown = parts.slice(0, MAX_REPORTED_FINDINGS);
+  const extra = parts.length - shown.length;
+  return shown.join("; ") + (extra > 0 ? ` (and ${extra} more)` : "");
+}
 
-  if (!Array.isArray(value.nodes)) {
-    throw new Error("Invalid JSON: nodes must be an array");
-  }
-  if (!Array.isArray(value.edges)) {
-    throw new Error("Invalid JSON: edges must be an array");
-  }
-
-  if (typeof project.root_node_id === "string") {
-    const nodeIds = new Set(
-      value.nodes
-        .filter(isRecord)
-        .map((node) => node.id)
-        .filter((id): id is string => typeof id === "string"),
+/**
+ * Parse and semantically validate an untrusted bundle against the canonical
+ * `@arkaik/schema` rules (`parseBundle` for shape, `validateBundle` for the
+ * graph rules JSON Schema cannot express — duplicate IDs, dangling edge refs,
+ * etc.). Returns the typed {@link ProjectBundle} on success; throws an Error
+ * with a readable, path-specific message on the first batch of failures.
+ * Warnings (e.g. the stale edge-ID convention) never block.
+ */
+export function parseAndValidateBundle(value: unknown): ProjectBundle {
+  const parsed = parseBundle(value);
+  if (!parsed.success) {
+    const parts = parsed.error.issues.map(
+      (issue) => `${formatIssuePath(issue.path)}: ${issue.message}`,
     );
-    if (!nodeIds.has(project.root_node_id)) {
-      throw new Error("Invalid JSON: project.root_node_id must reference an existing node id");
-    }
+    throw new Error(`Invalid bundle: ${joinReported(parts)}`);
   }
+
+  const { valid, errors } = validateBundle(value);
+  if (!valid) {
+    const parts = errors.map(
+      (finding: ValidationFinding) =>
+        finding.path ? `${finding.path}: ${finding.message}` : finding.message,
+    );
+    throw new Error(`Invalid bundle: ${joinReported(parts)}`);
+  }
+
+  return parsed.data;
 }
 
 async function ensureUniqueProjectId(initialId: string): Promise<string> {
@@ -166,11 +164,11 @@ export async function importProjectFromFile(file: File): Promise<Project> {
     throw new Error("Invalid JSON file");
   }
 
-  assertProjectBundleShape(parsed);
+  const bundle = parseAndValidateBundle(parsed);
 
   const normalizedBundle: ProjectBundle = {
-    ...parsed,
-    project: normalizeProjectTimestamps(parsed.project),
+    ...bundle,
+    project: normalizeProjectTimestamps(bundle.project),
   };
 
   const resolvedProjectId = await ensureUniqueProjectId(normalizedBundle.project.id);


### PR DESCRIPTION
## Summary
Refactor the app's domain type definitions to re-export from the canonical `@arkaik/schema` package instead of duplicating type declarations. This ensures the app and schema package cannot drift and eliminates maintenance burden of keeping two copies of the same types in sync.

## Key Changes
- **lib/data/types.ts**: Replaced 88 lines of local type declarations with re-exports from `@arkaik/schema`, including `ProjectBundle`, `Node`, `Edge`, `Project`, `NodeMetadata`, `FlowPlaylist`, and related types. Kept local type aliases (`Species`, `Status`, `Platform`, `EdgeType`) as thin wrappers around the imported ID unions for backward compatibility with ~23 existing importers.

- **lib/utils/export.ts**: Replaced manual `assertProjectBundleShape()` validation with `parseBundle()` and `validateBundle()` from `@arkaik/schema`. The new approach:
  - Uses zod schema validation for structural correctness
  - Applies semantic validation rules (duplicate IDs, dangling edge references, etc.) that JSON Schema cannot express
  - Provides better error messages with path-specific feedback (e.g., `nodes[3].id: must be a string`)
  - Caps reported findings at 5 to keep error messages readable

- **app/project/[id]/canvas/page.tsx**: Updated import and call sites to use `parseAndValidateBundle()` instead of `assertProjectBundleShape()`.

## Implementation Details
- The new `parseAndValidateBundle()` function combines shape validation and semantic validation, throwing a single descriptive error on the first batch of failures
- Error messages use `formatIssuePath()` to render zod issue paths in dot-notation (e.g., `nodes[3].id`)
- `joinReported()` caps the number of reported findings and notes how many were elided for readability
- All existing type consumers remain unaffected; the module's public API is unchanged

https://claude.ai/code/session_01154ZJHT2WRwu7pHLEE4hJk