### PR TITLE
Implement explicit Bundle Format migration chain for schema versioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,6 @@ jobs:
 
       - name: Screenshot data-URI size warning tests
         run: npm run test:screenshot-size
+
+      - name: Bundle migration chain tests
+        run: npm run test:migrate

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@
 # transient CJS build emitted by the schema parity test / contract generators
 /packages/schema/.test-build/
 /packages/schema/.generate-build/
+/tests/data/.test-build/
+/tests/data/.test-build-export/
 
 # next.js
 /.next/

--- a/docs/arkaik-skill/references/schema.md
+++ b/docs/arkaik-skill/references/schema.md
@@ -91,6 +91,8 @@ interface Project {
 }
 
 interface ProjectBundle {
+  /** Bundle Format contract version (docs/spec/bundle-format.md § Schema Versioning). Absent MUST be treated as 1. */
+  schema_version?: number;
   project: Project;
   nodes: Node[];
   edges: Edge[];

--- a/lib/data/local-provider.ts
+++ b/lib/data/local-provider.ts
@@ -1,5 +1,6 @@
 import type { DataProvider } from "./data-provider";
 import type { Node, Edge, ProjectBundle, PlaylistEntry } from "./types";
+import { migrateBundle } from "./migrate";
 import { wouldCreateCycle } from "@/lib/utils/cycle";
 
 function collectReferencedFlowIds(entries: PlaylistEntry[]): string[] {
@@ -29,88 +30,6 @@ function collectReferencedFlowIds(entries: PlaylistEntry[]): string[] {
 
 const STORAGE_KEY = "arkaik:store";
 
-type LegacyNode = Node & {
-  parent_id?: string | null;
-  sort_order?: number;
-  position_x?: number;
-  position_y?: number;
-};
-
-function normalizeBundle(bundle: ProjectBundle): ProjectBundle {
-  const nodes = bundle.nodes as LegacyNode[];
-  const childrenByParent = new Map<string, Array<{ id: string; sort: number; index: number }>>();
-
-  nodes.forEach((node, index) => {
-    const parentId = typeof node.parent_id === "string" ? node.parent_id : null;
-    if (!parentId) return;
-    const children = childrenByParent.get(parentId) ?? [];
-    children.push({ id: node.id, sort: node.sort_order ?? Number.MAX_SAFE_INTEGER, index });
-    childrenByParent.set(parentId, children);
-  });
-
-  const normalizedNodes: Node[] = nodes.map((node) => {
-    const rest: LegacyNode = { ...node };
-    delete rest.parent_id;
-    delete rest.sort_order;
-    delete rest.position_x;
-    delete rest.position_y;
-    return rest;
-  });
-
-  const nodeMap = new Map(normalizedNodes.map((node) => [node.id, node]));
-  for (const [parentId, children] of childrenByParent) {
-    const parent = nodeMap.get(parentId);
-    if (!parent) continue;
-    const entries = children
-      .sort((a, b) => (a.sort - b.sort) || (a.index - b.index))
-      .map((child) => {
-        const childNode = nodeMap.get(child.id);
-        if (!childNode) return null;
-        if (childNode.species === "flow") return { type: "flow", flow_id: child.id } as const;
-        if (childNode.species === "view") return { type: "view", view_id: child.id } as const;
-        return null;
-      })
-      .filter((entry): entry is { type: "flow"; flow_id: string } | { type: "view"; view_id: string } => Boolean(entry));
-    parent.metadata = {
-      ...parent.metadata,
-      playlist: {
-        entries,
-      },
-    };
-  }
-
-  const composePairs = new Set(
-    bundle.edges
-      .filter((edge) => edge.edge_type === "composes")
-      .map((edge) => `${edge.source_id}:${edge.target_id}`),
-  );
-  const extraComposeEdges: Edge[] = [];
-
-  for (const legacyNode of nodes) {
-    const parentId = typeof legacyNode.parent_id === "string" ? legacyNode.parent_id : null;
-    if (!parentId) continue;
-    if (!nodeMap.has(parentId)) continue;
-
-    const pair = `${parentId}:${legacyNode.id}`;
-    if (composePairs.has(pair)) continue;
-    composePairs.add(pair);
-
-    extraComposeEdges.push({
-      id: `legacy-compose-${parentId}-${legacyNode.id}`,
-      project_id: bundle.project.id,
-      source_id: parentId,
-      target_id: legacyNode.id,
-      edge_type: "composes",
-    });
-  }
-
-  return {
-    ...bundle,
-    nodes: normalizedNodes,
-    edges: [...bundle.edges, ...extraComposeEdges],
-  };
-}
-
 function loadStore(): Map<string, ProjectBundle> {
   if (typeof window === "undefined") return new Map();
   try {
@@ -118,7 +37,7 @@ function loadStore(): Map<string, ProjectBundle> {
     if (!raw) return new Map();
     const obj = JSON.parse(raw) as Record<string, ProjectBundle>;
     return new Map(
-      Object.entries(obj).map(([projectId, bundle]) => [projectId, normalizeBundle(bundle)]),
+      Object.entries(obj).map(([projectId, bundle]) => [projectId, migrateBundle(bundle)]),
     );
   } catch (err) {
     console.error("[LocalProvider] Failed to load store from localStorage:", err);
@@ -162,7 +81,7 @@ export const localProvider: DataProvider = {
     return Array.from(store.values()).filter((bundle) => !isArchived(bundle));
   },
   async saveProject(bundle: ProjectBundle) {
-    const normalized = normalizeBundle(bundle);
+    const normalized = migrateBundle(bundle);
     store.set(normalized.project.id, normalized);
     normalized.nodes.forEach((n) => nodeIndex.set(n.id, normalized.project.id));
     normalized.edges.forEach((e) => edgeIndex.set(e.id, normalized.project.id));
@@ -286,7 +205,7 @@ export const localProvider: DataProvider = {
     return bundle;
   },
   async importProject(bundle: ProjectBundle) {
-    const normalized = normalizeBundle(bundle);
+    const normalized = migrateBundle(bundle);
     store.set(normalized.project.id, normalized);
     normalized.nodes.forEach((n) => nodeIndex.set(n.id, normalized.project.id));
     normalized.edges.forEach((e) => edgeIndex.set(e.id, normalized.project.id));

--- a/lib/data/migrate.ts
+++ b/lib/data/migrate.ts
@@ -1,0 +1,165 @@
+import type { Node, Edge, ProjectBundle } from "./types";
+
+/**
+ * Explicit, ordered Bundle Format migration chain (docs/spec/bundle-format.md
+ * § Schema Versioning). Every persisted or imported bundle is run through
+ * {@link migrateBundle}, which upgrades it from whatever `schema_version` it
+ * declares to {@link CURRENT_SCHEMA_VERSION} by applying each ordered step.
+ *
+ * Design rules, straight from the spec:
+ * - A bundle with no `schema_version` predates versioning ("v0" from the
+ *   migration's point of view): it may still carry the legacy
+ *   `parent_id`/`sort_order`/`position_*` node fields, so it must pass through
+ *   the v0→1 step below. The *format* treats an absent `schema_version` as `1`
+ *   (bundle-format.md:33) — which is exactly the state that step produces.
+ * - Reading a version newer than we support: import what we understand and
+ *   preserve unknown fields on re-export, never strip (bundle-format.md:34).
+ *   A version at or above {@link CURRENT_SCHEMA_VERSION} matches no step and is
+ *   returned untouched, unknown top-level keys intact.
+ * - Each step is a pure data-in / data-out function, independently unit-testable
+ *   (tests/data/migrate.test.js).
+ */
+
+/** Highest `schema_version` this build knows how to read natively. */
+export const CURRENT_SCHEMA_VERSION = 1;
+
+/** A node as it appeared before playlists — the pre-v1 legacy shape. */
+type LegacyNode = Node & {
+  parent_id?: string | null;
+  sort_order?: number;
+  position_x?: number;
+  position_y?: number;
+};
+
+interface Migration {
+  /** The `schema_version` this step upgrades from. */
+  from: number;
+  /** The `schema_version` this step produces. */
+  to: number;
+  migrate: (bundle: ProjectBundle) => ProjectBundle;
+}
+
+/**
+ * The migration source version of a bundle: its declared `schema_version`, or
+ * `0` when absent (pre-versioning). This is deliberately *not* the format-level
+ * interpretation ("absent means 1") — it is the point where the chain starts so
+ * that legacy bundles still pass through the v0→1 step.
+ */
+function migrationSourceVersion(bundle: ProjectBundle): number {
+  const declared = (bundle as { schema_version?: unknown }).schema_version;
+  return typeof declared === "number" && Number.isFinite(declared) ? declared : 0;
+}
+
+/**
+ * Step one of the chain (implicit/v0 → 1): the former implicit `normalizeBundle`
+ * transform. Legacy bundles encoded flow/view composition with `parent_id` +
+ * `sort_order` on the child nodes; v1 encodes it as `metadata.playlist` on the
+ * parent flow plus `composes` edges. This strips the legacy node fields, builds
+ * the parent playlists in `(sort_order, original index)` order, and backfills
+ * any missing `composes` edges. Pure and idempotent: a bundle with no
+ * `parent_id` fields passes through structurally unchanged.
+ *
+ * Unknown top-level keys (and `schema_version` itself) survive via the spread.
+ */
+function migrateLegacyToV1(bundle: ProjectBundle): ProjectBundle {
+  const nodes = bundle.nodes as LegacyNode[];
+  const childrenByParent = new Map<string, Array<{ id: string; sort: number; index: number }>>();
+
+  nodes.forEach((node, index) => {
+    const parentId = typeof node.parent_id === "string" ? node.parent_id : null;
+    if (!parentId) return;
+    const children = childrenByParent.get(parentId) ?? [];
+    children.push({ id: node.id, sort: node.sort_order ?? Number.MAX_SAFE_INTEGER, index });
+    childrenByParent.set(parentId, children);
+  });
+
+  const normalizedNodes: Node[] = nodes.map((node) => {
+    const rest: LegacyNode = { ...node };
+    delete rest.parent_id;
+    delete rest.sort_order;
+    delete rest.position_x;
+    delete rest.position_y;
+    return rest;
+  });
+
+  const nodeMap = new Map(normalizedNodes.map((node) => [node.id, node]));
+  for (const [parentId, children] of childrenByParent) {
+    const parent = nodeMap.get(parentId);
+    if (!parent) continue;
+    const entries = children
+      .sort((a, b) => (a.sort - b.sort) || (a.index - b.index))
+      .map((child) => {
+        const childNode = nodeMap.get(child.id);
+        if (!childNode) return null;
+        if (childNode.species === "flow") return { type: "flow", flow_id: child.id } as const;
+        if (childNode.species === "view") return { type: "view", view_id: child.id } as const;
+        return null;
+      })
+      .filter((entry): entry is { type: "flow"; flow_id: string } | { type: "view"; view_id: string } => Boolean(entry));
+    parent.metadata = {
+      ...parent.metadata,
+      playlist: {
+        entries,
+      },
+    };
+  }
+
+  const composePairs = new Set(
+    bundle.edges
+      .filter((edge) => edge.edge_type === "composes")
+      .map((edge) => `${edge.source_id}:${edge.target_id}`),
+  );
+  const extraComposeEdges: Edge[] = [];
+
+  for (const legacyNode of nodes) {
+    const parentId = typeof legacyNode.parent_id === "string" ? legacyNode.parent_id : null;
+    if (!parentId) continue;
+    if (!nodeMap.has(parentId)) continue;
+
+    const pair = `${parentId}:${legacyNode.id}`;
+    if (composePairs.has(pair)) continue;
+    composePairs.add(pair);
+
+    extraComposeEdges.push({
+      id: `legacy-compose-${parentId}-${legacyNode.id}`,
+      project_id: bundle.project.id,
+      source_id: parentId,
+      target_id: legacyNode.id,
+      edge_type: "composes",
+    });
+  }
+
+  return {
+    ...bundle,
+    nodes: normalizedNodes,
+    edges: [...bundle.edges, ...extraComposeEdges],
+  };
+}
+
+/**
+ * The ordered chain. Steps are contiguous (each `to` is the next step's `from`)
+ * and applied in order from the bundle's source version up to
+ * {@link CURRENT_SCHEMA_VERSION}. Append future steps ({ from: 1, to: 2, ... })
+ * here — the dispatcher picks up the rest automatically.
+ */
+const MIGRATIONS: readonly Migration[] = [{ from: 0, to: 1, migrate: migrateLegacyToV1 }];
+
+/**
+ * Upgrade a bundle to the current schema version by running each applicable
+ * migration step in order. A bundle already at or above the current version is
+ * returned untouched (with all unknown fields preserved). Runs on every load,
+ * save, and import (`lib/data/local-provider.ts`).
+ */
+export function migrateBundle(bundle: ProjectBundle): ProjectBundle {
+  let current = bundle;
+  let version = migrationSourceVersion(bundle);
+
+  for (const step of MIGRATIONS) {
+    if (version === step.from) {
+      current = step.migrate(current);
+      version = step.to;
+    }
+  }
+
+  return current;
+}

--- a/lib/prompts/generated/schema.ts
+++ b/lib/prompts/generated/schema.ts
@@ -90,6 +90,8 @@ interface Project {
 }
 
 interface ProjectBundle {
+  /** Bundle Format contract version (docs/spec/bundle-format.md § Schema Versioning). Absent MUST be treated as 1. */
+  schema_version?: number;
   project: Project;
   nodes: Node[];
   edges: Edge[];

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "validate:seeds": "node docs/arkaik-skill/scripts/validate-bundle.js seed/pebbles.json && node docs/arkaik-skill/scripts/validate-bundle.js seed/arkaik-self-map.json && node docs/arkaik-skill/scripts/validate-bundle.js public/schema/example-bundle.json",
     "test:fixtures": "node tests/fixtures/run-fixture-tests.js",
     "test:schema": "node tests/schema/parity.test.js",
-    "test:screenshot-size": "node tests/schema/screenshot-size.test.js"
+    "test:screenshot-size": "node tests/schema/screenshot-size.test.js",
+    "test:migrate": "node tests/data/migrate.test.js && node tests/data/import-roundtrip.test.js && node tests/data/seed-import.test.js"
   },
   "dependencies": {
     "@radix-ui/react-collapsible": "^1.1.12",

--- a/packages/schema/src/bundle.ts
+++ b/packages/schema/src/bundle.ts
@@ -138,19 +138,25 @@ export const ProjectSchema: z.ZodType<Project> = z.object({
   archived_at: z.string().nullable().optional().meta({
     description: "ISO 8601 archive timestamp, or null if active.",
   }),
-}).meta({ id: "Project" });
+}).catchall(z.unknown()).meta({ id: "Project" });
 
 export interface ProjectBundle {
+  /** Bundle Format contract version (docs/spec/bundle-format.md § Schema Versioning). Absent MUST be treated as 1. */
+  schema_version?: number;
   project: Project;
   nodes: Node[];
   edges: Edge[];
 }
 
 export const ProjectBundleSchema: z.ZodType<ProjectBundle> = z.object({
+  schema_version: z.number().int().optional().meta({
+    description:
+      "Bundle Format contract version. Absent means 1 (docs/spec/bundle-format.md § Schema Versioning). Older versions migrate through an explicit chain; unknown fields from newer versions are preserved on re-export.",
+  }),
   project: ProjectSchema,
   nodes: z.array(NodeSchema).meta({ description: "All nodes in the project graph." }),
   edges: z.array(EdgeSchema).meta({ description: "All edges (relationships) between nodes." }),
-}).meta({
+}).catchall(z.unknown()).meta({
   id: "ProjectBundle",
   title: "Arkaik ProjectBundle",
   description:

--- a/public/schema/project-bundle.json
+++ b/public/schema/project-bundle.json
@@ -12,6 +12,12 @@
   ],
   "additionalProperties": true,
   "properties": {
+    "schema_version": {
+      "description": "Bundle Format contract version. Absent means 1 (docs/spec/bundle-format.md § Schema Versioning). Older versions migrate through an explicit chain; unknown fields from newer versions are preserved on re-export.",
+      "type": "integer",
+      "minimum": -9007199254740991,
+      "maximum": 9007199254740991
+    },
     "project": {
       "$ref": "#/$defs/Project"
     },

--- a/scripts/generate/generate-json-schema.js
+++ b/scripts/generate/generate-json-schema.js
@@ -51,11 +51,14 @@ function generate() {
   schema.$id = SCHEMA_ID;
   schema.version = SCHEMA_VERSION;
 
-  if (schema.additionalProperties === false) {
-    schema.additionalProperties = true;
-  }
+  // The bundle root and Project tolerate and preserve unknown fields
+  // (schema_version, journal, project.version, forward-compat keys). The
+  // canonical zod schemas use `.catchall(z.unknown())`, which z.toJSONSchema
+  // renders as `additionalProperties: {}`; normalize both to an explicit `true`
+  // so the published contract reads unambiguously as "extra fields allowed".
+  schema.additionalProperties = true;
   const projectDef = schema.$defs && schema.$defs.Project;
-  if (projectDef && projectDef.additionalProperties === false) {
+  if (projectDef) {
     projectDef.additionalProperties = true;
   }
 

--- a/tests/data/import-roundtrip.test.js
+++ b/tests/data/import-roundtrip.test.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+
+/**
+ * Regression test for the `rewriteBundleProjectId` unknown-key landmine
+ * (lib/utils/export.ts, docs/spec/bundle-format.md:40 / issue #201 AC 4).
+ *
+ * When an imported project's id collides with an existing one, the importer
+ * rewrites the id via `rewriteBundleProjectId`. That function historically
+ * risked reconstructing the bundle as `{ project, nodes, edges }` and dropping
+ * every other top-level key. This test drives the *full* ID-collision import
+ * path — parse (must preserve unknown keys) → rewrite (must preserve unknown
+ * keys) → import — and asserts an unknown top-level key, `schema_version`, and
+ * `project.version` all survive to the stored bundle, with ids rewritten.
+ *
+ * export.ts is loaded by transpiling it and intercepting its two runtime
+ * imports: the real `@arkaik/schema` (so parse/validate behave exactly as in
+ * the app) and a stub `localProvider` that forces one id collision and captures
+ * what gets imported.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const ts = require("typescript");
+const Module = require("module");
+
+const { loadSchema, BUILD_DIR: SCHEMA_BUILD_DIR } = require("../schema/load-schema");
+
+const ROOT = path.join(__dirname, "..", "..");
+const BUILD_DIR = path.join(__dirname, ".test-build-export");
+
+let failures = 0;
+function assert(cond, message) {
+  if (cond) console.log(`PASS: ${message}`);
+  else {
+    failures++;
+    console.log(`FAIL: ${message}`);
+  }
+}
+
+const COLLIDING_ID = "existing-project";
+let captured = null;
+
+const stubProvider = {
+  localProvider: {
+    getProject: async (id) => (id === COLLIDING_ID ? { project: { id } } : undefined),
+    importProject: async (bundle) => {
+      captured = bundle;
+      return bundle.project;
+    },
+  },
+};
+
+function loadExportModule() {
+  const schemaExports = loadSchema();
+
+  fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+  fs.mkdirSync(BUILD_DIR, { recursive: true });
+  fs.writeFileSync(path.join(BUILD_DIR, "package.json"), JSON.stringify({ type: "commonjs" }));
+
+  const source = fs.readFileSync(path.join(ROOT, "lib", "utils", "export.ts"), "utf8");
+  const { outputText } = ts.transpileModule(source, {
+    fileName: "export.ts",
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+      esModuleInterop: true,
+    },
+  });
+  const outFile = path.join(BUILD_DIR, "export.js");
+  fs.writeFileSync(outFile, outputText);
+
+  // Intercept the two bare/aliased imports the transpiled module require()s.
+  const originalLoad = Module._load;
+  Module._load = function (request, parent, isMain) {
+    if (request === "@arkaik/schema") return schemaExports;
+    if (request.includes("local-provider")) return stubProvider;
+    return originalLoad.call(this, request, parent, isMain);
+  };
+  try {
+    delete require.cache[outFile];
+    return require(outFile);
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+async function main() {
+  const exportModule = loadExportModule();
+
+  const bundle = {
+    schema_version: 1,
+    project: {
+      id: COLLIDING_ID,
+      title: "Colliding Project",
+      version: "2.1.0",
+      created_at: "2026-01-01T00:00:00.000Z",
+      updated_at: "2026-01-01T00:00:00.000Z",
+    },
+    nodes: [
+      { id: "V-home", project_id: COLLIDING_ID, species: "view", title: "Home", status: "idea", platforms: ["web"] },
+    ],
+    edges: [],
+    journal: [{ id: "01J9ZK4E4NVQ9K4YB2Q6WPXC1T", type: "release.tagged" }],
+  };
+
+  // Duck-typed File: importProjectFromFile only calls file.text().
+  const file = { text: async () => JSON.stringify(bundle) };
+  const createdProject = await exportModule.importProjectFromFile(file);
+
+  assert(captured !== null, "import path reached localProvider.importProject");
+  assert(
+    captured.project.id !== COLLIDING_ID && createdProject.id === captured.project.id,
+    "id-collision: project id was rewritten to a fresh id",
+  );
+  assert(
+    captured.nodes[0].project_id === captured.project.id,
+    "id-collision: node.project_id was repointed to the new id",
+  );
+  assert(
+    JSON.stringify(captured.journal) === JSON.stringify(bundle.journal),
+    "id-collision: unknown top-level `journal` key survived the rewrite (no silent stripping)",
+  );
+  assert(captured.schema_version === 1, "id-collision: schema_version survived the rewrite");
+  assert(captured.project.version === "2.1.0", "id-collision: project.version survived the rewrite");
+
+  fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+  fs.rmSync(SCHEMA_BUILD_DIR, { recursive: true, force: true });
+
+  if (failures > 0) {
+    console.log(`\n${failures} import round-trip test(s) failed.`);
+    process.exit(1);
+  }
+  console.log("\nAll import round-trip tests passed.");
+}
+
+main();

--- a/tests/data/load-migrate.js
+++ b/tests/data/load-migrate.js
@@ -1,0 +1,38 @@
+/**
+ * Loads lib/data/migrate.ts into a running Node process without a bundler, the
+ * same transpile-on-the-fly approach tests/schema/load-schema.js uses for the
+ * @arkaik/schema package. migrate.ts imports only *types* from ./types, so the
+ * transpiled CommonJS output has no runtime `require`s to resolve — a single
+ * file is enough.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const ts = require("typescript");
+
+const ROOT = path.join(__dirname, "..", "..");
+const SRC_FILE = path.join(ROOT, "lib", "data", "migrate.ts");
+const BUILD_DIR = path.join(__dirname, ".test-build");
+
+function loadMigrate() {
+  fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+  fs.mkdirSync(BUILD_DIR, { recursive: true });
+  fs.writeFileSync(path.join(BUILD_DIR, "package.json"), JSON.stringify({ type: "commonjs" }));
+
+  const source = fs.readFileSync(SRC_FILE, "utf8");
+  const { outputText } = ts.transpileModule(source, {
+    fileName: "migrate.ts",
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+      esModuleInterop: true,
+    },
+  });
+
+  const outFile = path.join(BUILD_DIR, "migrate.js");
+  fs.writeFileSync(outFile, outputText);
+  delete require.cache[outFile];
+  return require(outFile);
+}
+
+module.exports = { loadMigrate, BUILD_DIR };

--- a/tests/data/migrate.test.js
+++ b/tests/data/migrate.test.js
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+
+/**
+ * Unit tests for the explicit Bundle Format migration chain
+ * (lib/data/migrate.ts, docs/spec/bundle-format.md § Schema Versioning).
+ *
+ * Covers, per issue #201:
+ *  - the implicit/v0 → 1 step (former normalizeBundle) transforms legacy
+ *    parent_id/sort_order/position_* nodes into playlists + composes edges;
+ *  - the step is idempotent (safe to run on every load/save/import);
+ *  - version dispatch: a bundle already declaring schema_version >= 1 skips the
+ *    legacy step;
+ *  - a version newer than we support is imported untouched, with unknown
+ *    top-level fields preserved (no silent stripping);
+ *  - unknown top-level keys survive the v0 → 1 migration.
+ */
+
+const { loadMigrate, BUILD_DIR } = require("./load-migrate");
+const fs = require("fs");
+
+let failures = 0;
+function assert(cond, message) {
+  if (cond) {
+    console.log(`PASS: ${message}`);
+  } else {
+    failures++;
+    console.log(`FAIL: ${message}`);
+  }
+}
+const eq = (a, b) => JSON.stringify(a) === JSON.stringify(b);
+
+const { migrateBundle, CURRENT_SCHEMA_VERSION } = loadMigrate();
+
+function legacyBundle() {
+  return {
+    project: {
+      id: "p1",
+      title: "P1",
+      created_at: "2026-01-01T00:00:00.000Z",
+      updated_at: "2026-01-01T00:00:00.000Z",
+    },
+    nodes: [
+      { id: "F-root", project_id: "p1", species: "flow", title: "Root", status: "idea", platforms: ["web"] },
+      {
+        id: "V-a",
+        project_id: "p1",
+        species: "view",
+        title: "A",
+        status: "idea",
+        platforms: ["web"],
+        parent_id: "F-root",
+        sort_order: 2,
+        position_x: 10,
+        position_y: 20,
+      },
+      {
+        id: "V-b",
+        project_id: "p1",
+        species: "view",
+        title: "B",
+        status: "idea",
+        platforms: ["web"],
+        parent_id: "F-root",
+        sort_order: 1,
+      },
+    ],
+    edges: [],
+  };
+}
+
+// --- v0 → 1: legacy transform ---
+{
+  const out = migrateBundle(legacyBundle());
+
+  const hasLegacyKeys = out.nodes.some(
+    (n) => "parent_id" in n || "sort_order" in n || "position_x" in n || "position_y" in n,
+  );
+  assert(!hasLegacyKeys, "v0→1: legacy parent_id/sort_order/position_* fields are stripped");
+
+  const root = out.nodes.find((n) => n.id === "F-root");
+  assert(
+    eq(root.metadata?.playlist?.entries, [
+      { type: "view", view_id: "V-b" },
+      { type: "view", view_id: "V-a" },
+    ]),
+    "v0→1: parent flow gets a playlist ordered by sort_order (V-b before V-a)",
+  );
+
+  const edgeIds = out.edges.map((e) => e.id).sort();
+  assert(
+    eq(edgeIds, ["legacy-compose-F-root-V-a", "legacy-compose-F-root-V-b"]),
+    "v0→1: missing composes edges are backfilled",
+  );
+  assert(
+    out.edges.every((e) => e.edge_type === "composes" && e.project_id === "p1"),
+    "v0→1: backfilled edges are composes edges scoped to the project",
+  );
+
+  assert(out.schema_version === undefined, "v0→1: migration does not stamp schema_version (absent still means 1)");
+}
+
+// --- idempotency ---
+{
+  const once = migrateBundle(legacyBundle());
+  const twice = migrateBundle(once);
+  assert(eq(once, twice), "idempotent: migrating an already-migrated bundle is a no-op");
+}
+
+// --- version dispatch: schema_version >= 1 skips the legacy step ---
+{
+  const v1 = legacyBundle();
+  v1.schema_version = 1;
+  const out = migrateBundle(v1);
+
+  const va = out.nodes.find((n) => n.id === "V-a");
+  assert(va.parent_id === "F-root", "dispatch: a schema_version:1 bundle skips the v0→1 legacy transform");
+  const root = out.nodes.find((n) => n.id === "F-root");
+  assert(!root.metadata?.playlist, "dispatch: no playlist is synthesized for a declared-v1 bundle");
+  assert(out.edges.length === 0, "dispatch: no legacy composes edges are backfilled for a declared-v1 bundle");
+  assert(out.schema_version === 1, "dispatch: declared schema_version is preserved");
+}
+
+// --- reading a newer version: import untouched, preserve unknown fields ---
+{
+  const future = {
+    schema_version: CURRENT_SCHEMA_VERSION + 98,
+    project: {
+      id: "p2",
+      title: "P2",
+      version: "3.0.0",
+      created_at: "2026-01-01T00:00:00.000Z",
+      updated_at: "2026-01-01T00:00:00.000Z",
+    },
+    nodes: [{ id: "V-x", project_id: "p2", species: "view", title: "X", status: "idea", platforms: ["web"] }],
+    edges: [],
+    journal: [{ id: "01J", type: "node.created" }],
+    future_field: { anything: true },
+  };
+  const out = migrateBundle(future);
+  assert(eq(out, future), "newer version: bundle is returned untouched, byte-for-byte");
+  assert(eq(out.journal, future.journal), "newer version: unknown top-level `journal` is preserved");
+  assert(out.project.version === "3.0.0", "newer version: unknown project.version is preserved");
+  assert(eq(out.future_field, future.future_field), "newer version: unknown forward-compat key is preserved");
+}
+
+// --- unknown top-level key survives the v0 → 1 migration ---
+{
+  const legacy = legacyBundle();
+  legacy.journal = [{ id: "01K", type: "release.tagged" }];
+  const out = migrateBundle(legacy);
+  assert(eq(out.journal, legacy.journal), "v0→1: unknown top-level `journal` key survives the migration");
+}
+
+fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+
+if (failures > 0) {
+  console.log(`\n${failures} migration test(s) failed.`);
+  process.exit(1);
+}
+console.log("\nAll migration tests passed.");

--- a/tests/data/seed-import.test.js
+++ b/tests/data/seed-import.test.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+/**
+ * Verifies (issue #201 Verification) that every seed and the example bundle
+ * still import unchanged after the v2 foundation lands — both as-is and with an
+ * explicit `schema_version: 1`:
+ *  - parseBundle() accepts them (shape parse preserves schema_version);
+ *  - migrateBundle() is a no-op on them (already v1-clean) — export → import
+ *    round-trip is byte-for-byte unchanged.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const { loadMigrate, BUILD_DIR: MIGRATE_BUILD_DIR } = require("./load-migrate");
+const { loadSchema, BUILD_DIR: SCHEMA_BUILD_DIR } = require("../schema/load-schema");
+
+const ROOT = path.join(__dirname, "..", "..");
+const BUNDLES = ["seed/pebbles.json", "seed/arkaik-self-map.json", "public/schema/example-bundle.json"];
+
+let failures = 0;
+function assert(cond, message) {
+  if (cond) console.log(`PASS: ${message}`);
+  else {
+    failures++;
+    console.log(`FAIL: ${message}`);
+  }
+}
+const eq = (a, b) => JSON.stringify(a) === JSON.stringify(b);
+
+const { migrateBundle } = loadMigrate();
+const { parseBundle } = loadSchema();
+
+for (const rel of BUNDLES) {
+  const bundle = JSON.parse(fs.readFileSync(path.join(ROOT, rel), "utf8"));
+
+  // As-is.
+  assert(parseBundle(bundle).success, `${rel}: parseBundle accepts it as-is`);
+  assert(eq(migrateBundle(bundle), bundle), `${rel}: migrateBundle is a no-op (round-trip unchanged)`);
+
+  // With an explicit schema_version: 1 (Conformance Level 1).
+  const versioned = { schema_version: 1, ...bundle };
+  const parsed = parseBundle(versioned);
+  assert(parsed.success, `${rel}: parseBundle accepts it with explicit schema_version: 1`);
+  assert(
+    parsed.success && parsed.data.schema_version === 1,
+    `${rel}: parseBundle preserves schema_version: 1 (not stripped)`,
+  );
+  assert(eq(migrateBundle(versioned), versioned), `${rel}: migrateBundle is a no-op on a declared-v1 bundle`);
+}
+
+fs.rmSync(MIGRATE_BUILD_DIR, { recursive: true, force: true });
+fs.rmSync(SCHEMA_BUILD_DIR, { recursive: true, force: true });
+
+if (failures > 0) {
+  console.log(`\n${failures} seed-import test(s) failed.`);
+  process.exit(1);
+}
+console.log("\nAll seed-import tests passed.");


### PR DESCRIPTION
## Summary

Introduces an explicit, ordered migration chain for Bundle Format schema versioning (per docs/spec/bundle-format.md § Schema Versioning). This replaces the implicit `normalizeBundle` function with a versioned, testable migration system that handles legacy bundle formats and preserves unknown fields for forward compatibility.

## Key Changes

- **New migration system** (`lib/data/migrate.ts`):
  - Implements `migrateBundle()` function that upgrades bundles from any `schema_version` to `CURRENT_SCHEMA_VERSION` (currently 1)
  - Bundles without `schema_version` are treated as v0 and run through the legacy transformation step
  - Bundles at or above current version are returned untouched with all unknown fields preserved
  - Migration steps are pure, independently testable functions

- **v0 → v1 migration** (formerly implicit `normalizeBundle`):
  - Strips legacy node fields: `parent_id`, `sort_order`, `position_x`, `position_y`
  - Synthesizes `metadata.playlist` entries on parent flows/views from legacy hierarchy
  - Backfills missing `composes` edges between parents and children
  - Idempotent: safe to run on every load/save/import
  - Preserves unknown top-level keys via spread operator

- **Schema updates** (`packages/schema/src/bundle.ts`):
  - Added optional `schema_version?: number` field to `ProjectBundle`
  - Added `.catchall(z.unknown())` to `Project` and `ProjectBundle` schemas to explicitly allow and preserve unknown fields
  - Updated JSON schema generation to normalize `additionalProperties` to `true` for clarity

- **Integration** (`lib/data/local-provider.ts`):
  - Replaced all `normalizeBundle()` calls with `migrateBundle()`
  - Applied on load, save, and import paths

- **Comprehensive test coverage**:
  - `tests/data/migrate.test.js`: Unit tests for migration chain (legacy transform, idempotency, version dispatch, forward compatibility)
  - `tests/data/import-roundtrip.test.js`: Regression test for ID-collision import path preserving unknown keys
  - `tests/data/seed-import.test.js`: Verification that existing seeds and example bundle remain unchanged
  - Added `test:migrate` npm script to CI workflow

## Notable Implementation Details

- Migration source version detection treats absent `schema_version` as `0` (pre-versioning), distinct from the format-level interpretation of "absent means 1"
- Unknown top-level keys survive migrations via object spread, ensuring forward compatibility
- The migration chain is extensible: future steps simply append to the `MIGRATIONS` array with contiguous `from`/`to` versions
- All migrations are pure functions with no side effects, enabling independent unit testing

https://claude.ai/code/session_014jcExtRX8FpeRyXTKJnBRN