### PR TITLE
M2: Refs rendering — typed external links + mirrored status badges

### DIFF
--- a/components/graph/nodes/RefBadges.tsx
+++ b/components/graph/nodes/RefBadges.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
+import { StatusBadge } from "@/components/layout/StatusBadge";
+import {
+  REF_TYPE_ICONS,
+  REF_TYPE_ICON_FALLBACK,
+  REF_TYPE_LABELS,
+  REF_TYPE_LABEL_FALLBACK,
+} from "@/components/graph/nodes/node-styles";
+import type { Ref } from "@/lib/data/types";
+
+function formatSyncedAt(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+
+  const diffDays = Math.round((Date.now() - date.getTime()) / 86_400_000);
+  if (diffDays <= 0) return "synced today";
+  if (diffDays === 1) return "synced 1 day ago";
+  if (diffDays < 30) return `synced ${diffDays} days ago`;
+  return `synced ${date.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" })}`;
+}
+
+interface RefBadgeProps {
+  refItem: Ref;
+}
+
+export function RefBadge({ refItem }: RefBadgeProps) {
+  const Icon = REF_TYPE_ICONS[refItem.type] ?? REF_TYPE_ICON_FALLBACK;
+  const label = REF_TYPE_LABELS[refItem.type] ?? REF_TYPE_LABEL_FALLBACK;
+  const title = refItem.title || refItem.url;
+  const hasDetail = Boolean(refItem.external_status || refItem.synced_at);
+
+  const link = (
+    <a
+      href={refItem.url}
+      target="_blank"
+      rel="nofollow noreferrer"
+      className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted transition-colors"
+    >
+      <Icon className="size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />
+      <span className="truncate">{title}</span>
+    </a>
+  );
+
+  return (
+    <div className="flex items-center gap-1">
+      {hasDetail ? (
+        <HoverCard openDelay={250}>
+          <HoverCardTrigger asChild>{link}</HoverCardTrigger>
+          <HoverCardContent className="w-64 p-3" align="start">
+            <div className="space-y-1">
+              <p className="text-sm font-medium text-foreground">{label}</p>
+              {refItem.external_status && (
+                <p className="text-xs text-muted-foreground">Status: {refItem.external_status}</p>
+              )}
+              {refItem.synced_at && (
+                <p className="text-xs text-muted-foreground">{formatSyncedAt(refItem.synced_at)}</p>
+              )}
+            </div>
+          </HoverCardContent>
+        </HoverCard>
+      ) : (
+        link
+      )}
+      {refItem.status_mapped && <StatusBadge status={refItem.status_mapped} className="shrink-0" />}
+    </div>
+  );
+}
+
+interface RefListProps {
+  refs?: Ref[];
+}
+
+export function RefList({ refs }: RefListProps) {
+  if (!refs || refs.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-0.5">
+      {refs.map((refItem) => (
+        <RefBadge key={refItem.id} refItem={refItem} />
+      ))}
+    </div>
+  );
+}

--- a/components/graph/nodes/node-styles.ts
+++ b/components/graph/nodes/node-styles.ts
@@ -1,6 +1,7 @@
 import type { StatusId } from "@/lib/config/statuses";
 import type { PlatformId } from "@/lib/config/platforms";
 import type { SpeciesId } from "@/lib/config/species";
+import type { RefType } from "@/lib/data/types";
 import type { LucideIcon } from "lucide-react";
 import {
   Monitor,
@@ -12,6 +13,7 @@ import {
   Plug,
   Lightbulb, CircleDashed, CircleDotDashed, CirclePlay, CircleFadingArrowUp,
   CircleCheckBig, CircleSlash, CircleX,
+  Figma, Github, Gitlab, Ticket, GitPullRequest, GitMerge, ExternalLink, Link2,
 } from "lucide-react";
 
 export const STATUS_STYLES: Record<StatusId, { badge: string; dot: string }> = {
@@ -88,3 +90,31 @@ export const STATUS_GHOST_STYLES: Record<StatusId, { wrapper: string; border: st
   archived:    { wrapper: "opacity-60", border: ""              },
   blocked:     { wrapper: "",           border: ""              },
 };
+
+// Known `Ref.type` values (docs/spec/bundle-format.md § References). Keyed by
+// plain `string`, not `RefType`, because `Ref.type` also accepts unrecognized
+// values (`RefType | (string & {})`); unrecognized types fall back to
+// REF_TYPE_ICON_FALLBACK / REF_TYPE_LABEL_FALLBACK and render as generic links,
+// per the format's "unknown types MUST be preserved" rule.
+export const REF_TYPE_ICONS: Record<string, LucideIcon> = {
+  figma:            Figma,
+  "github-issue":   Github,
+  "gitlab-issue":   Gitlab,
+  "linear-issue":   Ticket,
+  "github-pr":      GitPullRequest,
+  "gitlab-mr":      GitMerge,
+  url:              ExternalLink,
+} satisfies Record<RefType, LucideIcon>;
+
+export const REF_TYPE_LABELS: Record<string, string> = {
+  figma:            "Figma",
+  "github-issue":   "GitHub Issue",
+  "gitlab-issue":   "GitLab Issue",
+  "linear-issue":   "Linear Issue",
+  "github-pr":      "GitHub PR",
+  "gitlab-mr":      "GitLab MR",
+  url:              "Link",
+} satisfies Record<RefType, string>;
+
+export const REF_TYPE_ICON_FALLBACK: LucideIcon = Link2;
+export const REF_TYPE_LABEL_FALLBACK = "Link";

--- a/components/panels/NodeDetailPanel.tsx
+++ b/components/panels/NodeDetailPanel.tsx
@@ -27,6 +27,7 @@ import {
   STATUS_STYLES,
 } from "@/components/graph/nodes/node-styles";
 import { SpeciesBadge, EntityId } from "@/components/graph/nodes/EntityBadges";
+import { RefList } from "@/components/graph/nodes/RefBadges";
 import { PlatformVariants } from "@/components/panels/PlatformVariants";
 import { PlatformGaugeList } from "@/components/graph/nodes/PlatformGaugeList";
 import { PlaylistEditor } from "@/components/panels/PlaylistEditor";
@@ -275,6 +276,21 @@ function InvocationSection({ node, allNodes, onNavigate }: InvocationSectionProp
   );
 }
 
+function RefsSection({ node }: { node: Node }) {
+  const refs = node.metadata?.refs;
+
+  if (!refs || refs.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="px-6 flex flex-col gap-2">
+      <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">References</span>
+      <RefList refs={refs} />
+    </div>
+  );
+}
+
 interface ConnectionsSectionProps {
   node: Node;
   allNodes: Node[];
@@ -466,6 +482,7 @@ export function NodeDetailPanel({
         {node && (
           <>
             <NodeFields key={node.id} node={node} onUpdate={onUpdate} />
+            <RefsSection key={`refs-${node.id}`} node={node} />
             {node.species === "view" && (
               <PlatformVariantsSection
                 key={`pv-${node.id}`}

--- a/lib/data/types.ts
+++ b/lib/data/types.ts
@@ -19,6 +19,8 @@ export type {
   JunctionCase,
   FlowPlaylist,
   NodeMetadata,
+  Ref,
+  RefType,
   Node,
   Edge,
   Project,

--- a/seed/pebbles.json
+++ b/seed/pebbles.json
@@ -22,7 +22,33 @@
         "web",
         "ios",
         "android"
-      ]
+      ],
+      "metadata": {
+        "refs": [
+          {
+            "id": "gh-281",
+            "type": "github-pr",
+            "url": "https://github.com/pebbles-app/pebbles-ios/pull/281",
+            "title": "iOS: WelcomeView implementation",
+            "external_status": "merged",
+            "status_mapped": "live",
+            "platform": "ios",
+            "synced_at": "2026-07-09T14:30:00.000Z"
+          },
+          {
+            "id": "figma-landing",
+            "type": "figma",
+            "url": "https://www.figma.com/file/pebbles-design/Pebbles?node-id=1%3A42",
+            "title": "Landing — Design"
+          },
+          {
+            "id": "notion-landing-brief",
+            "type": "notion-page",
+            "url": "https://notion.so/pebbles/landing-brief",
+            "title": "Landing brief"
+          }
+        ]
+      }
     },
     {
       "id": "V-login",


### PR DESCRIPTION
## Summary

Closes #206. Renders `metadata.refs` (the `Ref` type from #202) as typed external links with mirrored status — display only, per `docs/spec/bundle-format.md:53–75` and `docs/vision.md:98–113`.

- `components/graph/nodes/RefBadges.tsx` (new): `RefBadge`/`RefList` — each ref renders as an external `<a href="{ref.url}" rel="nofollow noreferrer" target="_blank">` with a type icon + title. When `status_mapped` is set, a `StatusBadge` (reused from `components/layout/StatusBadge.tsx`) sits alongside it, mirroring the external state. When `external_status`/`synced_at` are present, hovering the link opens a `HoverCard` (idiom from `EntityBadges.tsx`) surfacing the raw external status string and a freshness readout ("synced N days ago").
- `components/graph/nodes/node-styles.ts`: adds `REF_TYPE_ICONS`/`REF_TYPE_LABELS` for the 7 known `Ref.type` values, plus `REF_TYPE_ICON_FALLBACK`/`REF_TYPE_LABEL_FALLBACK` so unrecognized types render as generic links (never rejected, per the format's preserve-unknown rule).
- `components/panels/NodeDetailPanel.tsx`: adds a `RefsSection` ("References") following the existing section pattern — renders nothing when `refs` is empty/absent.
- `lib/data/types.ts`: re-exports `Ref`/`RefType` from `@arkaik/schema` (previously missing from the app's re-export surface despite the schema package already exporting them from #202).
- `seed/pebbles.json`: seeds `V-landing` with a `github-pr` (status_mapped, mirrored badge), a `figma`, and an unknown-type (`notion-page`) ref for manual verification — matches the issue's suggested fixture shape.

No ref ever mutates `node.status`; verified in the running app that `V-landing.status` stays `"development"` while its PR ref mirrors `"live"`.

## Test plan

- [x] `npm run build` — green
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — no new warnings/errors
- [x] `npm run validate:seeds`, `npm run test:schema`, `npm run test:fixtures`, `npm run test:refs` — all pass
- [x] Manually drove the app (headless Chromium): loaded the Pebbles example, confirmed the PR ref shows a mirrored "Live" badge (green check) with `node.status` unchanged at "Development", the Figma ref shows a plain link, the unknown-type ref shows a generic link icon, hovering the PR link reveals "Status: merged" + "synced 2 days ago", hovering the badge shows the mapped "Live" tooltip, and a node with no refs renders no "References" section. No console errors.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AtgZeZ43a4MAj2g9a5yJ1Q)_