### PR TITLE
Add journal projection functions and read-path utilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Journal (Level 2) tests
         run: npm run test:journal
 
+      - name: Journal projection tests
+        run: npm run test:journal-projections
+
       - name: Screenshot data-URI size warning tests
         run: npm run test:screenshot-size
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 /packages/schema/.generate-build/
 /tests/data/.test-build/
 /tests/data/.test-build-export/
+/tests/data/.test-build-journal/
 
 # next.js
 /.next/

--- a/lib/data/data-provider.ts
+++ b/lib/data/data-provider.ts
@@ -1,4 +1,4 @@
-import type { Node, Edge, Project, ProjectBundle } from "./types";
+import type { Node, Edge, Project, ProjectBundle, JournalEvent } from "./types";
 
 export interface DataProvider {
   getProject(id: string): Promise<ProjectBundle | undefined>;
@@ -8,6 +8,13 @@ export interface DataProvider {
 
   getNodes(projectId: string): Promise<Node[]>;
   getEdges(projectId: string): Promise<Edge[]>;
+  /**
+   * The embedded journal events for a project, or `[]` when the bundle carries
+   * none (Level 0/1, or history stripped for publish). The browser app reads
+   * only the embedded journal; repo `.jsonl` sidecar loading is a CLI/M3
+   * concern (docs/spec/journal.md § Storage Shapes).
+   */
+  getJournal(projectId: string): Promise<JournalEvent[]>;
 
   createNode(node: Node): Promise<Node>;
   updateNode(id: string, patch: Partial<Omit<Node, "id" | "project_id">>): Promise<Node>;

--- a/lib/data/local-provider.ts
+++ b/lib/data/local-provider.ts
@@ -105,6 +105,9 @@ export const localProvider: DataProvider = {
   async getEdges(projectId: string) {
     return store.get(projectId)?.edges ?? [];
   },
+  async getJournal(projectId: string) {
+    return store.get(projectId)?.journal ?? [];
+  },
 
   async createNode(node: Node) {
     const bundle = store.get(node.project_id);

--- a/lib/hooks/useJournal.ts
+++ b/lib/hooks/useJournal.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import type { JournalEvent } from "@/lib/data/types";
+import { localProvider } from "@/lib/data/local-provider";
+
+/**
+ * Loads a project's embedded `journal[]` — consistent with {@link useNodes} /
+ * {@link useEdges}. Read-only by design: app-side event emission is M3, so this
+ * hook exposes the events and load state, not mutators. The browser app
+ * consumes only the embedded journal; the repo `.jsonl` sidecar is a CLI
+ * concern (docs/spec/journal.md § Storage Shapes).
+ */
+export function useJournal(projectId: string) {
+  const [journal, setJournal] = useState<JournalEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    localProvider
+      .getJournal(projectId)
+      .then((j) => {
+        setJournal(j);
+        setLoading(false);
+      })
+      .catch((err) => {
+        console.error("[useJournal] Failed to load journal:", err);
+        setError(err instanceof Error ? err.message : "Failed to load journal");
+        setLoading(false);
+      });
+  }, [projectId]);
+
+  return { journal, loading, error };
+}

--- a/lib/utils/journal.ts
+++ b/lib/utils/journal.ts
@@ -1,0 +1,259 @@
+/**
+ * Journal projections — pure functions over (snapshot, journal), the same
+ * pattern as the status rollups in `lib/utils/platform-status.ts`
+ * (docs/spec/journal.md § Projections). Module-local exported result types,
+ * minimal `Pick<>` inputs, no I/O, no React, immutable: every function returns
+ * fresh data and never mutates its arguments.
+ *
+ * The journal is the *read* surface here — these functions never emit events
+ * (app-side emission is M3). Ordering follows the journal ordering rule (by
+ * `ts`, tiebreaking by `id`); {@link orderEvents} is reused from the schema
+ * package so the rule lives in exactly one place. A bundle without a journal
+ * yields the empty projection, never an error — that is the whole
+ * backward-compatibility story (docs/spec/journal.md § Projections).
+ */
+
+import { orderEvents } from "@arkaik/schema";
+import type { PlatformId } from "@/lib/config/platforms";
+import type {
+  Node,
+  JournalEvent,
+  EdgeAddedEvent,
+  ReleaseTaggedEvent,
+  IdeaProposedEvent,
+  RequestFiledEvent,
+} from "@/lib/data/types";
+
+/** Narrow an `unknown` journal field to a string in one place. */
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+// --- Node timeline -------------------------------------------------------
+
+/** The ordered events touching a single node (docs/spec/journal.md:102). */
+export type NodeTimeline = JournalEvent[];
+
+/**
+ * Every event touching `nodeId`, in journal order. An event touches a node when
+ * it carries that `node_id` (creation, updates, status changes, deletion, refs,
+ * a linked idea/request) or when the node is an endpoint of an edge event —
+ * `edge.added` directly, `edge.removed` resolved back to the endpoints its
+ * earlier `edge.added` recorded. Returns a fresh array; an empty journal (or a
+ * node nothing references) yields `[]`.
+ */
+export function computeNodeTimeline(events: readonly JournalEvent[], nodeId: string): NodeTimeline {
+  // Resolve edge endpoints from edge.added so a later edge.removed — which
+  // carries only edge_id — can still be attributed to the nodes it connected.
+  const edgeEndpoints = new Map<string, { source?: string; target?: string }>();
+  for (const ev of events) {
+    if (ev.type === "edge.added") {
+      const edgeId = asString((ev as EdgeAddedEvent).edge_id);
+      if (edgeId !== undefined) {
+        edgeEndpoints.set(edgeId, {
+          source: asString((ev as EdgeAddedEvent).source_id),
+          target: asString((ev as EdgeAddedEvent).target_id),
+        });
+      }
+    }
+  }
+
+  const touches = (ev: JournalEvent): boolean => {
+    if (asString(ev.node_id) === nodeId) return true;
+    if (ev.type === "edge.added") {
+      const edge = ev as EdgeAddedEvent;
+      return asString(edge.source_id) === nodeId || asString(edge.target_id) === nodeId;
+    }
+    if (ev.type === "edge.removed") {
+      const edgeId = asString(ev.edge_id);
+      const ends = edgeId !== undefined ? edgeEndpoints.get(edgeId) : undefined;
+      return Boolean(ends && (ends.source === nodeId || ends.target === nodeId));
+    }
+    return false;
+  };
+
+  return orderEvents(events.filter(touches));
+}
+
+// --- Changelog -----------------------------------------------------------
+
+/**
+ * The ordered slice of events between two `release.tagged` markers
+ * (docs/spec/journal.md:92,103). Both markers are boundaries and are excluded
+ * from `events`.
+ */
+export interface Changelog {
+  /** The earlier marker's version, or `null` when the slice starts at the journal's beginning. */
+  fromVersion: string | null;
+  /** The later marker's version — the release this changelog describes. */
+  toVersion: string;
+  /** Set when the `to` marker is platform-scoped; `events` is then filtered to that platform. */
+  platform?: PlatformId;
+  /** The events strictly between the two markers, in journal order. */
+  events: JournalEvent[];
+}
+
+export interface ChangelogOptions {
+  /**
+   * The earlier boundary. Omit to use the `release.tagged` marker immediately
+   * preceding `toVersion`; pass `null` to start from the journal's beginning.
+   */
+  fromVersion?: string | null;
+  /**
+   * Snapshot nodes keyed by id, used only to resolve platform filtering when the
+   * `to` marker is platform-scoped. Absent → a platform-scoped changelog keeps
+   * only events that name the platform themselves (e.g. `node.status_changed`).
+   */
+  nodesById?: ReadonlyMap<string, Pick<Node, "platforms">>;
+}
+
+/** Does an event fall within a platform-scoped release's changelog? */
+function eventAffectsPlatform(
+  ev: JournalEvent,
+  platform: PlatformId,
+  nodesById?: ReadonlyMap<string, Pick<Node, "platforms">>,
+): boolean {
+  // An event that carries its own platform speaks for that platform directly
+  // (a per-platform status change, a platform-scoped release marker).
+  const ownPlatform = asString(ev.platform);
+  if (ownPlatform !== undefined) return ownPlatform === platform;
+
+  if (!nodesById) return false;
+
+  const onPlatform = (id: unknown): boolean => {
+    const nodeId = asString(id);
+    return nodeId !== undefined && (nodesById.get(nodeId)?.platforms.includes(platform) ?? false);
+  };
+
+  if (onPlatform(ev.node_id)) return true;
+  if (ev.type === "edge.added") {
+    const edge = ev as EdgeAddedEvent;
+    return onPlatform(edge.source_id) || onPlatform(edge.target_id);
+  }
+  return false;
+}
+
+/**
+ * The changelog for release `toVersion`: the ordered events between its
+ * `release.tagged` marker and the previous one (both markers excluded). When
+ * `toVersion`'s marker is platform-scoped, the slice is filtered to events
+ * affecting that platform's nodes (docs/spec/journal.md:92). A `toVersion` with
+ * no matching marker — including an empty journal — yields an empty changelog.
+ */
+export function computeChangelog(
+  events: readonly JournalEvent[],
+  toVersion: string,
+  options: ChangelogOptions = {},
+): Changelog {
+  const ordered = orderEvents(events);
+  const isRelease = (ev: JournalEvent, version: string): boolean =>
+    ev.type === "release.tagged" && asString((ev as ReleaseTaggedEvent).version) === version;
+
+  // The `to` marker: last matching, so a re-tagged version resolves to the latest.
+  let toIndex = -1;
+  for (let i = ordered.length - 1; i >= 0; i -= 1) {
+    if (isRelease(ordered[i], toVersion)) {
+      toIndex = i;
+      break;
+    }
+  }
+  if (toIndex === -1) {
+    return { fromVersion: null, toVersion, events: [] };
+  }
+
+  const platform = asString((ordered[toIndex] as ReleaseTaggedEvent).platform) as PlatformId | undefined;
+
+  // The `from` boundary index.
+  let fromIndex = -1;
+  if (options.fromVersion === null) {
+    fromIndex = -1; // explicit: from the beginning
+  } else if (typeof options.fromVersion === "string") {
+    for (let i = 0; i < toIndex; i += 1) {
+      if (isRelease(ordered[i], options.fromVersion)) {
+        fromIndex = i;
+        break;
+      }
+    }
+  } else {
+    // Default: the release marker immediately preceding `toIndex`.
+    for (let i = toIndex - 1; i >= 0; i -= 1) {
+      if (ordered[i].type === "release.tagged") {
+        fromIndex = i;
+        break;
+      }
+    }
+  }
+
+  let slice = ordered.slice(fromIndex + 1, toIndex);
+  if (platform) {
+    slice = slice.filter((ev) => eventAffectsPlatform(ev, platform, options.nodesById));
+  }
+
+  return {
+    fromVersion: fromIndex >= 0 ? asString((ordered[fromIndex] as ReleaseTaggedEvent).version) ?? null : null,
+    toVersion,
+    ...(platform ? { platform } : {}),
+    events: slice,
+  };
+}
+
+// --- Backlog -------------------------------------------------------------
+
+/** Open ideas and requests (docs/spec/journal.md:105). */
+export interface Backlog {
+  /** Open `idea.proposed` items, in journal order. */
+  ideas: IdeaProposedEvent[];
+  /** Open `request.filed` items, in journal order. */
+  requests: RequestFiledEvent[];
+  /** Open ideas and requests interleaved, in journal order. */
+  items: (IdeaProposedEvent | RequestFiledEvent)[];
+}
+
+export interface BacklogOptions {
+  /**
+   * Ids of nodes that currently exist — the authoritative snapshot. An item
+   * whose `node_id` is present here has a linked node and is closed. When
+   * omitted, existence is derived from the journal's `node.created` /
+   * `node.deleted` events instead.
+   */
+  existingNodeIds?: ReadonlySet<string>;
+}
+
+/** Nodes that exist after replaying the journal's create/delete events. */
+function deriveExistingNodeIds(orderedEvents: readonly JournalEvent[]): Set<string> {
+  const existing = new Set<string>();
+  for (const ev of orderedEvents) {
+    const nodeId = asString(ev.node_id);
+    if (nodeId === undefined) continue;
+    if (ev.type === "node.created") existing.add(nodeId);
+    else if (ev.type === "node.deleted") existing.delete(nodeId);
+  }
+  return existing;
+}
+
+/**
+ * The open backlog: every `idea.proposed` / `request.filed` that has not yet
+ * been resolved. An item is *open* until a linked node exists — its `node_id`
+ * points at a node in the snapshot (or, when no snapshot is supplied, at a node
+ * the journal created and has not deleted). An item with no `node_id`, or one
+ * whose linked node no longer exists, stays open. An empty journal yields an
+ * empty backlog.
+ */
+export function computeBacklog(events: readonly JournalEvent[], options: BacklogOptions = {}): Backlog {
+  const ordered = orderEvents(events);
+  const existing = options.existingNodeIds ?? deriveExistingNodeIds(ordered);
+
+  const items: (IdeaProposedEvent | RequestFiledEvent)[] = [];
+  for (const ev of ordered) {
+    if (ev.type !== "idea.proposed" && ev.type !== "request.filed") continue;
+    const linkedId = asString(ev.node_id);
+    const closed = linkedId !== undefined && existing.has(linkedId);
+    if (!closed) items.push(ev as IdeaProposedEvent | RequestFiledEvent);
+  }
+
+  return {
+    ideas: items.filter((item): item is IdeaProposedEvent => item.type === "idea.proposed"),
+    requests: items.filter((item): item is RequestFiledEvent => item.type === "request.filed"),
+    items,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:schema": "node tests/schema/parity.test.js",
     "test:refs": "node tests/schema/refs.test.js",
     "test:journal": "node tests/schema/journal.test.js",
+    "test:journal-projections": "node tests/data/journal-projections.test.js",
     "test:screenshot-size": "node tests/schema/screenshot-size.test.js",
     "test:migrate": "node tests/data/migrate.test.js && node tests/data/import-roundtrip.test.js && node tests/data/seed-import.test.js"
   },

--- a/tests/data/journal-projections.test.js
+++ b/tests/data/journal-projections.test.js
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+
+/**
+ * Unit tests for the journal read-path projections (lib/utils/journal.ts,
+ * docs/spec/journal.md § Projections): node timeline, changelog, and backlog.
+ *
+ * Exercised over one fixture journal, deliberately stored out of order to prove
+ * consumers tolerate unordered lines (the journal ordering rule). Every
+ * projection is also checked against the empty journal — it must return empty,
+ * never throw (issue #204 acceptance criteria).
+ */
+
+const { loadJournalProjections, BUILD_DIR, SCHEMA_BUILD_DIR } = require("./load-journal-projections");
+const fs = require("fs");
+
+let failures = 0;
+function check(name, cond, detail) {
+  if (cond) {
+    console.log(`PASS: ${name}`);
+  } else {
+    failures++;
+    console.log(`FAIL: ${name}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+const ids = (events) => events.map((e) => e.id).join(",");
+
+const { computeNodeTimeline, computeChangelog, computeBacklog } = loadJournalProjections();
+
+// --- Fixture journal (stored shuffled; consumers must order it) ------------
+// Timeline (by ts): V-home created → idea "Dark mode" → V-settings created →
+// edge e1 (V-home→V-settings) → release 1.0 → V-home live → V-settings dev →
+// request "Add search" → idea "Profile" (→V-profile) → V-profile created →
+// release 1.1 → V-settings live on ios → V-home title edited → edge e1 removed →
+// release 1.2 (ios).
+const EVENTS = {
+  create_home: { id: "01A", ts: "2026-01-01T00:00:00.000Z", type: "node.created", node_id: "V-home", species: "view", title: "Home" },
+  idea_dark: { id: "01B", ts: "2026-01-01T01:00:00.000Z", type: "idea.proposed", title: "Dark mode" },
+  create_settings: { id: "01C", ts: "2026-01-01T02:00:00.000Z", type: "node.created", node_id: "V-settings", species: "view", title: "Settings" },
+  edge_add: { id: "01D", ts: "2026-01-01T03:00:00.000Z", type: "edge.added", edge_id: "e1", source_id: "V-home", target_id: "V-settings", edge_type: "composes" },
+  release_10: { id: "01E", ts: "2026-01-02T00:00:00.000Z", type: "release.tagged", version: "1.0" },
+  home_live: { id: "01F", ts: "2026-01-03T00:00:00.000Z", type: "node.status_changed", node_id: "V-home", from: "idea", to: "live" },
+  settings_dev: { id: "01G", ts: "2026-01-03T01:00:00.000Z", type: "node.status_changed", node_id: "V-settings", from: "idea", to: "development" },
+  request_search: { id: "01H", ts: "2026-01-03T02:00:00.000Z", type: "request.filed", title: "Add search", source: "user" },
+  idea_profile: { id: "01I", ts: "2026-01-03T03:00:00.000Z", type: "idea.proposed", title: "Profile page", node_id: "V-profile" },
+  create_profile: { id: "01J", ts: "2026-01-03T04:00:00.000Z", type: "node.created", node_id: "V-profile", species: "view", title: "Profile" },
+  release_11: { id: "01K", ts: "2026-01-04T00:00:00.000Z", type: "release.tagged", version: "1.1" },
+  settings_live_ios: { id: "01L", ts: "2026-01-05T00:00:00.000Z", type: "node.status_changed", node_id: "V-settings", from: "development", to: "live", platform: "ios" },
+  home_title: { id: "01M", ts: "2026-01-05T01:00:00.000Z", type: "node.updated", node_id: "V-home", fields: ["title"], from: "Home", to: "Home v2" },
+  edge_remove: { id: "01N", ts: "2026-01-05T02:00:00.000Z", type: "edge.removed", edge_id: "e1" },
+  release_12_ios: { id: "01O", ts: "2026-01-06T00:00:00.000Z", type: "release.tagged", version: "1.2", platform: "ios" },
+};
+// Shuffled input order — the projections must sort it themselves.
+const JOURNAL = [
+  EVENTS.release_11, EVENTS.create_home, EVENTS.edge_remove, EVENTS.settings_dev,
+  EVENTS.release_12_ios, EVENTS.idea_dark, EVENTS.home_live, EVENTS.create_settings,
+  EVENTS.release_10, EVENTS.create_profile, EVENTS.idea_profile, EVENTS.home_title,
+  EVENTS.edge_add, EVENTS.request_search, EVENTS.settings_live_ios,
+];
+
+// Snapshot node → platforms, used only for platform-scoped changelog filtering.
+const NODES_BY_ID = new Map([
+  ["V-home", { platforms: ["web", "ios"] }],
+  ["V-settings", { platforms: ["ios"] }],
+  ["V-profile", { platforms: ["web"] }],
+]);
+
+function main() {
+  // --- Node timeline: ordered events touching a node, including edge events ---
+  const homeTimeline = computeNodeTimeline(JOURNAL, "V-home");
+  check(
+    "timeline(V-home) returns its events in order (create, edge+, status, update, edge-)",
+    ids(homeTimeline) === "01A,01D,01F,01M,01N",
+    ids(homeTimeline),
+  );
+
+  const settingsTimeline = computeNodeTimeline(JOURNAL, "V-settings");
+  check(
+    "timeline(V-settings) attributes edge.removed back to its endpoint",
+    ids(settingsTimeline) === "01C,01D,01G,01L,01N",
+    ids(settingsTimeline),
+  );
+
+  check("timeline does not mutate the input array", JOURNAL[0].id === "01K");
+  check("timeline(unknown node) is empty", computeNodeTimeline(JOURNAL, "V-ghost").length === 0);
+  check("timeline(empty journal) is empty", computeNodeTimeline([], "V-home").length === 0);
+
+  // --- Changelog: the ordered slice strictly between two release markers ---
+  const clExplicit = computeChangelog(JOURNAL, "1.1", { fromVersion: "1.0" });
+  check(
+    "changelog 1.0→1.1 is exactly the between-markers slice",
+    ids(clExplicit.events) === "01F,01G,01H,01I,01J",
+    ids(clExplicit.events),
+  );
+  check("changelog reports fromVersion/toVersion", clExplicit.fromVersion === "1.0" && clExplicit.toVersion === "1.1");
+  check("changelog excludes both release markers", !clExplicit.events.some((e) => e.type === "release.tagged"));
+
+  const clDefault = computeChangelog(JOURNAL, "1.1");
+  check(
+    "changelog to 1.1 with no from defaults to the previous marker (1.0)",
+    clDefault.fromVersion === "1.0" && ids(clDefault.events) === ids(clExplicit.events),
+    `${clDefault.fromVersion} / ${ids(clDefault.events)}`,
+  );
+
+  const clFirst = computeChangelog(JOURNAL, "1.0");
+  check(
+    "changelog to the first release runs from the journal's beginning",
+    clFirst.fromVersion === null && ids(clFirst.events) === "01A,01B,01C,01D",
+    `${clFirst.fromVersion} / ${ids(clFirst.events)}`,
+  );
+
+  // --- Changelog: platform-scoped release filters to that platform's nodes ---
+  const clIos = computeChangelog(JOURNAL, "1.2", { nodesById: NODES_BY_ID });
+  check(
+    "platform-scoped changelog 1.2 (ios) keeps the ios status change + the ios node's update",
+    clIos.platform === "ios" && ids(clIos.events) === "01L,01M",
+    `${clIos.platform} / ${ids(clIos.events)}`,
+  );
+
+  const clIosNoNodes = computeChangelog(JOURNAL, "1.2");
+  check(
+    "platform-scoped changelog without a snapshot keeps only self-declaring events",
+    ids(clIosNoNodes.events) === "01L",
+    ids(clIosNoNodes.events),
+  );
+
+  check("changelog to an unknown version is empty", computeChangelog(JOURNAL, "9.9").events.length === 0);
+  check("changelog(empty journal) is empty", computeChangelog([], "1.0").events.length === 0);
+
+  // --- Backlog: open ideas/requests; a gained linked node closes an item ---
+  const backlog = computeBacklog(JOURNAL);
+  check(
+    "backlog excludes the idea that gained a linked node (V-profile)",
+    ids(backlog.items) === "01B,01H",
+    ids(backlog.items),
+  );
+  check("backlog splits ideas and requests", ids(backlog.ideas) === "01B" && ids(backlog.requests) === "01H");
+
+  // Snapshot without V-profile → the linked node no longer exists → item reopens.
+  const backlogNoProfile = computeBacklog(JOURNAL, { existingNodeIds: new Set(["V-home", "V-settings"]) });
+  check(
+    "backlog reopens an idea whose linked node is absent from the snapshot",
+    ids(backlogNoProfile.items) === "01B,01H,01I",
+    ids(backlogNoProfile.items),
+  );
+
+  check("backlog(empty journal) is empty", computeBacklog([]).items.length === 0);
+
+  fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+  fs.rmSync(SCHEMA_BUILD_DIR, { recursive: true, force: true });
+
+  if (failures > 0) {
+    console.log(`\n${failures} journal-projection test(s) failed.`);
+    process.exit(1);
+  }
+  console.log(`\nAll journal-projection tests passed.`);
+}
+
+main();

--- a/tests/data/load-journal-projections.js
+++ b/tests/data/load-journal-projections.js
@@ -1,0 +1,52 @@
+/**
+ * Loads lib/utils/journal.ts (the projection functions) into a running Node
+ * process without a bundler. Same transpile-on-the-fly approach as
+ * load-migrate.js / load-schema.js.
+ *
+ * journal.ts's only runtime import is `orderEvents` from @arkaik/schema (its
+ * type imports erase); we build the schema package with load-schema.js and
+ * rewrite that bare specifier to the built CJS index so the require resolves.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const ts = require("typescript");
+const { loadSchema, BUILD_DIR: SCHEMA_BUILD_DIR } = require("../schema/load-schema");
+
+const ROOT = path.join(__dirname, "..", "..");
+const SRC_FILE = path.join(ROOT, "lib", "utils", "journal.ts");
+const BUILD_DIR = path.join(__dirname, ".test-build-journal");
+
+function loadJournalProjections() {
+  // Build the schema package so `require(...schema index)` resolves at runtime.
+  loadSchema();
+
+  fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+  fs.mkdirSync(BUILD_DIR, { recursive: true });
+  fs.writeFileSync(path.join(BUILD_DIR, "package.json"), JSON.stringify({ type: "commonjs" }));
+
+  const source = fs.readFileSync(SRC_FILE, "utf8");
+  const { outputText } = ts.transpileModule(source, {
+    fileName: "journal.ts",
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+      esModuleInterop: true,
+    },
+  });
+
+  // Point the bare @arkaik/schema require at the built CJS index. The path is
+  // absolute and JSON-encoded so it survives on any OS.
+  const schemaIndex = path.join(SCHEMA_BUILD_DIR, "index.js");
+  const rewritten = outputText.replace(
+    /require\((['"])@arkaik\/schema\1\)/g,
+    `require(${JSON.stringify(schemaIndex)})`,
+  );
+
+  const outFile = path.join(BUILD_DIR, "journal.js");
+  fs.writeFileSync(outFile, rewritten);
+  delete require.cache[outFile];
+  return require(outFile);
+}
+
+module.exports = { loadJournalProjections, BUILD_DIR, SCHEMA_BUILD_DIR };


### PR DESCRIPTION
## Summary
Implements the journal read-path layer with three core projection functions (`computeNodeTimeline`, `computeChangelog`, `computeBacklog`) that derive application state from the immutable event journal. These pure functions follow the pattern established in the status rollups, enabling efficient querying of journal data without I/O or mutations.

## Key Changes

- **Journal projection module** (`lib/utils/journal.ts`): Three pure functions that project journal events into useful application views:
  - `computeNodeTimeline()`: Returns all events touching a specific node, including edge events with resolved endpoints
  - `computeChangelog()`: Extracts ordered events between two release markers with optional platform-scoped filtering
  - `computeBacklog()`: Identifies open ideas and requests (those without linked nodes)

- **React hook** (`lib/hooks/useJournal.ts`): Client-side hook for loading a project's embedded journal with standard loading/error state management

- **Data provider integration**: Extended `DataProvider` interface and `localProvider` implementation with `getJournal()` method to expose embedded journal events

- **Comprehensive test suite** (`tests/data/journal-projections.test.js`): Unit tests covering all three projections with a deliberately shuffled fixture journal to verify consumers handle unordered input. Tests confirm empty journals return empty projections (backward compatibility per issue #204)

- **Build and CI integration**: Added test runner loader (`load-journal-projections.js`), npm script, and CI workflow step

## Implementation Details

- All projections reuse `orderEvents()` from the schema package to ensure the ordering rule lives in one place
- Events are narrowed to strings via `asString()` helper to handle unknown journal field types safely
- Edge removal events are resolved back to their endpoints using earlier `edge.added` events
- Platform-scoped changelog filtering supports both snapshot-based node lookup and self-declaring events
- Backlog closure logic supports both snapshot-provided node existence and journal-derived state
- No mutations: every function returns fresh data structures

https://claude.ai/code/session_011tsmrpUBZHbTwP8dwk8aXf