### PR TITLE
M2: Read-only journal UI — node History + project changelog view

### DIFF
--- a/app/project/[id]/canvas/page.tsx
+++ b/app/project/[id]/canvas/page.tsx
@@ -20,6 +20,7 @@ import { SidebarTrigger } from "@/components/ui/sidebar";
 import { useNodes } from "@/lib/hooks/useNodes";
 import { useEdges } from "@/lib/hooks/useEdges";
 import { useProject } from "@/lib/hooks/useProject";
+import { useJournal } from "@/lib/hooks/useJournal";
 import { useKeyboardShortcuts } from "@/lib/hooks/useKeyboardShortcuts";
 import { parseAndValidateBundle, downloadJson, exportProject, importProject, normalizeProjectTimestamps } from "@/lib/utils/export";
 import { generateNodeId } from "@/lib/utils/id";
@@ -152,6 +153,7 @@ export default function ProjectCanvasPage() {
   const { nodes: dataNodes, loading: nodesLoading, updateNode, addNode, removeNode, removeNodes } = useNodes(id);
   const { edges: dataEdges, loading: edgesLoading, addEdge, removeEdge } = useEdges(id);
   const { project: projectBundle, loading: projectLoading, updateProject } = useProject(id);
+  const { journal } = useJournal(id);
 
   const viewCardVariant: ViewCardVariant = projectBundle?.project.metadata?.view_card_variant === "large"
     ? "large"
@@ -1414,6 +1416,7 @@ export default function ProjectCanvasPage() {
         onDelete={handleDeleteNodeRequest}
         allNodes={dataNodes}
         allEdges={dataEdges}
+        journal={journal}
         onNavigate={handleNavigate}
         onCreateNode={handleCreateNodeFromPanel}
         onZoomShot={(node, platform) => {

--- a/app/project/[id]/changelog/page.tsx
+++ b/app/project/[id]/changelog/page.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useMemo } from "react";
+import { useParams } from "next/navigation";
+import { LightbulbIcon, MessageSquareTextIcon, TagIcon } from "lucide-react";
+import { orderEvents } from "@arkaik/schema";
+import { Separator } from "@/components/ui/separator";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+import { useNodes } from "@/lib/hooks/useNodes";
+import { useProject } from "@/lib/hooks/useProject";
+import { useJournal } from "@/lib/hooks/useJournal";
+import { computeBacklog, computeChangelog, type Backlog, type Changelog } from "@/lib/utils/journal";
+import { describeJournalEvent, formatEventDate } from "@/components/journal/describe-event";
+import { PLATFORM_LABELS } from "@/components/graph/nodes/node-styles";
+import type { Node, ReleaseTaggedEvent } from "@/lib/data/types";
+
+interface ReleaseEntry {
+  tag: ReleaseTaggedEvent;
+  changelog: Changelog;
+}
+
+function ReleaseCard({ entry, nodesById }: { entry: ReleaseEntry; nodesById: Map<string, Node> }) {
+  const { tag, changelog } = entry;
+
+  return (
+    <div className="rounded-xl border bg-card p-4 flex flex-col gap-3">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <TagIcon className="size-4 text-muted-foreground" aria-hidden="true" />
+          <span className="text-sm font-semibold">{changelog.toVersion}</span>
+          {changelog.platform && (
+            <span className="rounded-full border px-2 py-0.5 text-xs text-muted-foreground">
+              {PLATFORM_LABELS[changelog.platform]}
+            </span>
+          )}
+        </div>
+        <span className="text-xs text-muted-foreground">{formatEventDate(tag.ts)}</span>
+      </div>
+      {tag.notes && <p className="text-sm text-muted-foreground">{tag.notes}</p>}
+      {changelog.events.length === 0 ? (
+        <p className="text-xs text-muted-foreground">No changes recorded for this release.</p>
+      ) : (
+        <div className="flex flex-col gap-0.5">
+          {changelog.events.map((event) => {
+            const { icon: Icon, text, meta } = describeJournalEvent(event, nodesById);
+
+            return (
+              <div key={event.id} className="flex items-start gap-2 rounded-md px-2 py-1.5 text-sm">
+                <Icon className="size-3.5 shrink-0 text-muted-foreground mt-0.5" aria-hidden="true" />
+                <div className="flex-1 min-w-0">
+                  <p className="truncate">{text}</p>
+                  {meta && <p className="text-xs text-muted-foreground truncate">{meta}</p>}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function BacklogList({ backlog }: { backlog: Backlog }) {
+  if (backlog.items.length === 0) {
+    return <p className="text-sm text-muted-foreground">No open ideas or requests.</p>;
+  }
+
+  return (
+    <div className="flex flex-col gap-0.5">
+      {backlog.items.map((item) => {
+        const Icon = item.type === "idea.proposed" ? LightbulbIcon : MessageSquareTextIcon;
+
+        return (
+          <div key={item.id} className="flex items-start gap-2 rounded-md border px-3 py-2 text-sm">
+            <Icon className="size-3.5 shrink-0 text-muted-foreground mt-0.5" aria-hidden="true" />
+            <div className="flex-1 min-w-0">
+              <p className="truncate font-medium">{item.title}</p>
+              {item.description && <p className="text-xs text-muted-foreground truncate">{item.description}</p>}
+            </div>
+            <span className="text-xs text-muted-foreground shrink-0">
+              {item.type === "idea.proposed" ? "Idea" : "Request"}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function ChangelogPage() {
+  const params = useParams();
+  const id = Array.isArray(params.id) ? params.id[0] : params.id ?? "";
+
+  const { project: projectBundle, loading: projectLoading } = useProject(id);
+  const { nodes: dataNodes, loading: nodesLoading } = useNodes(id);
+  const { journal, loading: journalLoading } = useJournal(id);
+
+  const nodesById = useMemo(() => new Map(dataNodes.map((node) => [node.id, node])), [dataNodes]);
+
+  const releases = useMemo<ReleaseEntry[]>(() => {
+    const tags = orderEvents(
+      journal.filter((event): event is ReleaseTaggedEvent => event.type === "release.tagged"),
+    );
+    // A re-tagged version resolves to its latest occurrence (computeChangelog's own rule);
+    // keep the last one per version, most-recent release first.
+    const byVersion = new Map<string, ReleaseTaggedEvent>();
+    for (const tag of tags) byVersion.set(tag.version, tag);
+
+    return [...byVersion.values()].reverse().map((tag) => ({
+      tag,
+      changelog: computeChangelog(journal, tag.version, { nodesById }),
+    }));
+  }, [journal, nodesById]);
+
+  const backlog = useMemo(
+    () => computeBacklog(journal, { existingNodeIds: new Set(dataNodes.map((node) => node.id)) }),
+    [journal, dataNodes],
+  );
+
+  if (projectLoading || nodesLoading || journalLoading) {
+    return (
+      <div className="h-full w-full flex items-center justify-center">
+        <span className="text-muted-foreground text-sm">Loading changelog...</span>
+      </div>
+    );
+  }
+
+  const isEmpty = journal.length === 0;
+
+  return (
+    <div className="h-full w-full flex flex-col">
+      <header className="flex h-12 shrink-0 items-center gap-3 border-b bg-background/95 px-3 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+        <SidebarTrigger className="-ml-1 cursor-pointer" />
+        <Separator orientation="vertical" className="mx-1 h-4" />
+        <div className="min-w-0">
+          <p className="truncate text-sm font-medium">{projectBundle?.project.title ?? "Untitled project"}</p>
+          <p className="truncate text-xs text-muted-foreground">Changelog</p>
+        </div>
+        {projectBundle?.project.version && (
+          <div className="ml-auto flex items-center gap-2 text-xs text-muted-foreground">
+            <span>Current version</span>
+            <span className="rounded-full border px-2 py-0.5 font-medium text-foreground">
+              {projectBundle.project.version}
+            </span>
+          </div>
+        )}
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-auto p-4 md:p-6">
+        <div className="mx-auto flex w-full max-w-3xl flex-col gap-8">
+          {isEmpty ? (
+            <div className="rounded-xl border border-dashed p-10 text-center">
+              <p className="text-sm text-muted-foreground">
+                No journal yet. Releases and updates will appear here once history is recorded.
+              </p>
+            </div>
+          ) : (
+            <>
+              <section className="flex flex-col gap-4">
+                <h2 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Releases</h2>
+                {releases.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">No releases tagged yet.</p>
+                ) : (
+                  <div className="flex flex-col gap-6">
+                    {releases.map((entry) => (
+                      <ReleaseCard key={entry.tag.id} entry={entry} nodesById={nodesById} />
+                    ))}
+                  </div>
+                )}
+              </section>
+
+              <section className="flex flex-col gap-3">
+                <h2 className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Backlog</h2>
+                <BacklogList backlog={backlog} />
+              </section>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/project/[id]/layout.tsx
+++ b/app/project/[id]/layout.tsx
@@ -16,7 +16,11 @@ export default function ProjectLayout({
   const id = Array.isArray(params.id) ? params.id[0] : params.id ?? "";
   const { project } = useProject(id);
 
-  const currentView = pathname.startsWith(`/project/${id}/library`) ? "library" : "canvas";
+  const currentView = pathname.startsWith(`/project/${id}/library`)
+    ? "library"
+    : pathname.startsWith(`/project/${id}/changelog`)
+      ? "changelog"
+      : "canvas";
   const currentSpecies = currentView === "library" ? searchParams.get("species") : null;
   const currentQueryString = currentView === "library" ? searchParams.toString() : "";
 

--- a/app/project/[id]/library/page.tsx
+++ b/app/project/[id]/library/page.tsx
@@ -18,6 +18,7 @@ import type { Node as DataNode } from "@/lib/data/types";
 import { useEdges } from "@/lib/hooks/useEdges";
 import { useNodes } from "@/lib/hooks/useNodes";
 import { useProject } from "@/lib/hooks/useProject";
+import { useJournal } from "@/lib/hooks/useJournal";
 import { findWhereUsed } from "@/lib/utils/where-used";
 import { generateNodeId } from "@/lib/utils/id";
 import {
@@ -153,6 +154,7 @@ export default function ProjectLibraryPage() {
   const { nodes: dataNodes, loading: nodesLoading, updateNode, addNode } = useNodes(id);
   const { edges: dataEdges, loading: edgesLoading } = useEdges(id);
   const { project: projectBundle } = useProject(id);
+  const { journal } = useJournal(id);
 
   const nodesById = useMemo(
     () => new Map(dataNodes.map((node) => [node.id, node])),
@@ -338,6 +340,7 @@ export default function ProjectLibraryPage() {
         onUpdate={handleNodeUpdate}
         allNodes={dataNodes}
         allEdges={dataEdges}
+        journal={journal}
         onNavigate={setSelectedNode}
         onCreateNode={handleCreateNodeFromPanel}
       />

--- a/components/journal/describe-event.ts
+++ b/components/journal/describe-event.ts
@@ -1,0 +1,164 @@
+/**
+ * Human-readable rendering of a single journal event — shared by the node
+ * History section (`components/panels/NodeDetailPanel.tsx`) and the
+ * project-level changelog view (`app/project/[id]/changelog/page.tsx`), so the
+ * two read surfaces describe the same event the same way.
+ *
+ * Pure and presentation-only: it never touches the journal projections
+ * themselves (`lib/utils/journal.ts`), only formats one already-selected
+ * event for display.
+ */
+
+import type { LucideIcon } from "lucide-react";
+import {
+  CirclePlus,
+  Pencil,
+  ArrowRightLeft,
+  Trash2,
+  Link2,
+  Unlink,
+  Tag,
+  Lightbulb,
+  MessageSquareText,
+  RefreshCw,
+} from "lucide-react";
+import type { JournalEvent, Node } from "@/lib/data/types";
+import { SPECIES } from "@/lib/config/species";
+import { STATUSES } from "@/lib/config/statuses";
+import { EDGE_TYPES } from "@/lib/config/edge-types";
+import { PLATFORM_LABELS } from "@/components/graph/nodes/node-styles";
+
+const SPECIES_LABEL: Record<string, string> = Object.fromEntries(SPECIES.map((s) => [s.id, s.label]));
+const STATUS_LABEL: Record<string, string> = Object.fromEntries(STATUSES.map((s) => [s.id, s.label]));
+const EDGE_TYPE_LABEL: Record<string, string> = Object.fromEntries(EDGE_TYPES.map((e) => [e.id, e.label]));
+const PLATFORM_LABEL = PLATFORM_LABELS as Record<string, string>;
+
+const EVENT_ICONS: Record<string, LucideIcon> = {
+  "node.created": CirclePlus,
+  "node.updated": Pencil,
+  "node.status_changed": ArrowRightLeft,
+  "node.deleted": Trash2,
+  "edge.added": Link2,
+  "edge.removed": Unlink,
+  "release.tagged": Tag,
+  "idea.proposed": Lightbulb,
+  "request.filed": MessageSquareText,
+  "ref.added": Link2,
+  "ref.removed": Unlink,
+  "ref.status_changed": RefreshCw,
+};
+
+export interface DescribedEvent {
+  icon: LucideIcon;
+  text: string;
+  meta?: string;
+}
+
+function str(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+/** Resolves a node id to its current title, falling back to the raw id (e.g. a deleted node). */
+function resolveTitle(id: unknown, nodesById?: ReadonlyMap<string, Pick<Node, "title">>): string {
+  const nodeId = str(id);
+  if (nodeId === undefined) return "?";
+  return nodesById?.get(nodeId)?.title ?? nodeId;
+}
+
+export function describeJournalEvent(
+  event: JournalEvent,
+  nodesById?: ReadonlyMap<string, Pick<Node, "title">>,
+): DescribedEvent {
+  const icon = EVENT_ICONS[event.type] ?? Pencil;
+
+  switch (event.type) {
+    case "node.created": {
+      const species = str(event.species);
+      return {
+        icon,
+        text: `${resolveTitle(event.node_id, nodesById)} created`,
+        meta: species ? SPECIES_LABEL[species] ?? species : undefined,
+      };
+    }
+    case "node.updated": {
+      const fields = Array.isArray(event.fields)
+        ? event.fields.filter((f): f is string => typeof f === "string")
+        : [];
+      const from = str(event.from);
+      const to = str(event.to);
+      if (fields.length === 1 && fields[0] === "title" && from !== undefined && to !== undefined) {
+        return { icon, text: `Title changed: "${from}" → "${to}"` };
+      }
+      return {
+        icon,
+        text: `${resolveTitle(event.node_id, nodesById)} updated`,
+        meta: fields.length > 0 ? fields.join(", ") : undefined,
+      };
+    }
+    case "node.status_changed": {
+      const from = str(event.from);
+      const to = str(event.to);
+      const platform = str(event.platform);
+      return {
+        icon,
+        text: `${resolveTitle(event.node_id, nodesById)}: ${from ? STATUS_LABEL[from] ?? from : "?"} → ${to ? STATUS_LABEL[to] ?? to : "?"}`,
+        meta: platform ? PLATFORM_LABEL[platform] ?? platform : undefined,
+      };
+    }
+    case "node.deleted":
+      return { icon, text: `${resolveTitle(event.node_id, nodesById)} deleted` };
+    case "edge.added": {
+      const edgeType = str(event.edge_type);
+      return {
+        icon,
+        text: `${resolveTitle(event.source_id, nodesById)} → ${resolveTitle(event.target_id, nodesById)}`,
+        meta: edgeType ? EDGE_TYPE_LABEL[edgeType] ?? edgeType : undefined,
+      };
+    }
+    case "edge.removed":
+      return { icon, text: "Edge removed" };
+    case "release.tagged": {
+      const version = str(event.version) ?? "?";
+      const platform = str(event.platform);
+      return {
+        icon,
+        text: `Released ${version}`,
+        meta: platform ? PLATFORM_LABEL[platform] ?? platform : undefined,
+      };
+    }
+    case "idea.proposed":
+      return { icon, text: `Idea: ${str(event.title) ?? "Untitled"}` };
+    case "request.filed":
+      return {
+        icon,
+        text: `Request: ${str(event.title) ?? "Untitled"}`,
+        meta: str(event.source),
+      };
+    case "ref.added":
+      return {
+        icon,
+        text: `${resolveTitle(event.node_id, nodesById)}: reference added`,
+        meta: str(event.ref_type),
+      };
+    case "ref.removed":
+      return { icon, text: `${resolveTitle(event.node_id, nodesById)}: reference removed` };
+    case "ref.status_changed": {
+      const from = str(event.from);
+      const to = str(event.to) ?? "?";
+      return {
+        icon,
+        text: `${resolveTitle(event.node_id, nodesById)}: reference ${from ? `${from} → ${to}` : to}`,
+      };
+    }
+    default:
+      // Unknown type — forward-compatible: render the raw type rather than erroring.
+      return { icon, text: event.type };
+  }
+}
+
+/** `ts` formatted as a short date; falls back to the raw string if unparseable. */
+export function formatEventDate(ts: string): string {
+  const date = new Date(ts);
+  if (Number.isNaN(date.getTime())) return ts;
+  return date.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+}

--- a/components/layout/ProjectSidebar.tsx
+++ b/components/layout/ProjectSidebar.tsx
@@ -5,6 +5,7 @@ import {
   BookOpenIcon,
   DatabaseIcon,
   GitBranchIcon,
+  HistoryIcon,
   LayoutPanelTopIcon,
   MonitorIcon,
   ServerIcon,
@@ -31,7 +32,7 @@ import {
 interface ProjectSidebarProps {
   projectId: string;
   currentProjectTitle?: string;
-  currentView: "canvas" | "library";
+  currentView: "canvas" | "library" | "changelog";
   currentSpecies: string | null;
   currentQueryString?: string;
 }
@@ -52,6 +53,7 @@ export function ProjectSidebar({
 }: ProjectSidebarProps) {
   const canvasHref = `/project/${projectId}/canvas`;
   const libraryHref = `/project/${projectId}/library`;
+  const changelogHref = `/project/${projectId}/changelog`;
 
   return (
     <Sidebar collapsible="icon">
@@ -99,6 +101,15 @@ export function ProjectSidebar({
                   </SidebarMenuSubItem>
                 ))}
               </SidebarMenuSub>
+            </SidebarMenuItem>
+
+            <SidebarMenuItem>
+              <SidebarMenuButton asChild isActive={currentView === "changelog"} tooltip="Changelog">
+                <Link href={changelogHref}>
+                  <HistoryIcon />
+                  <span>Changelog</span>
+                </Link>
+              </SidebarMenuButton>
             </SidebarMenuItem>
           </SidebarMenu>
         </SidebarGroup>

--- a/components/layout/ProjectSwitcher.tsx
+++ b/components/layout/ProjectSwitcher.tsx
@@ -23,7 +23,7 @@ import { useProjects } from "@/lib/hooks/useProjects";
 interface ProjectSwitcherProps {
   currentProjectId: string;
   currentProjectTitle?: string;
-  currentView: "canvas" | "library";
+  currentView: "canvas" | "library" | "changelog";
   currentQueryString?: string;
 }
 

--- a/components/panels/NodeDetailPanel.tsx
+++ b/components/panels/NodeDetailPanel.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
 import { X } from "lucide-react";
-import type { Node, Edge, PlaylistEntry } from "@/lib/data/types";
+import type { Node, Edge, JournalEvent, PlaylistEntry } from "@/lib/data/types";
 import type { StatusId } from "@/lib/config/statuses";
 import type { PlatformId } from "@/lib/config/platforms";
 import { SPECIES } from "@/lib/config/species";
@@ -38,6 +38,8 @@ import {
   mergeRollups,
 } from "@/lib/utils/platform-status";
 import { findWhereUsed } from "@/lib/utils/where-used";
+import { computeNodeTimeline } from "@/lib/utils/journal";
+import { describeJournalEvent, formatEventDate } from "@/components/journal/describe-event";
 
 function collectReferencedNodeIds(entries: PlaylistEntry[]): string[] {
   const result: string[] = [];
@@ -120,6 +122,7 @@ interface NodeDetailPanelProps {
   onDelete?: (nodeId: string) => void;
   allNodes?: Node[];
   allEdges?: Edge[];
+  journal?: JournalEvent[];
   onNavigate?: (node: Node) => void;
   onCreateNode?: (species: "flow" | "view", title: string) => Promise<Node>;
   onZoomShot?: (node: Node, platform: PlatformId) => void;
@@ -353,6 +356,44 @@ function ConnectionItem({
   );
 }
 
+interface HistorySectionProps {
+  node: Node;
+  journal: JournalEvent[];
+  allNodes: Node[];
+}
+
+function HistorySection({ node, journal, allNodes }: HistorySectionProps) {
+  const timeline = computeNodeTimeline(journal, node.id);
+
+  if (timeline.length === 0) {
+    return null;
+  }
+
+  const nodesById = new Map(allNodes.map((n) => [n.id, n]));
+
+  return (
+    <div className="px-6 flex flex-col gap-2">
+      <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">History</span>
+      <div className="flex flex-col gap-0.5">
+        {[...timeline].reverse().map((event) => {
+          const { icon: Icon, text, meta } = describeJournalEvent(event, nodesById);
+
+          return (
+            <div key={event.id} className="flex items-start gap-2 rounded-md px-2 py-1.5 text-sm">
+              <Icon className="size-3.5 shrink-0 text-muted-foreground mt-0.5" aria-hidden="true" />
+              <div className="flex-1 min-w-0">
+                <p className="truncate">{text}</p>
+                {meta && <p className="text-xs text-muted-foreground truncate">{meta}</p>}
+              </div>
+              <span className="text-xs text-muted-foreground shrink-0">{formatEventDate(event.ts)}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 interface PlatformVariantsSectionProps {
   node: Node;
   onUpdate?: (id: string, patch: Partial<Omit<Node, "id" | "project_id">>) => Promise<void> | void;
@@ -439,6 +480,7 @@ export function NodeDetailPanel({
   onDelete,
   allNodes,
   allEdges,
+  journal,
   onNavigate,
   onCreateNode,
   onZoomShot,
@@ -522,6 +564,14 @@ export function NodeDetailPanel({
                 allNodes={allNodes}
                 allEdges={allEdges}
                 onNavigate={onNavigate}
+              />
+            )}
+            {journal && (
+              <HistorySection
+                key={`history-${node.id}`}
+                node={node}
+                journal={journal}
+                allNodes={allNodes ?? []}
               />
             )}
           </>


### PR DESCRIPTION
## Summary

Implements the read-only journal surfaces from M2: a per-node history timeline in the detail panel and a project-level changelog view, both rendering the `lib/utils/journal.ts` projections from #204. Rendering only — no app-side event emission (that's M3).

Resolves #205.

## Key Changes

- **`HistorySection` in `components/panels/NodeDetailPanel.tsx`**: mirrors `InvocationSection`/`ConnectionsSection` — same header recipe and container spacing, returns `null` on empty. Renders `computeNodeTimeline(journal, node.id)`, most-recent event first.
- **Changelog route** (`app/project/[id]/changelog/page.tsx`): shows `project.version`, one card per release (via `computeChangelog`, grouping by version so a re-tag resolves to its latest occurrence), and the open backlog (via `computeBacklog`).
- **Navigation**: a `Changelog` item added to `ProjectSidebar`, `currentView` extended to `"canvas" | "library" | "changelog"` in `app/project/[id]/layout.tsx` and threaded through `ProjectSwitcher`.
- **Shared formatter** (`components/journal/describe-event.ts`): a single `describeJournalEvent()` renders every event type (icon + text + meta) consistently between the History section and the changelog view.
- **Wiring**: both `canvas/page.tsx` and `library/page.tsx` now call `useJournal(id)` and pass `journal` into `NodeDetailPanel`.

## Backward compatibility

An absent or empty journal (every seed bundle) renders the existing empty states, never an error: no History section on any node, and the changelog view shows "No journal yet." Verified with `seed/pebbles.json` and `seed/arkaik-self-map.json` in the browser — no console/page errors on canvas, library, or changelog.

## Testing

- `npm run build` — green, `/project/[id]/changelog` compiles as a new route
- `npm run test:journal-projections`, `npm run test:migrate` — pass (untouched, confirming the projections layer is unaffected)
- `npm run lint` — clean (pre-existing warnings only, unrelated to this change)
- Manual verification in a real browser (Playwright + the pre-installed Chromium) with a synthetic journal-bearing bundle: History section renders per-node events in reverse chronological order; the changelog view renders releases with notes/dates/events and the backlog; both seeds render cleanly with an empty-state changelog and no History section


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bc56Pe62GUv4tyztMXLMpb)_