### PR TITLE
M3: Canonical serialization on app export — shared serializeBundle() in @arkaik/schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Schema validator parity tests
         run: npm run test:schema
 
+      - name: Canonical serialization determinism tests
+        run: npm run test:serialize
+
       - name: Ref + version format field tests
         run: npm run test:refs
 

--- a/app/project/[id]/canvas/page.tsx
+++ b/app/project/[id]/canvas/page.tsx
@@ -23,6 +23,7 @@ import { useProject } from "@/lib/hooks/useProject";
 import { useJournal } from "@/lib/hooks/useJournal";
 import { useKeyboardShortcuts } from "@/lib/hooks/useKeyboardShortcuts";
 import { parseAndValidateBundle, downloadJson, exportProject, importProject, normalizeProjectTimestamps } from "@/lib/utils/export";
+import { serializeBundle } from "@arkaik/schema";
 import { generateNodeId } from "@/lib/utils/id";
 import { wouldCreateCycle } from "@/lib/utils/cycle";
 import type { SpeciesId } from "@/lib/config/species";
@@ -712,7 +713,7 @@ export default function ProjectCanvasPage() {
 
   const rawBaseText = useMemo(() => {
     if (!rawBundle) return "";
-    return rawFormat === "json" ? JSON.stringify(rawBundle, null, 2) : stringifyYaml(rawBundle);
+    return rawFormat === "json" ? serializeBundle(rawBundle) : stringifyYaml(rawBundle);
   }, [rawBundle, rawFormat]);
 
   const rawInitialTexts = useMemo(() => {
@@ -721,7 +722,7 @@ export default function ProjectCanvasPage() {
     }
 
     return {
-      json: JSON.stringify(rawBundle, null, 2),
+      json: serializeBundle(rawBundle),
       yaml: stringifyYaml(rawBundle),
     };
   }, [rawBundle]);
@@ -731,7 +732,7 @@ export default function ProjectCanvasPage() {
   const rawHasUnsavedChanges = rawDraftJson !== rawInitialTexts.json || rawDraftYaml !== rawInitialTexts.yaml;
 
   const syncRawDrafts = useCallback((bundle: ProjectBundle) => {
-    setRawDraftJson(JSON.stringify(bundle, null, 2));
+    setRawDraftJson(serializeBundle(bundle));
     setRawDraftYaml(stringifyYaml(bundle));
   }, []);
 
@@ -819,7 +820,7 @@ export default function ProjectCanvasPage() {
 
     try {
       const parsed = parseDraftToBundle(rawDraftText, rawFormat);
-      setRawDraftJson(JSON.stringify(parsed, null, 2));
+      setRawDraftJson(serializeBundle(parsed));
       setRawDraftYaml(stringifyYaml(parsed));
       setRawFormat(nextFormat);
       setRawError(null);

--- a/lib/utils/export.ts
+++ b/lib/utils/export.ts
@@ -1,5 +1,5 @@
 import type { Project, ProjectBundle } from "@/lib/data/types";
-import { parseBundle, validateBundle, type ValidationFinding } from "@arkaik/schema";
+import { parseBundle, serializeBundle, validateBundle, type ValidationFinding } from "@arkaik/schema";
 import { localProvider } from "@/lib/data/local-provider";
 
 const MAX_RECOMMENDED_EXPORT_BYTES = 4 * 1024 * 1024;
@@ -91,7 +91,7 @@ function rewriteBundleProjectId(bundle: ProjectBundle, newProjectId: string): Pr
 }
 
 export function exportToJson(bundle: ProjectBundle): string {
-  return JSON.stringify(bundle, null, 2);
+  return serializeBundle(bundle);
 }
 
 function sanitizeFilenameSegment(input: string): string {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "validate:seeds": "node docs/arkaik-skill/scripts/validate-bundle.js seed/pebbles.json && node docs/arkaik-skill/scripts/validate-bundle.js seed/arkaik-self-map.json && node docs/arkaik-skill/scripts/validate-bundle.js public/schema/example-bundle.json",
     "test:fixtures": "node tests/fixtures/run-fixture-tests.js",
     "test:schema": "node tests/schema/parity.test.js",
+    "test:serialize": "node tests/schema/serialize.test.js",
     "test:refs": "node tests/schema/refs.test.js",
     "test:journal": "node tests/schema/journal.test.js",
     "test:journal-projections": "node tests/data/journal-projections.test.js",

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -5,3 +5,4 @@ export * from "./journal-events";
 export * from "./bundle";
 export * from "./validate";
 export * from "./parse";
+export * from "./serialize";

--- a/packages/schema/src/serialize.ts
+++ b/packages/schema/src/serialize.ts
@@ -1,0 +1,167 @@
+import type { ProjectBundle } from "./bundle";
+
+/**
+ * Canonical serialization for Arkaik ProjectBundles
+ * (docs/spec/bundle-format.md § Canonical Serialization).
+ *
+ * So bundles diff and merge cleanly in git, writers emit a canonical form:
+ *  - UTF-8, LF line endings, 2-space indentation, trailing newline;
+ *  - top-level key order `schema_version, project, nodes, edges, journal`,
+ *    with any other/unknown top-level keys kept AFTER these, codepoint-sorted;
+ *  - `nodes` and `edges` sorted by `id` (codepoint ascending);
+ *  - object keys emitted in the schema field order (Node/Edge/Project/
+ *    ProjectBundle), with unknown fields after the known ones, codepoint-sorted.
+ *
+ * Deliberately zod-free (only plain field-order lists, no schema imports): the
+ * module stays bundleable into the standalone validator, mirroring validate.ts.
+ * All unknown/catchall keys are preserved — nothing is silently stripped
+ * (docs/spec/bundle-format.md § Schema Versioning).
+ */
+
+/**
+ * Schema field orders, mirroring the zod object schemas in bundle.ts. Kept as
+ * hardcoded lists (like scripts/generate/generate-json-schema.js does for the
+ * JSON Schema key order) and verified against bundle.ts:
+ *  - ProjectBundleSchema (bundle.ts ~218): schema_version, project, nodes, edges, journal
+ *  - ProjectSchema       (bundle.ts ~189): id, title, description, version,
+ *                                          root_node_id, metadata, created_at,
+ *                                          updated_at, archived_at
+ *  - NodeSchema          (bundle.ts ~131): id, project_id, species, title,
+ *                                          description, status, platforms, metadata
+ *  - EdgeSchema          (bundle.ts ~151): id, project_id, source_id, target_id,
+ *                                          edge_type, metadata
+ */
+const BUNDLE_KEY_ORDER: readonly string[] = ["schema_version", "project", "nodes", "edges", "journal"];
+const PROJECT_KEY_ORDER: readonly string[] = [
+  "id",
+  "title",
+  "description",
+  "version",
+  "root_node_id",
+  "metadata",
+  "created_at",
+  "updated_at",
+  "archived_at",
+];
+const NODE_KEY_ORDER: readonly string[] = [
+  "id",
+  "project_id",
+  "species",
+  "title",
+  "description",
+  "status",
+  "platforms",
+  "metadata",
+];
+const EDGE_KEY_ORDER: readonly string[] = [
+  "id",
+  "project_id",
+  "source_id",
+  "target_id",
+  "edge_type",
+  "metadata",
+];
+
+/**
+ * Raw codepoint comparison via `<`/`>` on the string (NOT `localeCompare`,
+ * whose locale-aware collation is neither stable across environments nor the
+ * ordering the spec calls for).
+ */
+function codepointCompare(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Emission order for an object's own keys: the `known` schema fields that are
+ * present (in schema order) first, then every remaining key codepoint-sorted.
+ */
+function emissionOrder(keys: string[], known: readonly string[]): string[] {
+  const present = new Set(keys);
+  const ordered = known.filter((k) => present.has(k));
+  const orderedSet = new Set(ordered);
+  const rest = keys.filter((k) => !orderedSet.has(k)).sort(codepointCompare);
+  return [...ordered, ...rest];
+}
+
+/**
+ * Canonicalize a nested value (metadata, journal entries, unknown subtrees):
+ * object keys are codepoint-sorted, arrays keep their order, primitives pass
+ * through untouched. No schema field order applies below the top-level
+ * entities.
+ */
+function canonicalizeNested(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalizeNested);
+  if (isPlainObject(value)) {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value).sort(codepointCompare)) {
+      out[key] = canonicalizeNested(value[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Canonicalize an object that has a known schema field order (Project, Node,
+ * Edge): known fields first in schema order, remaining fields codepoint-sorted;
+ * each value canonicalized as a nested value.
+ */
+function canonicalizeOrdered(obj: Record<string, unknown>, known: readonly string[]): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const key of emissionOrder(Object.keys(obj), known)) {
+    out[key] = canonicalizeNested(obj[key]);
+  }
+  return out;
+}
+
+function idOf(item: unknown): string {
+  if (isPlainObject(item) && typeof item.id === "string") return item.id;
+  return "";
+}
+
+/**
+ * Canonicalize the `nodes`/`edges` arrays: order each element's keys by the
+ * given schema field order, then sort the array by `id` (raw codepoint
+ * comparison). The sort is stable, so entries with equal ids keep their
+ * relative order.
+ */
+function canonicalizeSortedEntities(value: unknown, known: readonly string[]): unknown {
+  if (!Array.isArray(value)) return canonicalizeNested(value);
+  const items = value.map((item) =>
+    isPlainObject(item) ? canonicalizeOrdered(item, known) : canonicalizeNested(item),
+  );
+  items.sort((a, b) => codepointCompare(idOf(a), idOf(b)));
+  return items;
+}
+
+function canonicalizeBundle(bundle: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const key of emissionOrder(Object.keys(bundle), BUNDLE_KEY_ORDER)) {
+    const value = bundle[key];
+    if (key === "project") {
+      out[key] = isPlainObject(value) ? canonicalizeOrdered(value, PROJECT_KEY_ORDER) : canonicalizeNested(value);
+    } else if (key === "nodes") {
+      out[key] = canonicalizeSortedEntities(value, NODE_KEY_ORDER);
+    } else if (key === "edges") {
+      out[key] = canonicalizeSortedEntities(value, EDGE_KEY_ORDER);
+    } else {
+      // schema_version, journal (array order preserved — its ts-then-id
+      // ordering is owned elsewhere), and any unknown top-level keys.
+      out[key] = canonicalizeNested(value);
+    }
+  }
+  return out;
+}
+
+/**
+ * Serialize a {@link ProjectBundle} to its canonical JSON string: 2-space
+ * indent, LF newlines, trailing newline. Pure string/object operations — safe
+ * in the browser and in a bundler-free Node loader alike.
+ */
+export function serializeBundle(bundle: ProjectBundle): string {
+  return JSON.stringify(canonicalizeBundle(bundle as unknown as Record<string, unknown>), null, 2) + "\n";
+}

--- a/scripts/generate/load-schema-package.js
+++ b/scripts/generate/load-schema-package.js
@@ -16,7 +16,7 @@ const SCHEMA_DIR = path.join(__dirname, "..", "..", "packages", "schema");
 const SRC_DIR = path.join(SCHEMA_DIR, "src");
 const BUILD_DIR = path.join(SCHEMA_DIR, ".generate-build");
 
-const MODULES = ["ids", "enums", "playlist", "journal", "journal-events", "bundle", "validate", "parse", "index"];
+const MODULES = ["ids", "enums", "playlist", "journal", "journal-events", "bundle", "validate", "parse", "serialize", "index"];
 
 function loadSchemaPackage() {
   fs.rmSync(BUILD_DIR, { recursive: true, force: true });

--- a/tests/schema/load-schema.js
+++ b/tests/schema/load-schema.js
@@ -16,7 +16,7 @@ const BUILD_DIR = path.join(SCHEMA_DIR, ".test-build");
 
 // Order does not matter for output — CommonJS resolves requires lazily — but we
 // transpile every module the entrypoint depends on.
-const MODULES = ["ids", "enums", "playlist", "journal", "journal-events", "bundle", "validate", "parse", "index"];
+const MODULES = ["ids", "enums", "playlist", "journal", "journal-events", "bundle", "validate", "parse", "serialize", "index"];
 
 function loadSchema() {
   fs.rmSync(BUILD_DIR, { recursive: true, force: true });

--- a/tests/schema/serialize.test.js
+++ b/tests/schema/serialize.test.js
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+
+/**
+ * Exercises the canonical bundle serializer `serializeBundle()`
+ * (docs/spec/bundle-format.md § Canonical Serialization, issue #216).
+ *
+ * Covers:
+ *  - formatting: LF newlines, 2-space indent, trailing newline;
+ *  - top-level key order (schema_version, project, nodes, edges, journal) with
+ *    unknown top-level keys kept after these, codepoint-sorted;
+ *  - nodes/edges sorted by id via raw codepoint comparison (not localeCompare);
+ *  - object field order from the schema, with unknown fields after the known
+ *    ones, codepoint-sorted, and never stripped;
+ *  - journal[] array order is preserved (not re-sorted by a bundle-level key);
+ *  - idempotence: serialize(JSON.parse(serialize(x))) === serialize(x);
+ *  - order-independence: shuffling nodes/edges yields identical output.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const { loadSchema, BUILD_DIR } = require("./load-schema");
+
+const ROOT = path.join(__dirname, "..", "..");
+
+function shuffleReverse(arr) {
+  return arr.slice().reverse();
+}
+
+function shuffleRotate(arr) {
+  if (arr.length < 2) return arr.slice();
+  return [...arr.slice(1), arr[0]];
+}
+
+function main() {
+  const { serializeBundle } = loadSchema();
+  let failures = 0;
+  const assert = (cond, message) => {
+    if (!cond) {
+      failures++;
+      console.log(`FAIL: ${message}`);
+    } else {
+      console.log(`PASS: ${message}`);
+    }
+  };
+
+  // --- Real seed: formatting + idempotence + order-independence ---------------
+  const seed = JSON.parse(fs.readFileSync(path.join(ROOT, "seed", "pebbles.json"), "utf8"));
+  const seedOut = serializeBundle(seed);
+
+  assert(seedOut.endsWith("\n"), "seed: output ends with a trailing newline");
+  assert(!seedOut.includes("\r"), "seed: output uses LF line endings (no CR)");
+  assert(/\n {2}"project":/.test(seedOut), "seed: 2-space indent at top level");
+
+  // Idempotence — serializing already-canonical JSON is a fixed point.
+  assert(
+    serializeBundle(JSON.parse(seedOut)) === seedOut,
+    "seed: idempotent (serialize(parse(serialize(x))) === serialize(x))",
+  );
+
+  // Order-independence — shuffling nodes/edges must not change the output.
+  const shuffled = {
+    ...seed,
+    nodes: shuffleReverse(seed.nodes),
+    edges: shuffleRotate(seed.edges),
+  };
+  assert(
+    serializeBundle(shuffled) === seedOut,
+    "seed: shuffling nodes/edges yields byte-identical output",
+  );
+
+  // nodes/edges are emitted sorted by id (codepoint ascending).
+  const seedParsed = JSON.parse(seedOut);
+  const nodeIds = seedParsed.nodes.map((n) => n.id);
+  const edgeIds = seedParsed.edges.map((e) => e.id);
+  const isCodepointSorted = (ids) => ids.every((id, i) => i === 0 || ids[i - 1] <= id);
+  assert(isCodepointSorted(nodeIds), "seed: nodes sorted by id (codepoint ascending)");
+  assert(isCodepointSorted(edgeIds), "seed: edges sorted by id (codepoint ascending)");
+
+  // --- Inline bundle: raw codepoint order, unknown keys, journal order --------
+  const inline = {
+    // Deliberately out of canonical order to prove reordering.
+    edges: [],
+    zeta_extra: "z-top",
+    project: {
+      updated_at: "2026-01-02T00:00:00.000Z",
+      created_at: "2026-01-01T00:00:00.000Z",
+      title: "Inline",
+      id: "inline",
+      forward_compat: "kept",
+    },
+    schema_version: 2,
+    alpha_extra: { keep: true },
+    nodes: [
+      // 'a' (0x61) vs 'B' (0x42): codepoint puts uppercase B before lowercase a,
+      // whereas a locale-aware compare would typically order 'a' first.
+      {
+        id: "N-a",
+        project_id: "inline",
+        species: "view",
+        title: "lower a",
+        status: "idea",
+        platforms: ["web"],
+        zzz_unknown: 1,
+        aaa_unknown: 2,
+      },
+      {
+        id: "N-B",
+        project_id: "inline",
+        species: "view",
+        title: "upper B",
+        status: "idea",
+        platforms: ["web"],
+      },
+    ],
+    journal: [
+      { id: "01B", ts: "2026-01-02T00:00:00.000Z", type: "node.created" },
+      { id: "01A", ts: "2026-01-01T00:00:00.000Z", type: "node.created" },
+    ],
+  };
+
+  const inlineOut = serializeBundle(inline);
+  const inlineParsed = JSON.parse(inlineOut);
+
+  // Top-level key order: known keys first (present ones), then unknown keys
+  // codepoint-sorted (alpha_extra before zeta_extra).
+  assert(
+    JSON.stringify(Object.keys(inlineParsed)) ===
+      JSON.stringify(["schema_version", "project", "nodes", "edges", "journal", "alpha_extra", "zeta_extra"]),
+    "inline: top-level key order (schema keys, then unknown codepoint-sorted)",
+  );
+  assert(
+    inlineParsed.zeta_extra === "z-top" && inlineParsed.alpha_extra.keep === true,
+    "inline: unknown top-level keys preserved (values intact)",
+  );
+
+  // Project key order: known schema order, unknown 'forward_compat' after them.
+  assert(
+    JSON.stringify(Object.keys(inlineParsed.project)) ===
+      JSON.stringify(["id", "title", "created_at", "updated_at", "forward_compat"]),
+    "inline: project keys in schema order, unknown key after and preserved",
+  );
+
+  // Nodes sorted by id via codepoint: 'N-B' before 'N-a'.
+  assert(
+    JSON.stringify(inlineParsed.nodes.map((n) => n.id)) === JSON.stringify(["N-B", "N-a"]),
+    "inline: nodes sorted by raw codepoint (N-B before N-a), not localeCompare",
+  );
+
+  // Node field order: known schema fields first, then unknown fields
+  // codepoint-sorted (aaa_unknown before zzz_unknown), both preserved.
+  const nodeA = inlineParsed.nodes.find((n) => n.id === "N-a");
+  assert(
+    JSON.stringify(Object.keys(nodeA)) ===
+      JSON.stringify([
+        "id",
+        "project_id",
+        "species",
+        "title",
+        "status",
+        "platforms",
+        "aaa_unknown",
+        "zzz_unknown",
+      ]),
+    "inline: node keys in schema order, unknown fields after and codepoint-sorted",
+  );
+  assert(
+    nodeA.aaa_unknown === 2 && nodeA.zzz_unknown === 1,
+    "inline: unknown node fields preserved (not stripped)",
+  );
+
+  // journal[] keeps its original array order (NOT re-sorted by a bundle key).
+  assert(
+    JSON.stringify(inlineParsed.journal.map((j) => j.id)) === JSON.stringify(["01B", "01A"]),
+    "inline: journal array order preserved (not re-sorted)",
+  );
+
+  // Idempotence + order-independence on the inline bundle too.
+  assert(serializeBundle(JSON.parse(inlineOut)) === inlineOut, "inline: idempotent");
+  assert(
+    serializeBundle({ ...inline, nodes: shuffleReverse(inline.nodes) }) === inlineOut,
+    "inline: shuffling nodes yields identical output",
+  );
+
+  fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+
+  if (failures > 0) {
+    console.log(`\n${failures} serialize test(s) failed.`);
+    process.exit(1);
+  }
+  console.log("\nAll serialize tests passed.");
+}
+
+main();


### PR DESCRIPTION
## Summary

Closes #216. Adds a shared canonical bundle serializer to `@arkaik/schema` and routes the app's export + raw-JSON view through it, so bundles diff and merge cleanly in git (`docs/spec/bundle-format.md` § Canonical Serialization). This is the serializer `arkaik validate --fix-format` (#219) and `arkaik pack` (#223) will consume.

## Key Changes

- **`packages/schema/src/serialize.ts`** (new): zod-free `serializeBundle(bundle): string` (type-only `ProjectBundle` import, erased at compile → stays bundleable into the standalone validator). Emits LF + 2-space + trailing newline; top-level key order `schema_version, project, nodes, edges, journal` with any other/unknown top-level keys after these (codepoint-sorted); `nodes`/`edges` sorted by `id` via **raw codepoint** comparison (not `localeCompare`); Node/Edge/Project fields in schema field order (mirroring `bundle.ts`) with unknown fields after (codepoint-sorted); nested objects/`metadata` codepoint-sorted; embedded `journal[]` array order preserved; all unknown/catchall keys preserved (no silent stripping).
- **`packages/schema/src/index.ts`**: re-exports `./serialize`.
- **`lib/utils/export.ts`**: `exportToJson()` routes through `serializeBundle` (was `JSON.stringify(bundle, null, 2)`); the download path emits canonical bytes.
- **`app/project/[id]/canvas/page.tsx`**: the raw-JSON view/draft/format-switch sites use the same serializer, so the raw view and the downloaded file are byte-identical.
- **`tests/schema/serialize.test.js`** (new, `npm run test:serialize`, wired into CI): idempotence (`serialize(parse(serialize(x))) === serialize(x)`), order-independence (shuffled nodes/edges → identical output), raw codepoint ordering, and unknown top-level-key + unknown-node-field preservation/placement.
- **`tests/schema/load-schema.js`**, **`scripts/generate/load-schema-package.js`**: add `serialize` to the transpiled module list.

## Backward compatibility

The serializer is applied only on **export/raw-view**, never during import/migrate, so `seed/*.json` and `public/schema/example-bundle.json` bytes are unchanged and the byte-for-byte `seed-import` no-op test stays green.

## Test plan

- [x] `npm run generate` → no artifact drift
- [x] `npm run lint`, `npm run build`
- [x] `npm run validate:seeds`
- [x] `test:fixtures`, `test:schema`, **`test:serialize`**, `test:refs`, `test:journal`, `test:journal-projections`, `test:screenshot-size`, `test:migrate` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HE4i4eGXnXqsuLZtQvyKgb

---
_Generated by [Claude Code](https://claude.ai/code/session_01HE4i4eGXnXqsuLZtQvyKgb)_