### PR TITLE
M3: packages/cli scaffold + arkaik validate (--fix-format)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,6 @@ jobs:
 
       - name: Bundle migration chain tests
         run: npm run test:migrate
+
+      - name: CLI tests
+        run: npm run test:cli

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@
 # production
 /build
 
+# esbuild-bundled CLI output (rebuilt on demand by `npm run build -w arkaik`)
+/packages/cli/dist/
+
 # misc
 .DS_Store
 *.pem

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,6 +16,9 @@ const eslintConfig = defineConfig([
     "docs/arkaik-skill/scripts/**",
     "tests/**",
     "scripts/**",
+    // esbuild-bundled CLI output + its Node build script (not app source).
+    "packages/cli/dist/**",
+    "packages/cli/build.js",
   ]),
 ]);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3876,6 +3876,10 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/arkaik": {
+      "resolved": "packages/cli",
+      "link": true
+    },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
@@ -10259,6 +10263,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "packages/cli": {
+      "name": "arkaik",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@arkaik/schema": "*"
+      },
+      "bin": {
+        "arkaik": "dist/index.js"
       }
     },
     "packages/schema": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "test:journal": "node tests/schema/journal.test.js",
     "test:journal-projections": "node tests/data/journal-projections.test.js",
     "test:screenshot-size": "node tests/schema/screenshot-size.test.js",
-    "test:migrate": "node tests/data/migrate.test.js && node tests/data/import-roundtrip.test.js && node tests/data/seed-import.test.js"
+    "test:migrate": "node tests/data/migrate.test.js && node tests/data/import-roundtrip.test.js && node tests/data/seed-import.test.js",
+    "test:cli": "npm run build -w arkaik && node tests/cli/run-cli-tests.js"
   },
   "dependencies": {
     "@radix-ui/react-collapsible": "^1.1.12",

--- a/packages/cli/build.js
+++ b/packages/cli/build.js
@@ -1,0 +1,43 @@
+/**
+ * Build the `arkaik` CLI to dist/index.js.
+ *
+ * Build/run strategy (issue #219, docs/spec/toolchain.md § toolchain): the CLI
+ * source imports validateBundle / parseJournalLines / serializeBundle straight
+ * from `@arkaik/schema` (which ships raw TS), so we esbuild-bundle the entry
+ * into a single zero-dependency Node ESM script — mirroring
+ * scripts/generate/build-validator.js, which bundles the schema package's
+ * validate-bundle CLI the same way. Both the standalone validator and this CLI
+ * are therefore builds of the *same* canonical schema source: no re-implemented
+ * validation/serialization logic, and "neither drifts" (toolchain.md:45) holds.
+ *
+ * dist/ is gitignored and rebuilt on demand (`npm run build -w arkaik`, run by
+ * the root `test:cli` script and CI before the CLI tests spawn the binary).
+ */
+import { build } from "esbuild";
+import { chmodSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const dir = dirname(fileURLToPath(import.meta.url));
+const ENTRY = join(dir, "src", "index.ts");
+const OUT_FILE = join(dir, "dist", "index.js");
+
+async function run() {
+  await build({
+    entryPoints: [ENTRY],
+    outfile: OUT_FILE,
+    bundle: true,
+    platform: "node",
+    target: "node18",
+    format: "esm",
+    legalComments: "none",
+    banner: { js: "#!/usr/bin/env node" },
+  });
+  chmodSync(OUT_FILE, 0o755);
+  console.log(`built ${relative(dir, OUT_FILE)}`);
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "arkaik",
+  "version": "0.1.0",
+  "license": "MIT",
+  "type": "module",
+  "bin": {
+    "arkaik": "dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "node build.js"
+  },
+  "dependencies": {
+    "@arkaik/schema": "*"
+  }
+}

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -1,0 +1,181 @@
+/**
+ * `arkaik validate [--fix-format] [path]`.
+ *
+ * Reuses `@arkaik/schema` directly — validateBundle (semantic graph rules),
+ * parseJournalLines (JSONL sidecar), and serializeBundle (canonical form) — so
+ * there is no re-implemented logic here (docs/spec/toolchain.md § @arkaik/schema).
+ *
+ * The validate path mirrors packages/schema/src/cli/validate-bundle-cli.ts: it
+ * reads the bundle JSON, auto-discovers a sibling `journal.jsonl` sidecar and
+ * folds it in via parseJournalLines when the bundle carries no embedded
+ * journal (docs/spec/journal.md § Canonical), then runs validateBundle and
+ * prints a report over the structured {path, rule, message, severity} findings.
+ * Exit 0 when valid, 1 when invalid; warnings never fail.
+ */
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import {
+  validateBundle,
+  parseJournalLines,
+  serializeBundle,
+  type JournalLineFinding,
+  type ValidationFinding,
+} from "@arkaik/schema";
+
+const JOURNAL_SIDECAR = "journal.jsonl";
+
+const USAGE = `arkaik validate [--fix-format] [path]
+
+Validate a project bundle against the Arkaik schema rules. When the bundle has
+no embedded journal, a sibling journal.jsonl sidecar is folded in before
+validating. Exit 0 when valid, 1 when invalid; warnings never fail.
+
+Arguments:
+  path            Path to the bundle JSON file (required).
+
+Options:
+  --fix-format    Rewrite <path> to canonical serialization (serializeBundle)
+                  in place, instead of validating. Idempotent; preserves
+                  unknown keys/fields. A journal.jsonl sidecar is NOT folded in
+                  — fix-format only touches the bundle file itself.
+  -h, --help      Show this help.`;
+
+function fail(message: string): never {
+  console.error(message);
+  process.exit(1);
+}
+
+/** Read + JSON.parse the bundle at `filePath`, exiting with a FATAL on error. */
+function readBundle(filePath: string): unknown {
+  if (!existsSync(filePath)) fail(`File not found: ${filePath}`);
+  const raw = readFileSync(filePath, "utf8");
+  try {
+    return JSON.parse(raw);
+  } catch (e) {
+    return fail(`FATAL: Cannot parse JSON — ${(e as Error).message}`);
+  }
+}
+
+function countBySpecies(nodes: unknown[], species: string): number {
+  return nodes.filter((n) => (n as { species?: unknown } | null)?.species === species).length;
+}
+
+function formatFinding(f: ValidationFinding): string {
+  const where = f.path ? ` ${f.path}` : "";
+  return `${f.severity.toUpperCase()} [${f.rule}]${where}: ${f.message}`;
+}
+
+/** `--fix-format`: rewrite the bundle file to canonical serialization in place. */
+function fixFormat(filePath: string): never {
+  const bundle = readBundle(filePath);
+  if (typeof bundle !== "object" || bundle === null || Array.isArray(bundle)) {
+    fail("FATAL: Bundle must be a JSON object.");
+  }
+  const before = readFileSync(filePath, "utf8");
+  // serializeBundle preserves unknown top-level keys (schema_version, journal)
+  // and unknown fields, and is idempotent — running twice yields no change.
+  const after = serializeBundle(bundle as Parameters<typeof serializeBundle>[0]);
+  if (after === before) {
+    console.log(`Already canonical: ${filePath}`);
+  } else {
+    writeFileSync(filePath, after);
+    console.log(`Reformatted: ${filePath}`);
+  }
+  process.exit(0);
+}
+
+/** `validate`: validate the bundle (+ sidecar journal) and report findings. */
+function validate(filePath: string): never {
+  const bundle = readBundle(filePath);
+
+  const loose = bundle as
+    | { project?: unknown; nodes?: unknown; edges?: unknown; journal?: unknown }
+    | null;
+  if (typeof loose !== "object" || loose === null || !loose.project || !loose.nodes || !loose.edges) {
+    fail("FATAL: Missing top-level keys (project, nodes, edges).");
+  }
+
+  // Fold in the canonical JSONL sidecar when the bundle carries no embedded
+  // journal. An embedded `journal` (the packed interchange form) always wins.
+  let sidecarFindings: JournalLineFinding[] = [];
+  let sidecarLoaded = false;
+  if (loose.journal === undefined) {
+    const sidecarPath = join(dirname(filePath), JOURNAL_SIDECAR);
+    if (existsSync(sidecarPath)) {
+      const { events, findings } = parseJournalLines(readFileSync(sidecarPath, "utf8"));
+      sidecarFindings = findings;
+      sidecarLoaded = true;
+      loose.journal = events;
+    }
+  }
+
+  const nodes = Array.isArray(loose.nodes) ? loose.nodes : [];
+  const edges = Array.isArray(loose.edges) ? loose.edges : [];
+  const journal = Array.isArray(loose.journal) ? loose.journal : [];
+  const result = validateBundle(bundle);
+
+  console.log("\n  Arkaik Bundle Validation");
+  console.log("  =======================\n");
+  console.log(
+    `  Nodes: ${nodes.length} (${countBySpecies(nodes, "view")} views, ${countBySpecies(nodes, "flow")} flows, ${countBySpecies(nodes, "data-model")} data-models, ${countBySpecies(nodes, "api-endpoint")} api-endpoints)`,
+  );
+  console.log(`  Edges: ${edges.length}`);
+  if (sidecarLoaded) {
+    console.log(`  Journal: ${journal.length} event(s) from ${JOURNAL_SIDECAR} sidecar`);
+  } else if (journal.length > 0) {
+    console.log(`  Journal: ${journal.length} embedded event(s)`);
+  }
+  console.log("");
+
+  if (result.warnings.length > 0) {
+    console.log(`  Warnings: ${result.warnings.length}`);
+    result.warnings.forEach((w) => console.log(`    ${formatFinding(w)}`));
+    console.log("");
+  }
+
+  // Sidecar line-parse findings are hard errors, joined with the semantic
+  // errors from validateBundle.
+  const errorLines = [
+    ...sidecarFindings.map((f) => `ERROR [${f.rule}] line ${f.line}: ${f.message}`),
+    ...result.errors.map(formatFinding),
+  ];
+
+  if (errorLines.length === 0) {
+    console.log("  Result: VALID\n");
+    process.exit(0);
+  }
+
+  console.log(`  Errors: ${errorLines.length}`);
+  errorLines.forEach((m) => console.log(`    ${m}`));
+  console.log("\n  Result: INVALID\n");
+  process.exit(1);
+}
+
+export function runValidate(args: string[]): void {
+  let fixFormatFlag = false;
+  const positionals: string[] = [];
+
+  for (const arg of args) {
+    if (arg === "-h" || arg === "--help") {
+      console.log(USAGE);
+      process.exit(0);
+    } else if (arg === "--fix-format") {
+      fixFormatFlag = true;
+    } else if (arg.startsWith("-")) {
+      fail(`Unknown option: ${arg}\n\n${USAGE}`);
+    } else {
+      positionals.push(arg);
+    }
+  }
+
+  const filePath = positionals[0];
+  if (filePath === undefined) {
+    fail(`Missing bundle path.\n\n${USAGE}`);
+  }
+
+  if (fixFormatFlag) {
+    fixFormat(filePath);
+  } else {
+    validate(filePath);
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,46 @@
+/**
+ * `arkaik` CLI entry point.
+ *
+ * A tiny hand-rolled command dispatcher — deliberately dependency-free (no
+ * commander/yargs). Each command owns its own flag parsing so later commands
+ * (init/log/release/sync/pack/open — separate issues) slot in by adding a
+ * `case` here and a handler module under `./commands`.
+ *
+ * All schema behaviour is reused verbatim from `@arkaik/schema`; the commands
+ * never re-implement validation or serialization.
+ */
+import { runValidate } from "./commands/validate";
+
+const USAGE = `arkaik — CLI for Arkaik project bundles
+
+Usage:
+  arkaik <command> [options]
+
+Commands:
+  validate [path]   Validate a project bundle (folds in a journal.jsonl sidecar).
+
+Options:
+  -h, --help        Show this help.
+
+Run "arkaik <command> --help" for command-specific help.`;
+
+function main(argv: string[]): void {
+  const [command, ...rest] = argv;
+
+  if (command === undefined || command === "--help" || command === "-h" || command === "help") {
+    console.log(USAGE);
+    process.exit(0);
+  }
+
+  switch (command) {
+    case "validate":
+      runValidate(rest);
+      return;
+    default:
+      console.error(`Unknown command: ${command}\n`);
+      console.error(USAGE);
+      process.exit(1);
+  }
+}
+
+main(process.argv.slice(2));

--- a/tests/cli/fixtures/unsorted-bundle.json
+++ b/tests/cli/fixtures/unsorted-bundle.json
@@ -1,0 +1,34 @@
+{
+  "journal": [
+    { "id": "01J9ZK4E4N0000000000000001", "ts": "2026-01-01T00:00:00.000Z", "actor": "claude-code", "type": "node.created", "node_id": "V-home", "species": "view", "title": "Home" }
+  ],
+  "edges": [],
+  "nodes": [
+    {
+      "title": "Zebra",
+      "id": "V-zebra",
+      "project_id": "unsorted",
+      "species": "view",
+      "status": "idea",
+      "platforms": ["web"],
+      "custom_node_field": "kept"
+    },
+    {
+      "id": "V-home",
+      "project_id": "unsorted",
+      "species": "view",
+      "title": "Home",
+      "status": "idea",
+      "platforms": ["web"]
+    }
+  ],
+  "schema_version": 2,
+  "project": {
+    "title": "Unsorted",
+    "id": "unsorted",
+    "version": "1.0.0",
+    "created_at": "2026-01-01T00:00:00.000Z",
+    "updated_at": "2026-01-01T00:00:00.000Z"
+  },
+  "custom_top_level": { "z": 1, "a": 2 }
+}

--- a/tests/cli/run-cli-tests.js
+++ b/tests/cli/run-cli-tests.js
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+
+/**
+ * Spawns the built `arkaik` CLI (packages/cli/dist/index.js) against fixtures
+ * and asserts exit codes + output — mirroring tests/fixtures/run-fixture-tests.js.
+ *
+ * The CLI must be built first (`npm run build -w arkaik`); the root `test:cli`
+ * script does that before invoking this runner.
+ *
+ * Covers:
+ *  - `arkaik validate <path>` behaves like the standalone validate-bundle.js
+ *    (valid/invalid + sidecar cases), exiting 0/1 with a pathed error report.
+ *  - `arkaik validate --fix-format` canonicalizes in place, is idempotent, and
+ *    round-trips embedded journal / schema_version / unknown keys+fields.
+ */
+
+const { spawnSync } = require("child_process");
+const { existsSync, readFileSync, writeFileSync, mkdtempSync, copyFileSync } = require("fs");
+const { tmpdir } = require("os");
+const path = require("path");
+
+const ROOT = path.join(__dirname, "..", "..");
+const CLI = path.join(ROOT, "packages", "cli", "dist", "index.js");
+const FIXTURES = path.join(ROOT, "tests", "fixtures");
+const CLI_FIXTURES = path.join(__dirname, "fixtures");
+
+if (!existsSync(CLI)) {
+  console.error(`CLI not built at ${CLI}. Run \`npm run build -w arkaik\` first.`);
+  process.exit(1);
+}
+
+function runCli(args) {
+  return spawnSync(process.execPath, [CLI, ...args], { encoding: "utf8" });
+}
+
+let failures = 0;
+let passes = 0;
+
+function check(name, cond, detail) {
+  if (cond) {
+    passes++;
+    console.log(`PASS: ${name}`);
+  } else {
+    failures++;
+    console.log(`FAIL: ${name}`);
+    if (detail) console.log(detail);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// validate: exit-code parity with the standalone validator, incl. sidecars.
+// ---------------------------------------------------------------------------
+const VALIDATE_CASES = [
+  { file: "valid-bundle.json", expectValid: true },
+  { file: "valid-level2.json", expectValid: true },
+  { file: "duplicate-node-id.json", expectValid: false },
+  { file: "dangling-edge.json", expectValid: false },
+  { file: "sidecar-valid/bundle.json", expectValid: true },
+  { file: "sidecar-mismatch/bundle.json", expectValid: false },
+  { file: "sidecar-bad-line/bundle.json", expectValid: false },
+];
+
+for (const { file, expectValid } of VALIDATE_CASES) {
+  const result = runCli(["validate", path.join(FIXTURES, file)]);
+  const isValid = result.status === 0;
+  check(
+    `validate ${file} -> ${expectValid ? "valid" : "invalid"}`,
+    isValid === expectValid,
+    `exit=${result.status}\n${result.stdout}\n${result.stderr}`,
+  );
+}
+
+// A known-invalid bundle must surface a *pathed* error (JSON path in output).
+{
+  const result = runCli(["validate", path.join(FIXTURES, "duplicate-node-id.json")]);
+  check(
+    "validate duplicate-node-id emits a pathed error",
+    result.status === 1 && /nodes\[/.test(result.stdout),
+    `exit=${result.status}\n${result.stdout}`,
+  );
+}
+
+// Missing path is a usage error (exit 1).
+{
+  const result = runCli(["validate"]);
+  check("validate with no path -> exit 1", result.status === 1);
+}
+
+// Top-level help exits 0.
+{
+  const result = runCli(["--help"]);
+  check("--help -> exit 0", result.status === 0 && /Usage:/.test(result.stdout));
+}
+
+// Unknown command exits 1.
+{
+  const result = runCli(["frobnicate"]);
+  check("unknown command -> exit 1", result.status === 1);
+}
+
+// ---------------------------------------------------------------------------
+// validate --fix-format: canonicalize in place, idempotent, lossless round-trip.
+// ---------------------------------------------------------------------------
+{
+  const dir = mkdtempSync(path.join(tmpdir(), "arkaik-cli-"));
+  const target = path.join(dir, "bundle.json");
+  copyFileSync(path.join(CLI_FIXTURES, "unsorted-bundle.json"), target);
+
+  const original = readFileSync(target, "utf8");
+  const first = runCli(["validate", "--fix-format", target]);
+  const afterFirst = readFileSync(target, "utf8");
+
+  check("fix-format exits 0", first.status === 0);
+  check("fix-format changed the unsorted file", afterFirst !== original);
+
+  // Idempotence: a second run makes no further change.
+  const second = runCli(["validate", "--fix-format", target]);
+  const afterSecond = readFileSync(target, "utf8");
+  check("fix-format is idempotent (2nd run no-op)", second.status === 0 && afterSecond === afterFirst);
+
+  // Canonical shape: trailing newline, top-level key order, nodes sorted by id.
+  check("fix-format output ends with newline", afterFirst.endsWith("\n"));
+  const parsed = JSON.parse(afterFirst);
+  const topKeys = Object.keys(parsed);
+  check(
+    "fix-format top-level key order is canonical",
+    JSON.stringify(topKeys) ===
+      JSON.stringify(["schema_version", "project", "nodes", "edges", "journal", "custom_top_level"]),
+    `got ${JSON.stringify(topKeys)}`,
+  );
+  check(
+    "fix-format sorts nodes by id",
+    parsed.nodes.map((n) => n.id).join(",") === "V-home,V-zebra",
+    `got ${parsed.nodes.map((n) => n.id).join(",")}`,
+  );
+
+  // Lossless round-trip: embedded journal, schema_version, unknown top-level
+  // key, and unknown node field all survive.
+  check("fix-format keeps schema_version", parsed.schema_version === 2);
+  check("fix-format keeps embedded journal", Array.isArray(parsed.journal) && parsed.journal.length === 1);
+  check(
+    "fix-format keeps unknown top-level key",
+    parsed.custom_top_level && parsed.custom_top_level.a === 2 && parsed.custom_top_level.z === 1,
+  );
+  const zebra = parsed.nodes.find((n) => n.id === "V-zebra");
+  check("fix-format keeps unknown node field", zebra && zebra.custom_node_field === "kept");
+
+  // fix-format must NOT fold a sidecar into the bundle file. Run it on a copy of
+  // the sidecar fixture (which has NO embedded journal) and confirm the file
+  // still carries no `journal` key afterward.
+  const scDir = mkdtempSync(path.join(tmpdir(), "arkaik-cli-sc-"));
+  const scTarget = path.join(scDir, "bundle.json");
+  copyFileSync(path.join(FIXTURES, "sidecar-valid", "bundle.json"), scTarget);
+  copyFileSync(path.join(FIXTURES, "sidecar-valid", "journal.jsonl"), path.join(scDir, "journal.jsonl"));
+  runCli(["validate", "--fix-format", scTarget]);
+  const scParsed = JSON.parse(readFileSync(scTarget, "utf8"));
+  check("fix-format does not fold sidecar into the bundle", scParsed.journal === undefined);
+}
+
+console.log(`\n${passes} passed, ${failures} failed.`);
+process.exit(failures > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

Closes #219. Adds the MIT `arkaik` CLI package (`packages/cli`) with its first command — `validate` — and the command-dispatch skeleton the remaining commands (`init`, `log`/`release`, `sync`, `pack`/`open`) will extend. `validate` reuses `@arkaik/schema` directly, so the CLI and the standalone `validate-bundle.js` are two builds of the same source (`docs/spec/toolchain.md:45`, "neither drifts").

## Key Changes

- **`packages/cli`** (new, MIT): `name: "arkaik"`, `bin: arkaik → dist/index.js`, depends on `@arkaik/schema`. `src/index.ts` is a minimal arg parser + command dispatch (`--help`); `src/commands/validate.ts` is the first command.
- **`arkaik validate [path]`**: reads the bundle, auto-discovers a sibling `journal.jsonl` sidecar and folds it in (like `packages/schema/src/cli/validate-bundle-cli.ts`), runs `validateBundle`, prints `SEVERITY [rule] path: message` findings, exits 0 (valid) / 1 (invalid). Warnings never fail.
- **`arkaik validate --fix-format [path]`**: rewrites the file to canonical form via `serializeBundle` (#216) — idempotent, round-trips unknown top-level keys (`schema_version`, `journal`) and unknown fields, and leaves the sidecar untouched.
- **Build strategy**: esbuild bundles `src/index.ts → dist/index.js` (`packages/cli/build.js`, mirroring `scripts/generate/build-validator.js`). `dist/` is gitignored and rebuilt on demand; `eslint` ignores `dist/` + `build.js` but lints CLI `src/*.ts`.
- **`tests/cli/`** (new, `npm run test:cli`, wired into CI): builds the CLI, then spawns the binary — valid→0, invalid (duplicate node id)→1 with a pathed error, sidecar valid/mismatch/bad-line parity, `--help`/missing-arg/unknown-command, and `--fix-format` idempotence + lossless round-trip.
- **`package-lock.json`**: registers the `arkaik` workspace (no runtime deps beyond `@arkaik/schema`).

## Test plan

- [x] `npm run generate` → no artifact drift
- [x] `npm run lint`, `npm run build` (Next app unaffected — CLI isn't imported by the app)
- [x] `npm run validate:seeds`
- [x] `test:fixtures`, `test:schema`, `test:serialize`, `test:refs`, `test:journal`, `test:journal-projections`, `test:screenshot-size`, `test:migrate`, **`test:cli`** (22 assertions) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HE4i4eGXnXqsuLZtQvyKgb

---
_Generated by [Claude Code](https://claude.ai/code/session_01HE4i4eGXnXqsuLZtQvyKgb)_