### PR TITLE
M3: arkaik init — scaffold docs/arkaik/, render the skill, --update

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:journal-projections": "node tests/data/journal-projections.test.js",
     "test:screenshot-size": "node tests/schema/screenshot-size.test.js",
     "test:migrate": "node tests/data/migrate.test.js && node tests/data/import-roundtrip.test.js && node tests/data/seed-import.test.js",
-    "test:cli": "npm run build -w arkaik && node tests/cli/run-cli-tests.js"
+    "test:cli": "npm run build -w arkaik && node tests/cli/run-cli-tests.js && node tests/cli/init.test.js"
   },
   "dependencies": {
     "@radix-ui/react-collapsible": "^1.1.12",

--- a/packages/cli/build.js
+++ b/packages/cli/build.js
@@ -10,17 +10,37 @@
  * are therefore builds of the *same* canonical schema source: no re-implemented
  * validation/serialization logic, and "neither drifts" (toolchain.md:45) holds.
  *
+ * `arkaik init` (issue #220) installs the agent skill as a render of
+ * `docs/arkaik-skill/skill.md` plus its two generated siblings
+ * (`references/schema.md`, `scripts/validate-bundle.js`). Rather than commit a
+ * second copy of those assets under packages/cli, we copy them into
+ * dist/assets/skill/ here at build time — docs/arkaik-skill/ stays the single
+ * source of truth, the published CLI carries the assets it needs, and there is
+ * no drift check to maintain because nothing new is committed.
+ *
  * dist/ is gitignored and rebuilt on demand (`npm run build -w arkaik`, run by
  * the root `test:cli` script and CI before the CLI tests spawn the binary).
  */
 import { build } from "esbuild";
-import { chmodSync } from "node:fs";
+import { chmodSync, cpSync, mkdirSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const dir = dirname(fileURLToPath(import.meta.url));
 const ENTRY = join(dir, "src", "index.ts");
 const OUT_FILE = join(dir, "dist", "index.js");
+
+const SKILL_SRC_DIR = join(dir, "..", "..", "docs", "arkaik-skill");
+const SKILL_DIST_DIR = join(dir, "dist", "assets", "skill");
+
+function copySkillAssets() {
+  mkdirSync(join(SKILL_DIST_DIR, "references"), { recursive: true });
+  mkdirSync(join(SKILL_DIST_DIR, "scripts"), { recursive: true });
+  cpSync(join(SKILL_SRC_DIR, "skill.md"), join(SKILL_DIST_DIR, "skill.md"));
+  cpSync(join(SKILL_SRC_DIR, "references", "schema.md"), join(SKILL_DIST_DIR, "references", "schema.md"));
+  cpSync(join(SKILL_SRC_DIR, "scripts", "validate-bundle.js"), join(SKILL_DIST_DIR, "scripts", "validate-bundle.js"));
+  console.log(`copied skill assets -> ${relative(dir, SKILL_DIST_DIR)}`);
+}
 
 async function run() {
   await build({
@@ -35,6 +55,7 @@ async function run() {
   });
   chmodSync(OUT_FILE, 0o755);
   console.log(`built ${relative(dir, OUT_FILE)}`);
+  copySkillAssets();
 }
 
 run().catch((err) => {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,0 +1,294 @@
+/**
+ * `arkaik init [--product <name>] [--bundle <path>] [--journal <path>]
+ *              [--skills-dir <path>] [--update]`
+ *
+ * Scaffolds `docs/arkaik/` in the current working directory (the target
+ * repo), configures `.gitattributes` for the journal's union merge
+ * (docs/spec/journal.md § Storage Shapes), and installs the Arkaik agent
+ * skill as a *render* (not a copy) into the repo's skills directory
+ * (docs/spec/toolchain.md § Skill Distribution).
+ *
+ * The skill template (`skill.md`) and its two generated siblings
+ * (`references/schema.md`, `scripts/validate-bundle.js`) live once at
+ * `docs/arkaik-skill/` and are copied into `dist/assets/skill/` at CLI build
+ * time (see build.js) — this module resolves them relative to its own
+ * bundled location (`import.meta.url`) so the published CLI carries them
+ * with no drift and nothing new committed to the repo.
+ *
+ * Idempotent and non-destructive by default: every scaffolded artifact
+ * (bundle, journal, assets dir, skill) is created only if missing — a plain
+ * re-run never clobbers local edits. `--update` is the one sanctioned way to
+ * upgrade an already-installed skill (+ its generated assets), gated on the
+ * `version` frontmatter stamp; it never touches the bundle or journal.
+ */
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { serializeBundle, validateBundle, type ProjectBundle } from "@arkaik/schema";
+
+const DEFAULT_BUNDLE_PATH = "docs/arkaik/bundle.json";
+const DEFAULT_JOURNAL_PATH = "docs/arkaik/journal.jsonl";
+const DEFAULT_SKILLS_DIR = ".claude/skills/arkaik";
+
+// The skill template + generated siblings, copied next to this bundled file's
+// own output location by build.js (dist/index.js -> dist/assets/skill/).
+const ASSET_DIR = join(dirname(fileURLToPath(import.meta.url)), "assets", "skill");
+
+const USAGE = `arkaik init [--product <name>] [--bundle <path>] [--journal <path>] [--skills-dir <path>] [--update]
+
+Scaffold docs/arkaik/ (bundle.json, journal.jsonl, assets/) in the current
+directory, configure .gitattributes for the journal's union merge, and
+install the Arkaik agent skill (rendered SKILL.md + its generated reference
+and validator) into the repo's skills directory.
+
+Safe to re-run: existing bundle/journal/skill files are left untouched unless
+--update is given, which upgrades only the skill + its generated assets when
+a newer version is packaged (never the bundle or journal).
+
+Options:
+  --product <name>      Product name rendered into the skill and used for the
+                         scaffolded bundle's title (default: derived from the
+                         current directory name).
+  --bundle <path>       Path to the bundle snapshot (default: ${DEFAULT_BUNDLE_PATH}).
+  --journal <path>      Path to the journal sidecar (default: ${DEFAULT_JOURNAL_PATH}).
+  --skills-dir <path>   Directory to install the skill into (default: ${DEFAULT_SKILLS_DIR}).
+  --update              Re-render the skill + its generated assets when the
+                         packaged version is newer than what's installed;
+                         no-op when already current. Never touches the
+                         bundle or journal.
+  -h, --help             Show this help.`;
+
+function fail(message: string): never {
+  console.error(message);
+  process.exit(1);
+}
+
+interface InitOptions {
+  product?: string;
+  bundle?: string;
+  journal?: string;
+  skillsDir?: string;
+  update: boolean;
+}
+
+function parseArgs(args: string[]): InitOptions {
+  const opts: InitOptions = { update: false };
+
+  const nextValue = (i: number, flag: string): string => {
+    const value = args[i];
+    if (value === undefined) fail(`Missing value for ${flag}\n\n${USAGE}`);
+    return value;
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "-h" || arg === "--help") {
+      console.log(USAGE);
+      process.exit(0);
+    } else if (arg === "--update") {
+      opts.update = true;
+    } else if (arg === "--product") {
+      opts.product = nextValue(++i, arg);
+    } else if (arg === "--bundle") {
+      opts.bundle = nextValue(++i, arg);
+    } else if (arg === "--journal") {
+      opts.journal = nextValue(++i, arg);
+    } else if (arg === "--skills-dir") {
+      opts.skillsDir = nextValue(++i, arg);
+    } else {
+      fail(`Unknown option: ${arg}\n\n${USAGE}`);
+    }
+  }
+  return opts;
+}
+
+/** Title-case the current directory name as a fallback product name. */
+function defaultProductName(): string {
+  const words = basename(process.cwd())
+    .split(/[-_\s]+/)
+    .filter(Boolean);
+  if (words.length === 0) return "Untitled Project";
+  return words.map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
+}
+
+/** Derive a kebab-case project id from a human-readable product name. */
+function kebabCase(input: string): string {
+  const slug = input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || "project";
+}
+
+/** Write `content` to `path` only if it doesn't already exist. */
+function writeIfAbsent(path: string, content: string, label: string): void {
+  if (existsSync(path)) {
+    console.log(`Skipping ${label} (already exists): ${path}`);
+    return;
+  }
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+  console.log(`Created ${path}`);
+}
+
+/** Scaffold a minimal, valid Level-1 bundle snapshot at `bundlePath`. */
+function scaffoldBundle(bundlePath: string, productName: string): void {
+  if (existsSync(bundlePath)) {
+    console.log(`Skipping bundle (already exists): ${bundlePath}`);
+    return;
+  }
+  const now = new Date().toISOString();
+  const bundle: ProjectBundle = {
+    schema_version: 1,
+    project: {
+      id: kebabCase(productName),
+      title: productName,
+      created_at: now,
+      updated_at: now,
+    },
+    nodes: [],
+    edges: [],
+  };
+
+  const result = validateBundle(bundle);
+  if (!result.valid) {
+    // Should be unreachable — a minimal bundle with no nodes/edges satisfies
+    // every semantic rule. Fail loudly rather than write something broken.
+    fail(`internal error: scaffolded bundle failed validation:\n${result.errors.map((e) => e.message).join("\n")}`);
+  }
+
+  mkdirSync(dirname(bundlePath), { recursive: true });
+  writeFileSync(bundlePath, serializeBundle(bundle));
+  console.log(`Created ${bundlePath}`);
+}
+
+/** Idempotently add the journal's union-merge rule to .gitattributes. */
+function ensureGitAttributes(journalRelPath: string): void {
+  const line = `${journalRelPath} merge=union`;
+  const gitAttributesPath = resolve(process.cwd(), ".gitattributes");
+
+  if (!existsSync(gitAttributesPath)) {
+    writeFileSync(gitAttributesPath, `${line}\n`);
+    console.log(`Created .gitattributes with: ${line}`);
+    return;
+  }
+
+  const content = readFileSync(gitAttributesPath, "utf8");
+  if (content.split(/\r?\n/).includes(line)) {
+    console.log(".gitattributes already has the journal union-merge rule.");
+    return;
+  }
+
+  const separator = content.length > 0 && !content.endsWith("\n") ? "\n" : "";
+  writeFileSync(gitAttributesPath, `${content}${separator}${line}\n`);
+  console.log(`Added to .gitattributes: ${line}`);
+}
+
+/** Extract the `version:` value from a skill file's YAML frontmatter. */
+function extractVersion(content: string): string | undefined {
+  const frontmatterMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  const frontmatter = frontmatterMatch ? frontmatterMatch[1] : content;
+  return frontmatter.match(/^version:\s*(\S+)\s*$/m)?.[1];
+}
+
+/** Compare two dot-separated version strings numerically, part by part. */
+function compareVersions(a: string, b: string): number {
+  const partsA = a.split(".").map((n) => Number.parseInt(n, 10) || 0);
+  const partsB = b.split(".").map((n) => Number.parseInt(n, 10) || 0);
+  for (let i = 0; i < Math.max(partsA.length, partsB.length); i++) {
+    const diff = (partsA[i] ?? 0) - (partsB[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+function renderTemplate(template: string, vars: Record<string, string>): string {
+  let out = template;
+  for (const [key, value] of Object.entries(vars)) {
+    out = out.split(`{{${key}}}`).join(value);
+  }
+  return out;
+}
+
+/** Render the packaged skill template + copy its generated siblings into `skillsDirPath`. */
+function renderAndWriteSkill(skillsDirPath: string, vars: Record<string, string>): string {
+  const rawSkill = readFileSync(join(ASSET_DIR, "skill.md"), "utf8");
+
+  mkdirSync(join(skillsDirPath, "references"), { recursive: true });
+  mkdirSync(join(skillsDirPath, "scripts"), { recursive: true });
+
+  writeFileSync(join(skillsDirPath, "SKILL.md"), renderTemplate(rawSkill, vars));
+  copyFileSync(join(ASSET_DIR, "references", "schema.md"), join(skillsDirPath, "references", "schema.md"));
+  copyFileSync(join(ASSET_DIR, "scripts", "validate-bundle.js"), join(skillsDirPath, "scripts", "validate-bundle.js"));
+
+  return extractVersion(rawSkill) ?? "unknown";
+}
+
+/** Plain `init`: install the skill only if it isn't there yet. */
+function installSkill(skillsDirPath: string, vars: Record<string, string>): void {
+  const skillPath = join(skillsDirPath, "SKILL.md");
+  if (existsSync(skillPath)) {
+    console.log(`Skipping skill install (already exists): ${skillPath}. Use \`arkaik init --update\` to upgrade.`);
+    return;
+  }
+  const version = renderAndWriteSkill(skillsDirPath, vars);
+  console.log(`Installed skill v${version} -> ${skillPath}`);
+}
+
+/** `--update`: upgrade the skill + generated assets only if the packaged version is newer. */
+function updateSkill(skillsDirPath: string, vars: Record<string, string>): void {
+  const packagedVersion = extractVersion(readFileSync(join(ASSET_DIR, "skill.md"), "utf8"));
+  const skillPath = join(skillsDirPath, "SKILL.md");
+
+  if (!existsSync(skillPath)) {
+    const version = renderAndWriteSkill(skillsDirPath, vars);
+    console.log(`No existing skill found at ${skillPath}; installed v${version}.`);
+    return;
+  }
+
+  const installedVersion = extractVersion(readFileSync(skillPath, "utf8"));
+  if (
+    installedVersion !== undefined &&
+    packagedVersion !== undefined &&
+    compareVersions(packagedVersion, installedVersion) <= 0
+  ) {
+    console.log(`Skill already up to date (v${installedVersion}).`);
+    return;
+  }
+
+  const version = renderAndWriteSkill(skillsDirPath, vars);
+  console.log(`Upgraded skill v${installedVersion ?? "unknown"} -> v${version}.`);
+}
+
+export function runInit(args: string[]): void {
+  const opts = parseArgs(args);
+  const productName = opts.product ?? defaultProductName();
+  const bundleRelPath = opts.bundle ?? DEFAULT_BUNDLE_PATH;
+  const journalRelPath = opts.journal ?? DEFAULT_JOURNAL_PATH;
+  const skillsDirRelPath = opts.skillsDir ?? DEFAULT_SKILLS_DIR;
+
+  const cwd = process.cwd();
+  const bundlePath = resolve(cwd, bundleRelPath);
+  const journalPath = resolve(cwd, journalRelPath);
+  const skillsDirPath = resolve(cwd, skillsDirRelPath);
+
+  const vars = { PRODUCT_NAME: productName, BUNDLE_PATH: bundleRelPath, JOURNAL_PATH: journalRelPath };
+
+  if (opts.update) {
+    updateSkill(skillsDirPath, vars);
+    return;
+  }
+
+  scaffoldBundle(bundlePath, productName);
+  writeIfAbsent(journalPath, "", "journal");
+  writeIfAbsent(join(dirname(bundlePath), "assets", ".gitkeep"), "", "assets dir");
+  ensureGitAttributes(journalRelPath);
+  installSkill(skillsDirPath, vars);
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,12 +3,13 @@
  *
  * A tiny hand-rolled command dispatcher — deliberately dependency-free (no
  * commander/yargs). Each command owns its own flag parsing so later commands
- * (init/log/release/sync/pack/open — separate issues) slot in by adding a
- * `case` here and a handler module under `./commands`.
+ * (log/release/sync/pack/open — separate issues) slot in by adding a `case`
+ * here and a handler module under `./commands`.
  *
  * All schema behaviour is reused verbatim from `@arkaik/schema`; the commands
  * never re-implement validation or serialization.
  */
+import { runInit } from "./commands/init";
 import { runValidate } from "./commands/validate";
 
 const USAGE = `arkaik — CLI for Arkaik project bundles
@@ -17,6 +18,7 @@ Usage:
   arkaik <command> [options]
 
 Commands:
+  init [options]    Scaffold docs/arkaik/, install the agent skill (--update to upgrade).
   validate [path]   Validate a project bundle (folds in a journal.jsonl sidecar).
 
 Options:
@@ -33,6 +35,9 @@ function main(argv: string[]): void {
   }
 
   switch (command) {
+    case "init":
+      runInit(rest);
+      return;
     case "validate":
       runValidate(rest);
       return;

--- a/tests/cli/init.test.js
+++ b/tests/cli/init.test.js
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+
+/**
+ * Exercises `arkaik init` (issue #220) by spawning the built CLI
+ * (packages/cli/dist/index.js) with `cwd` pointed at a fresh `fs.mkdtemp`
+ * directory under `os.tmpdir()` — never the arkaik repo itself, so a bug here
+ * can't scaffold stray files into this working tree.
+ *
+ * Covers:
+ *  - a plain `init` scaffolds docs/arkaik/{bundle.json,journal.jsonl,assets/},
+ *    a canonical + validateBundle()-valid bundle, and the .gitattributes
+ *    union-merge line;
+ *  - re-running `init` is idempotent: no duplicated .gitattributes line, and
+ *    the bundle is left byte-identical (not regenerated with a fresh
+ *    timestamp);
+ *  - the skill installs as `SKILL.md` (rendered, no `{{...}}` left, product
+ *    name substituted) alongside its generated `references/schema.md` and
+ *    `scripts/validate-bundle.js`;
+ *  - `--update` upgrades an older-stamped SKILL.md and is a no-op when the
+ *    packaged version is already current, without touching bundle/journal.
+ */
+
+const { spawnSync } = require("child_process");
+const { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } = require("fs");
+const { tmpdir } = require("os");
+const path = require("path");
+
+const ROOT = path.join(__dirname, "..", "..");
+const CLI = path.join(ROOT, "packages", "cli", "dist", "index.js");
+
+if (!existsSync(CLI)) {
+  console.error(`CLI not built at ${CLI}. Run \`npm run build -w arkaik\` first.`);
+  process.exit(1);
+}
+
+const { serializeBundle, validateBundle } = require("../schema/load-schema").loadSchema();
+
+function runCli(args, cwd) {
+  return spawnSync(process.execPath, [CLI, ...args], { cwd, encoding: "utf8" });
+}
+
+let failures = 0;
+let passes = 0;
+
+function check(name, cond, detail) {
+  if (cond) {
+    passes++;
+    console.log(`PASS: ${name}`);
+  } else {
+    failures++;
+    console.log(`FAIL: ${name}`);
+    if (detail) console.log(detail);
+  }
+}
+
+const dir = mkdtempSync(path.join(tmpdir(), "arkaik-init-"));
+
+const BUNDLE_REL = path.join("docs", "arkaik", "bundle.json");
+const JOURNAL_REL = path.join("docs", "arkaik", "journal.jsonl");
+const ASSETS_DIR_REL = path.join("docs", "arkaik", "assets");
+const SKILL_DIR_REL = path.join(".claude", "skills", "arkaik");
+
+const bundlePath = path.join(dir, BUNDLE_REL);
+const journalPath = path.join(dir, JOURNAL_REL);
+const assetsDirPath = path.join(dir, ASSETS_DIR_REL);
+const gitAttributesPath = path.join(dir, ".gitattributes");
+const skillPath = path.join(dir, SKILL_DIR_REL, "SKILL.md");
+const schemaRefPath = path.join(dir, SKILL_DIR_REL, "references", "schema.md");
+const validatorScriptPath = path.join(dir, SKILL_DIR_REL, "scripts", "validate-bundle.js");
+
+// ---------------------------------------------------------------------------
+// Plain `init` scaffolds everything.
+// ---------------------------------------------------------------------------
+{
+  const result = runCli(["init", "--product", "Widget Co"], dir);
+  check("init exits 0", result.status === 0, `${result.stdout}\n${result.stderr}`);
+
+  check("bundle.json created", existsSync(bundlePath));
+  check("journal.jsonl created", existsSync(journalPath));
+  check("assets/ dir created", existsSync(assetsDirPath));
+  check(".gitattributes created", existsSync(gitAttributesPath));
+  check("SKILL.md installed", existsSync(skillPath));
+  check("references/schema.md installed", existsSync(schemaRefPath));
+  check("scripts/validate-bundle.js installed", existsSync(validatorScriptPath));
+
+  const journalContent = readFileSync(journalPath, "utf8");
+  check("journal.jsonl is empty", journalContent === "");
+
+  const bundleContent = readFileSync(bundlePath, "utf8");
+  const parsed = JSON.parse(bundleContent);
+  check(
+    "bundle.json is canonical (matches serializeBundle)",
+    serializeBundle(parsed) === bundleContent,
+    `got:\n${bundleContent}`,
+  );
+  const validation = validateBundle(parsed);
+  check("bundle.json passes validateBundle", validation.valid, JSON.stringify(validation.errors));
+  check("bundle.json title is the product name", parsed.project.title === "Widget Co");
+  check("bundle.json id is kebab-cased from the product name", parsed.project.id === "widget-co");
+  check("bundle.json schema_version is 1", parsed.schema_version === 1);
+  check("bundle.json has no nodes/edges", parsed.nodes.length === 0 && parsed.edges.length === 0);
+
+  const gitAttributes = readFileSync(gitAttributesPath, "utf8");
+  const expectedLine = `${JOURNAL_REL.split(path.sep).join("/")} merge=union`;
+  check(
+    ".gitattributes has the union-merge line",
+    gitAttributes.split(/\r?\n/).includes(expectedLine),
+    `got:\n${gitAttributes}`,
+  );
+
+  const skill = readFileSync(skillPath, "utf8");
+  check("SKILL.md has no leftover {{...}} placeholders", !/\{\{[A-Z_]+\}\}/.test(skill));
+  check("SKILL.md substitutes the product name", skill.includes("Widget Co"));
+  check("SKILL.md substitutes the bundle path", skill.includes("docs/arkaik/bundle.json"));
+  check("SKILL.md substitutes the journal path", skill.includes("docs/arkaik/journal.jsonl"));
+  check("SKILL.md frontmatter carries a version stamp", /^version:\s*\d+\.\d+\.\d+/m.test(skill));
+}
+
+// ---------------------------------------------------------------------------
+// Re-running plain `init` is idempotent: no duplicate .gitattributes line,
+// bundle/journal/skill left untouched (bundle would carry a fresh timestamp
+// if it were regenerated, so byte-identity is a meaningful check).
+// ---------------------------------------------------------------------------
+{
+  const bundleBefore = readFileSync(bundlePath, "utf8");
+  const gitAttributesBefore = readFileSync(gitAttributesPath, "utf8");
+  const skillBefore = readFileSync(skillPath, "utf8");
+
+  const result = runCli(["init", "--product", "Widget Co"], dir);
+  check("second init exits 0", result.status === 0, `${result.stdout}\n${result.stderr}`);
+
+  const bundleAfter = readFileSync(bundlePath, "utf8");
+  const gitAttributesAfter = readFileSync(gitAttributesPath, "utf8");
+  const skillAfter = readFileSync(skillPath, "utf8");
+
+  check("re-run leaves bundle.json byte-identical", bundleAfter === bundleBefore);
+  check("re-run leaves SKILL.md byte-identical (no --update)", skillAfter === skillBefore);
+
+  const lineCount = gitAttributesAfter
+    .split(/\r?\n/)
+    .filter((l) => l === `${JOURNAL_REL.split(path.sep).join("/")} merge=union`).length;
+  check("re-run does not duplicate the .gitattributes line", lineCount === 1, gitAttributesAfter);
+  check(".gitattributes unchanged on re-run", gitAttributesAfter === gitAttributesBefore);
+}
+
+// ---------------------------------------------------------------------------
+// `--update`: upgrades an older-stamped SKILL.md, is a no-op at the same
+// version, and never touches the bundle or journal.
+// ---------------------------------------------------------------------------
+{
+  const bundleBefore = readFileSync(bundlePath, "utf8");
+  const journalBefore = readFileSync(journalPath, "utf8");
+
+  const original = readFileSync(skillPath, "utf8");
+  const currentVersionMatch = original.match(/^version:\s*(\S+)/m);
+  const currentVersion = currentVersionMatch ? currentVersionMatch[1] : null;
+  check("captured the packaged skill version", currentVersion !== null, original.slice(0, 200));
+
+  // Simulate an older installed version.
+  const downgraded = original.replace(/^version:\s*\S+/m, "version: 0.0.1");
+  writeFileSync(skillPath, downgraded);
+
+  const upgradeResult = runCli(["init", "--update", "--product", "Widget Co"], dir);
+  check("update exits 0", upgradeResult.status === 0, `${upgradeResult.stdout}\n${upgradeResult.stderr}`);
+
+  const upgraded = readFileSync(skillPath, "utf8");
+  check(
+    "--update re-renders the skill back to the packaged version",
+    new RegExp(`^version:\\s*${currentVersion?.replace(/\./g, "\\.")}`, "m").test(upgraded),
+    upgraded.slice(0, 200),
+  );
+  check("--update output mentions the upgrade", /Upgraded skill/i.test(upgradeResult.stdout), upgradeResult.stdout);
+
+  // Same-version re-run is a no-op.
+  const noopResult = runCli(["init", "--update", "--product", "Widget Co"], dir);
+  check("no-op update exits 0", noopResult.status === 0);
+  check(
+    "no-op update prints an already-up-to-date message",
+    /already up to date/i.test(noopResult.stdout),
+    noopResult.stdout,
+  );
+  const afterNoop = readFileSync(skillPath, "utf8");
+  check("no-op update leaves SKILL.md unchanged", afterNoop === upgraded);
+
+  check("--update never touches bundle.json", readFileSync(bundlePath, "utf8") === bundleBefore);
+  check("--update never touches journal.jsonl", readFileSync(journalPath, "utf8") === journalBefore);
+}
+
+// ---------------------------------------------------------------------------
+// `--update` with no prior install falls back to a fresh install.
+// ---------------------------------------------------------------------------
+{
+  const freshDir = mkdtempSync(path.join(tmpdir(), "arkaik-init-update-fresh-"));
+  const result = runCli(["init", "--update", "--product", "Fresh Co"], freshDir);
+  check("update with no prior install exits 0", result.status === 0, `${result.stdout}\n${result.stderr}`);
+  check(
+    "update with no prior install installs SKILL.md",
+    existsSync(path.join(freshDir, SKILL_DIR_REL, "SKILL.md")),
+  );
+  check(
+    "update with no prior install does NOT scaffold the bundle",
+    !existsSync(path.join(freshDir, BUNDLE_REL)),
+  );
+  rmSync(freshDir, { recursive: true, force: true });
+}
+
+rmSync(dir, { recursive: true, force: true });
+
+console.log(`\n${passes} passed, ${failures} failed.`);
+process.exit(failures > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

Closes #220. Adds the `init` command to the `arkaik` CLI — the primary Kommit onboarding path. It scaffolds the `docs/arkaik/` storage layout, wires the journal union-merge attribute, and installs the agent skill as a per-project **render** (not a copy), with `--update` upgrades gated on the skill's frontmatter version.

## Key Changes

- **`packages/cli/src/commands/init.ts`** (new): `arkaik init [--product <name>] [--bundle <path>] [--journal <path>] [--skills-dir <path>] [--update]`.
  - Scaffolds `docs/arkaik/bundle.json` (minimal valid Level-1 bundle, emitted canonically via `serializeBundle`, passes `validateBundle`), `docs/arkaik/journal.jsonl` (empty), `docs/arkaik/assets/`.
  - Idempotently appends `docs/arkaik/journal.jsonl merge=union` to `.gitattributes` (`journal.md:34`) — no duplicate on re-run.
  - Renders `skill.md → SKILL.md` (uppercase, discovery) into `.claude/skills/arkaik/` substituting `{{PRODUCT_NAME}}`/`{{BUNDLE_PATH}}`/`{{JOURNAL_PATH}}`, plus the sibling generated `references/schema.md` + `scripts/validate-bundle.js`.
  - `--update` compares the packaged vs. installed frontmatter `version` and upgrades only the skill assets (never `bundle.json`/`journal.jsonl`); same-version is a no-op. Plain re-runs are safe/idempotent.
- **`packages/cli/build.js`**: copies `docs/arkaik-skill/{skill.md,references/schema.md,scripts/validate-bundle.js}` into `dist/assets/skill/` at build time — `docs/arkaik-skill/` stays the single source of truth, nothing new committed, no drift check needed. `init` resolves the assets via `import.meta.url`.
- **`packages/cli/src/index.ts`**: `init` registered in dispatch + `--help`.
- **`tests/cli/init.test.js`** (new): runs `init` in a fresh `os.tmpdir()` dir (never the repo tree) — asserts scaffold, canonical + valid bundle, non-duplicated gitattributes, no `{{...}}` left in `SKILL.md`, installed generated assets, and `--update` upgrade/no-op semantics.

## Test plan

- [x] `npm run generate` → no artifact drift
- [x] `npm run lint`, `npm run build`
- [x] `npm run validate:seeds`
- [x] all `test:*` including `test:cli` (22 validate + 38 init assertions)
- [x] `git status` clean of stray scaffold at the repo root (init only ever writes to its target cwd; tested in temp dirs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HE4i4eGXnXqsuLZtQvyKgb

---
_Generated by [Claude Code](https://claude.ai/code/session_01HE4i4eGXnXqsuLZtQvyKgb)_