### PR TITLE
M3: arkaik sync — mirror external ref status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 /tests/data/.test-build/
 /tests/data/.test-build-export/
 /tests/data/.test-build-journal/
+/packages/cli/.test-build/
 
 # next.js
 /.next/

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:emit": "node tests/schema/emit.test.js",
     "test:screenshot-size": "node tests/schema/screenshot-size.test.js",
     "test:migrate": "node tests/data/migrate.test.js && node tests/data/import-roundtrip.test.js && node tests/data/seed-import.test.js",
-    "test:cli": "npm run build -w arkaik && node tests/cli/run-cli-tests.js && node tests/cli/init.test.js && node tests/cli/log-release.test.js"
+    "test:cli": "npm run build -w arkaik && node tests/cli/run-cli-tests.js && node tests/cli/init.test.js && node tests/cli/log-release.test.js && node tests/cli/sync.test.js"
   },
   "dependencies": {
     "@radix-ui/react-collapsible": "^1.1.12",

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -1,0 +1,366 @@
+/**
+ * `arkaik sync [--provider <name>] [--dry-run] [path]`.
+ *
+ * Mirrors external ref status into the bundle (docs/spec/bundle-format.md §
+ * References, docs/vision.md § References, Assets & Integrations — the Kommit
+ * mode: "reads refs, queries the external APIs with locally provided tokens
+ * ..., updates the mirrored status, and appends ref.status_changed events. No
+ * arkaik server involved."):
+ *
+ *  1. walk every node's `metadata.refs`;
+ *  2. for a ref whose `type` maps to a *live* provider (v1: GitHub only, via
+ *     `../lib/providers`), fetch its current external status through the
+ *     injectable `httpClient` seam — never a bare `fetch` — so tests (and CI)
+ *     never touch the real network;
+ *  3. a ref of an unknown type, or one whose provider is a documented stub
+ *     (GitLab/Linear — not yet implemented), is left untouched: no error, no
+ *     write, just a notice for stubs;
+ *  4. when the fetched status differs from the ref's stored `external_status`,
+ *     update `external_status` + `synced_at` on the ref and append ONE
+ *     validated `ref.status_changed` event (dual-write, docs/spec/journal.md §
+ *     Authority & Consistency Model) — same run, same `synced_at`. Unchanged
+ *     refs get neither a write nor an event;
+ *  5. the bundle is rewritten canonically (`serializeBundle`) only if at least
+ *     one ref changed; `--dry-run` reports the same diff without writing
+ *     anything.
+ *
+ * `node.status` is never touched and `status_mapped` is never set — the ref's
+ * `external_status`/`synced_at` are the only snapshot fields this command
+ * writes, so `crossCheckJournal` (which cross-checks `node.status_changed`
+ * against `node.status`, not ref fields) stays satisfied and `arkaik validate`
+ * stays green afterward.
+ *
+ * The clock (`now`) and the http client are both injectable via {@link
+ * RunSyncOptions}, and `runSync` is exported standalone (not just the CLI
+ * entry) so tests can call it directly with a mock client and a fixed time.
+ */
+import { resolve } from "node:path";
+import { writeFileSync } from "node:fs";
+import { makeEvent, serializeBundle, type JournalEvent } from "@arkaik/schema";
+import { readBundle } from "../lib/bundle-io";
+import { appendJournalEvent, journalPathFor } from "../lib/journal-io";
+import { renderEventLine } from "../lib/render-event";
+import {
+  DEFAULT_HTTP_CLIENT,
+  fetchRefStatus,
+  providerForType,
+  PROVIDERS,
+  type HttpClient,
+} from "../lib/providers";
+
+const DEFAULT_BUNDLE_PATH = "docs/arkaik/bundle.json";
+const ACTOR = "arkaik-cli";
+
+const PROVIDER_LINES = PROVIDERS.map((p) => {
+  const state = p.status === "live" ? "live " : "stub ";
+  const token = p.tokenEnvVar ? ` (token: ${p.tokenEnvVar})` : "";
+  const note = p.status === "stub" ? " — not yet implemented, refs are reported and skipped" : "";
+  return `  ${p.name.padEnd(8)} ${state}— ${p.refTypes.join(", ")}${token}${note}`;
+}).join("\n");
+
+const USAGE = `arkaik sync [--provider <name>] [--dry-run] [path]
+
+Mirror external ref status into node metadata.refs. Reads every node's
+metadata.refs, queries each ref's provider for its current external status,
+and — when it differs from the mirrored external_status — updates
+external_status + synced_at in the bundle and appends a validated
+ref.status_changed event to journal.jsonl (dual-write, same run). Unchanged
+refs are left alone. Refs of an unrecognized type, or handled by a stub
+provider, are never modified and never error. external_status is a mirror,
+never authoritative: node.status is never changed and status_mapped is never
+auto-set by this command.
+
+Providers (v1):
+${PROVIDER_LINES}
+
+Arguments:
+  path              Path to the bundle JSON file (default: ${DEFAULT_BUNDLE_PATH}).
+
+Options:
+  --provider <name> Only sync refs handled by this provider (${PROVIDERS.map((p) => p.name).join(" | ")}).
+  --dry-run         Report what would change without writing the bundle or
+                     appending to the journal.
+  -h, --help        Show this help.`;
+
+function fail(message: string): never {
+  console.error(message);
+  process.exit(1);
+}
+
+export interface RefSyncChange {
+  nodeId: string;
+  refId: string;
+  refType: string;
+  from?: string;
+  to: string;
+}
+
+export interface RefSyncUnchanged {
+  nodeId: string;
+  refId: string;
+  refType: string;
+  status: string;
+}
+
+export interface RefSyncSkip {
+  nodeId: string;
+  refId: string;
+  refType: string;
+  reason: "unknown-type" | "stub-provider" | "filtered-out";
+  provider?: string;
+}
+
+export interface RefSyncError {
+  nodeId: string;
+  refId: string;
+  refType: string;
+  message: string;
+}
+
+export interface RunSyncOptions {
+  /** Path to the bundle JSON file (default: docs/arkaik/bundle.json), resolved against `cwd`. */
+  path?: string;
+  /** Only sync refs handled by this provider name. */
+  provider?: string;
+  /** Report what would change without writing anything. */
+  dryRun?: boolean;
+  /** Base directory `path` resolves against (default: process.cwd()). */
+  cwd?: string;
+  /** Source of tokens, keyed by each provider's `tokenEnvVar` (default: process.env). */
+  env?: Record<string, string | undefined>;
+  /** The HTTP seam every provider call goes through (default: real fetch). Tests inject a mock. */
+  httpClient?: HttpClient;
+  /** Clock for `synced_at`/event `ts` (default: `() => new Date()`). Tests inject a fixed clock. */
+  now?: () => Date;
+  /** Journal event `actor` (default: "arkaik-cli"). */
+  actor?: string;
+}
+
+export interface RunSyncResult {
+  ok: boolean;
+  /** Set when `ok` is false — a fatal error before any ref was processed. */
+  fatal?: string;
+  bundlePath: string;
+  journalPath: string;
+  dryRun: boolean;
+  changed: RefSyncChange[];
+  unchanged: RefSyncUnchanged[];
+  skipped: RefSyncSkip[];
+  errors: RefSyncError[];
+  /** Node id -> title, gathered from the snapshot as read — for rendering the report. */
+  nodeTitles: Map<string, string>;
+}
+
+function fatalResult(bundlePath: string, journalPath: string, dryRun: boolean, message: string): RunSyncResult {
+  return {
+    ok: false,
+    fatal: message,
+    bundlePath,
+    journalPath,
+    dryRun,
+    changed: [],
+    unchanged: [],
+    skipped: [],
+    errors: [],
+    nodeTitles: new Map(),
+  };
+}
+
+/**
+ * Sync every node's `metadata.refs` against their external providers. Pure
+ * with respect to its inputs (bundle path, provider filter, injected clock +
+ * http client): the only side effects are the bundle rewrite and journal
+ * append, both skipped under `--dry-run`.
+ */
+export async function runSync(options: RunSyncOptions = {}): Promise<RunSyncResult> {
+  const cwd = options.cwd ?? process.cwd();
+  const filePath = resolve(cwd, options.path ?? DEFAULT_BUNDLE_PATH);
+  const journalPath = journalPathFor(filePath);
+  const dryRun = options.dryRun ?? false;
+  const httpClient = options.httpClient ?? DEFAULT_HTTP_CLIENT;
+  const now = options.now ?? (() => new Date());
+  const env = options.env ?? process.env;
+  const actor = options.actor ?? ACTOR;
+
+  if (options.provider !== undefined && !PROVIDERS.some((p) => p.name === options.provider)) {
+    return fatalResult(
+      filePath,
+      journalPath,
+      dryRun,
+      `Unknown provider: ${options.provider} (known: ${PROVIDERS.map((p) => p.name).join(", ")})`,
+    );
+  }
+
+  let bundle: Record<string, unknown>;
+  try {
+    bundle = readBundle(filePath);
+  } catch (e) {
+    return fatalResult(filePath, journalPath, dryRun, (e as Error).message);
+  }
+
+  const nodes = Array.isArray(bundle.nodes) ? (bundle.nodes as Record<string, unknown>[]) : [];
+  const syncedAt = now().toISOString();
+
+  const changed: RefSyncChange[] = [];
+  const unchanged: RefSyncUnchanged[] = [];
+  const skipped: RefSyncSkip[] = [];
+  const errors: RefSyncError[] = [];
+  const nodeTitles = new Map<string, string>();
+  let dirty = false;
+
+  for (const node of nodes) {
+    const nodeId = typeof node.id === "string" ? node.id : undefined;
+    if (nodeId !== undefined && typeof node.title === "string") nodeTitles.set(nodeId, node.title);
+    const metadata = node.metadata;
+    const refs =
+      metadata !== null && typeof metadata === "object" && Array.isArray((metadata as Record<string, unknown>).refs)
+        ? ((metadata as Record<string, unknown>).refs as Record<string, unknown>[])
+        : [];
+
+    for (const ref of refs) {
+      const refId = typeof ref.id === "string" ? ref.id : undefined;
+      const refType = typeof ref.type === "string" ? ref.type : undefined;
+      const refUrl = typeof ref.url === "string" ? ref.url : undefined;
+      // Malformed ref (missing id/type/url) — leave untouched; validate() flags shape errors.
+      if (nodeId === undefined || refId === undefined || refType === undefined || refUrl === undefined) continue;
+
+      const provider = providerForType(refType);
+      if (!provider) {
+        skipped.push({ nodeId, refId, refType, reason: "unknown-type" });
+        continue;
+      }
+      if (options.provider !== undefined && provider.name !== options.provider) {
+        skipped.push({ nodeId, refId, refType, reason: "filtered-out", provider: provider.name });
+        continue;
+      }
+      if (provider.status !== "live") {
+        skipped.push({ nodeId, refId, refType, reason: "stub-provider", provider: provider.name });
+        continue;
+      }
+
+      const token = provider.tokenEnvVar ? env[provider.tokenEnvVar] : undefined;
+      let fetched: string;
+      try {
+        fetched = await fetchRefStatus({ type: refType, url: refUrl }, { token, httpClient });
+      } catch (e) {
+        errors.push({ nodeId, refId, refType, message: (e as Error).message });
+        continue;
+      }
+
+      const previous = typeof ref.external_status === "string" ? ref.external_status : undefined;
+      if (fetched === previous) {
+        unchanged.push({ nodeId, refId, refType, status: fetched });
+        continue;
+      }
+
+      changed.push({ nodeId, refId, refType, from: previous, to: fetched });
+      if (dryRun) continue;
+
+      ref.external_status = fetched;
+      ref.synced_at = syncedAt;
+      dirty = true;
+
+      const event = makeEvent(
+        "ref.status_changed",
+        {
+          node_id: nodeId,
+          ref_id: refId,
+          ...(previous !== undefined ? { from: previous } : {}),
+          to: fetched,
+          synced_at: syncedAt,
+        },
+        { actor, ts: syncedAt },
+      );
+      appendJournalEvent(journalPath, event);
+    }
+  }
+
+  if (dirty && !dryRun) {
+    writeFileSync(filePath, serializeBundle(bundle as unknown as Parameters<typeof serializeBundle>[0]));
+  }
+
+  return { ok: true, bundlePath: filePath, journalPath, dryRun, changed, unchanged, skipped, errors, nodeTitles };
+}
+
+/** A rendered `ref.status_changed` line for a change, reusing the shared event renderer. */
+function changeLine(change: RefSyncChange, nodeTitles: Map<string, string>): string {
+  const event: JournalEvent = {
+    id: "",
+    ts: "",
+    type: "ref.status_changed",
+    node_id: change.nodeId,
+    ref_id: change.refId,
+    ...(change.from !== undefined ? { from: change.from } : {}),
+    to: change.to,
+    synced_at: "",
+  };
+  const nodesById = new Map<string, { title: string }>();
+  for (const [id, title] of nodeTitles) nodesById.set(id, { title });
+  return renderEventLine(event, nodesById);
+}
+
+function report(result: RunSyncResult): void {
+  const nodeTitles = result.nodeTitles;
+  console.log(`\n  Arkaik Sync${result.dryRun ? " (dry run)" : ""}`);
+  console.log("  ============\n");
+
+  if (result.changed.length === 0) {
+    console.log("  No ref status changes.");
+  } else {
+    console.log(`  ${result.dryRun ? "Would change" : "Changed"}: ${result.changed.length}`);
+    result.changed.forEach((c) => console.log(`    - ${changeLine(c, nodeTitles)}`));
+  }
+
+  if (result.unchanged.length > 0) {
+    console.log(`  Unchanged: ${result.unchanged.length}`);
+  }
+
+  const stubSkips = result.skipped.filter((s) => s.reason === "stub-provider");
+  if (stubSkips.length > 0) {
+    console.log(`  Skipped (provider not yet implemented): ${stubSkips.length}`);
+    const byProvider = new Map<string, number>();
+    for (const s of stubSkips) byProvider.set(s.provider ?? "?", (byProvider.get(s.provider ?? "?") ?? 0) + 1);
+    for (const [provider, count] of byProvider) console.log(`    - ${provider}: ${count} ref(s)`);
+  }
+
+  if (result.errors.length > 0) {
+    console.log(`  Errors: ${result.errors.length}`);
+    result.errors.forEach((e) => console.log(`    - ${e.nodeId}/${e.refId} (${e.refType}): ${e.message}`));
+  }
+
+  console.log("");
+}
+
+export function runSyncCli(args: string[]): void {
+  let provider: string | undefined;
+  let dryRun = false;
+  const positionals: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "-h" || arg === "--help") {
+      console.log(USAGE);
+      process.exit(0);
+    } else if (arg === "--dry-run") {
+      dryRun = true;
+    } else if (arg === "--provider") {
+      const value = args[++i];
+      if (value === undefined) fail(`Missing value for --provider\n\n${USAGE}`);
+      provider = value;
+    } else if (arg.startsWith("-")) {
+      fail(`Unknown option: ${arg}\n\n${USAGE}`);
+    } else {
+      positionals.push(arg);
+    }
+  }
+
+  const filePath = positionals[0] ?? DEFAULT_BUNDLE_PATH;
+
+  runSync({ path: filePath, provider, dryRun })
+    .then((result) => {
+      if (!result.ok) fail(`FATAL: ${result.fatal}`);
+      report(result);
+      process.exit(result.errors.length > 0 ? 1 : 0);
+    })
+    .catch((e: unknown) => fail(`FATAL: ${(e as Error).message}`));
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -13,6 +13,7 @@ import { runInit } from "./commands/init";
 import { runValidate } from "./commands/validate";
 import { runLog } from "./commands/log";
 import { runRelease } from "./commands/release";
+import { runSyncCli } from "./commands/sync";
 
 const USAGE = `arkaik — CLI for Arkaik project bundles
 
@@ -24,6 +25,7 @@ Commands:
   validate [path]             Validate a project bundle (folds in a journal.jsonl sidecar).
   log [--node <id>] [path]    Print the journal: project changelog, or one node's timeline.
   release <version> [path]    Tag a release (append release.tagged) and draft its notes.
+  sync [options] [path]       Mirror external ref status (GitHub issues/PRs) into node refs.
 
 Options:
   -h, --help        Show this help.
@@ -50,6 +52,9 @@ function main(argv: string[]): void {
       return;
     case "release":
       runRelease(rest);
+      return;
+    case "sync":
+      runSyncCli(rest);
       return;
     default:
       console.error(`Unknown command: ${command}\n`);

--- a/packages/cli/src/lib/providers.ts
+++ b/packages/cli/src/lib/providers.ts
@@ -1,0 +1,163 @@
+/**
+ * External ref-status providers for `arkaik sync` (issue #222,
+ * docs/spec/bundle-format.md § References, docs/vision.md § References, Assets
+ * & Integrations).
+ *
+ * A small registry keyed by ref `type`, so GitLab/Linear can be filled in later
+ * without touching the sync command. Each provider is either:
+ *  - `"live"` — has a working `fetchStatus`, called by `fetchRefStatus`;
+ *  - `"stub"` — registered so its ref types are recognized and reported (not
+ *    silently mistaken for an unknown type), but has no `fetchStatus`; the sync
+ *    command skips these with a notice rather than calling them.
+ *
+ * The only network call in this module goes through the injected {@link
+ * HttpClient} — never a bare `fetch` — so `arkaik sync`'s tests (and CI) can
+ * substitute a mock and guarantee no real network happens. `DEFAULT_HTTP_CLIENT`
+ * is the real implementation (Node 20+'s global `fetch`), wired in only by the
+ * CLI entry point, never by tests.
+ */
+
+/** The HTTP seam every provider call goes through — mockable in tests. */
+export type HttpClient = (url: string, init?: RequestInit) => Promise<Response>;
+
+/** The real HTTP client: Node's global `fetch`. Used by the CLI, never by tests. */
+export const DEFAULT_HTTP_CLIENT: HttpClient = (url, init) => fetch(url, init);
+
+/** What a provider's `fetchStatus` needs about one ref, plus the injected seam. */
+export interface FetchContext {
+  /** Token from the provider's env var, when present. */
+  token?: string;
+  httpClient: HttpClient;
+}
+
+/** The minimal ref shape a provider needs: its type (to route) and URL (to query). */
+export interface RefLike {
+  type: string;
+  url: string;
+}
+
+export interface ProviderDef {
+  /** Provider name, matched against `--provider <name>`. */
+  name: string;
+  /** Ref `type` values this provider handles. */
+  refTypes: readonly string[];
+  status: "live" | "stub";
+  /** Env var a token is read from (documented in `arkaik sync --help`). */
+  tokenEnvVar?: string;
+  /** Present only for `"live"` providers. */
+  fetchStatus?: (ref: RefLike, ctx: FetchContext) => Promise<string>;
+}
+
+const GITHUB_ISSUE_URL_RE = /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/issues\/(\d+)(?:[/?#].*)?$/;
+const GITHUB_PR_URL_RE = /^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)(?:[/?#].*)?$/;
+
+function githubHeaders(token: string | undefined): Record<string, string> {
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return headers;
+}
+
+async function getGithubJson(
+  httpClient: HttpClient,
+  url: string,
+  token: string | undefined,
+  refUrl: string,
+): Promise<Record<string, unknown>> {
+  const res = await httpClient(url, { headers: githubHeaders(token) });
+  if (!res.ok) throw new Error(`GitHub API error ${res.status} for ${refUrl}`);
+  const body: unknown = await res.json();
+  if (typeof body !== "object" || body === null) {
+    throw new Error(`GitHub API returned a non-object response for ${refUrl}`);
+  }
+  return body as Record<string, unknown>;
+}
+
+/** `github-issue`: mirrors the issue's `state` verbatim ("open" | "closed"). */
+async function fetchGithubIssueStatus(ref: RefLike, ctx: FetchContext): Promise<string> {
+  const m = GITHUB_ISSUE_URL_RE.exec(ref.url);
+  if (!m) throw new Error(`Cannot parse a GitHub issue URL: ${ref.url}`);
+  const [, owner, repo, number] = m;
+  const body = await getGithubJson(
+    ctx.httpClient,
+    `https://api.github.com/repos/${owner}/${repo}/issues/${number}`,
+    ctx.token,
+    ref.url,
+  );
+  if (typeof body.state !== "string") throw new Error(`GitHub API response missing "state" for ${ref.url}`);
+  return body.state;
+}
+
+/** `github-pr`: "merged" when merged, else the PR's `state` ("open" | "closed"). */
+async function fetchGithubPrStatus(ref: RefLike, ctx: FetchContext): Promise<string> {
+  const m = GITHUB_PR_URL_RE.exec(ref.url);
+  if (!m) throw new Error(`Cannot parse a GitHub pull request URL: ${ref.url}`);
+  const [, owner, repo, number] = m;
+  const body = await getGithubJson(
+    ctx.httpClient,
+    `https://api.github.com/repos/${owner}/${repo}/pulls/${number}`,
+    ctx.token,
+    ref.url,
+  );
+  if (typeof body.state !== "string") throw new Error(`GitHub API response missing "state" for ${ref.url}`);
+  return body.merged === true ? "merged" : body.state;
+}
+
+async function fetchGithubStatus(ref: RefLike, ctx: FetchContext): Promise<string> {
+  if (ref.type === "github-issue") return fetchGithubIssueStatus(ref, ctx);
+  if (ref.type === "github-pr") return fetchGithubPrStatus(ref, ctx);
+  throw new Error(`Unsupported GitHub ref type: ${ref.type}`);
+}
+
+/**
+ * Provider registry (v1). GitHub is fully live. GitLab/Linear are registered as
+ * documented stubs so their ref types are recognized (reported + skipped with a
+ * notice) rather than treated as unknown — filling them in later is a matter of
+ * adding a `fetchStatus` and flipping `status` to `"live"`.
+ */
+export const PROVIDERS: readonly ProviderDef[] = [
+  {
+    name: "github",
+    refTypes: ["github-issue", "github-pr"],
+    status: "live",
+    tokenEnvVar: "GITHUB_TOKEN",
+    fetchStatus: fetchGithubStatus,
+  },
+  {
+    name: "gitlab",
+    refTypes: ["gitlab-issue", "gitlab-mr"],
+    status: "stub",
+    tokenEnvVar: "GITLAB_TOKEN",
+  },
+  {
+    name: "linear",
+    refTypes: ["linear-issue"],
+    status: "stub",
+    tokenEnvVar: "LINEAR_API_KEY",
+  },
+];
+
+const REF_TYPE_TO_PROVIDER = new Map<string, ProviderDef>();
+for (const provider of PROVIDERS) {
+  for (const type of provider.refTypes) REF_TYPE_TO_PROVIDER.set(type, provider);
+}
+
+/** The registered provider for a ref `type`, or `undefined` for an unknown/unsupported type. */
+export function providerForType(refType: string): ProviderDef | undefined {
+  return REF_TYPE_TO_PROVIDER.get(refType);
+}
+
+/**
+ * Fetch `ref`'s current external status through its provider. Only callable for
+ * a `"live"` provider — the sync command checks `providerForType(...).status`
+ * before calling this, so a stub or unknown type never reaches here.
+ */
+export async function fetchRefStatus(ref: RefLike, ctx: FetchContext): Promise<string> {
+  const provider = providerForType(ref.type);
+  if (!provider || provider.status !== "live" || !provider.fetchStatus) {
+    throw new Error(`No live provider for ref type "${ref.type}"`);
+  }
+  return provider.fetchStatus(ref, ctx);
+}

--- a/tests/cli/sync.test.js
+++ b/tests/cli/sync.test.js
@@ -1,0 +1,449 @@
+#!/usr/bin/env node
+
+/**
+ * Exercises `arkaik sync` (issue #222).
+ *
+ * Two layers:
+ *  - `runSync()` exercised in-process: `packages/cli/src/commands/sync.ts` is
+ *    esbuild-bundled (same technique `build.js` uses for the real CLI, just to
+ *    a throwaway `.test-build/` dir) into an importable ESM module, so a mock
+ *    `httpClient` can be injected straight into the exported function — no
+ *    subprocess, no real network, ever.
+ *  - the built CLI binary (`packages/cli/dist/index.js`) spawned for the
+ *    argv-parsing / exit-code / --help contract, using only fixtures with no
+ *    "live"-provider refs so a subprocess run can never reach the network.
+ *
+ * Covers:
+ *  - a changed github-issue ref updates external_status + synced_at in the
+ *    rewritten (canonical) bundle and appends exactly one ref.status_changed
+ *    event, dual-write, same run;
+ *  - an unchanged github-pr ref: no event, no write;
+ *  - a failed fetch (404): the ref is left completely untouched, reported as
+ *    an error, no event;
+ *  - an unknown ref type (figma) and a stub-provider ref type (gitlab-issue):
+ *    both left untouched, no error;
+ *  - node.status is never modified, status_mapped is never set, for any node;
+ *  - --dry-run (via runSync's dryRun option) writes nothing to bundle.json or
+ *    journal.jsonl while still reporting the would-be change;
+ *  - --provider filters processing to one provider's ref types;
+ *  - a token from `env` reaches the GitHub request as a Bearer header;
+ *  - `arkaik validate` stays VALID after a sync.
+ */
+
+const { build } = require("esbuild");
+const { spawnSync } = require("child_process");
+const { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } = require("fs");
+const { tmpdir } = require("os");
+const path = require("path");
+const { pathToFileURL } = require("url");
+
+const ROOT = path.join(__dirname, "..", "..");
+const CLI = path.join(ROOT, "packages", "cli", "dist", "index.js");
+const SYNC_ENTRY = path.join(ROOT, "packages", "cli", "src", "commands", "sync.ts");
+const TEST_BUILD_DIR = path.join(ROOT, "packages", "cli", ".test-build");
+const SYNC_BUNDLE = path.join(TEST_BUILD_DIR, "sync.mjs");
+
+if (!existsSync(CLI)) {
+  console.error(`CLI not built at ${CLI}. Run \`npm run build -w arkaik\` first.`);
+  process.exit(1);
+}
+
+function runCli(args) {
+  return spawnSync(process.execPath, [CLI, ...args], { encoding: "utf8" });
+}
+
+let failures = 0;
+let passes = 0;
+function check(name, cond, detail) {
+  if (cond) {
+    passes++;
+    console.log(`PASS: ${name}`);
+  } else {
+    failures++;
+    console.log(`FAIL: ${name}`);
+    if (detail) console.log(detail);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: two nodes, refs covering every routing outcome sync must handle.
+// ---------------------------------------------------------------------------
+function makeBundle() {
+  return {
+    schema_version: 1,
+    project: { id: "demo", title: "Demo", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" },
+    nodes: [
+      {
+        id: "V-home",
+        project_id: "demo",
+        species: "view",
+        title: "Home",
+        status: "live",
+        platforms: ["web"],
+        metadata: {
+          refs: [
+            { id: "gh-issue-1", type: "github-issue", url: "https://github.com/acme/demo/issues/42", title: "Tracking issue", external_status: "open" },
+            { id: "gh-issue-404", type: "github-issue", url: "https://github.com/acme/demo/issues/99", external_status: "open" },
+            { id: "gh-pr-1", type: "github-pr", url: "https://github.com/acme/demo/pull/7", external_status: "open" },
+            { id: "figma-1", type: "figma", url: "https://figma.com/file/xyz", title: "Design" },
+          ],
+        },
+      },
+      {
+        id: "V-settings",
+        project_id: "demo",
+        species: "view",
+        title: "Settings",
+        status: "live",
+        platforms: ["web"],
+        metadata: {
+          refs: [{ id: "gl-issue-1", type: "gitlab-issue", url: "https://gitlab.com/acme/demo/-/issues/3", external_status: "opened" }],
+        },
+      },
+    ],
+    edges: [],
+  };
+}
+
+const JOURNAL_LINES = [
+  { id: "01A", ts: "2026-01-01T00:00:00.000Z", type: "node.created", node_id: "V-home", species: "view", title: "Home" },
+  { id: "01B", ts: "2026-01-01T00:01:00.000Z", type: "node.created", node_id: "V-settings", species: "view", title: "Settings" },
+  { id: "01C", ts: "2026-01-01T00:02:00.000Z", type: "node.status_changed", node_id: "V-home", from: "idea", to: "live" },
+  { id: "01D", ts: "2026-01-01T00:03:00.000Z", type: "node.status_changed", node_id: "V-settings", from: "idea", to: "live" },
+];
+const JOURNAL = JOURNAL_LINES.map((e) => JSON.stringify(e)).join("\n") + "\n";
+
+const createdDirs = [];
+
+/** Fresh temp dir with bundle.json + journal.jsonl. Returns paths + parsed bundle for reference. */
+function fixture() {
+  const dir = mkdtempSync(path.join(tmpdir(), "arkaik-sync-"));
+  createdDirs.push(dir);
+  const bundlePath = path.join(dir, "bundle.json");
+  const journalPath = path.join(dir, "journal.jsonl");
+  const bundle = makeBundle();
+  writeFileSync(bundlePath, JSON.stringify(bundle, null, 2) + "\n");
+  writeFileSync(journalPath, JOURNAL);
+  return { dir, bundlePath, journalPath, originalBundle: bundle };
+}
+
+function readJson(p) {
+  return JSON.parse(readFileSync(p, "utf8"));
+}
+
+function readJournalEvents(journalPath) {
+  if (!existsSync(journalPath)) return [];
+  return readFileSync(journalPath, "utf8")
+    .split(/\r?\n/)
+    .filter((l) => l.trim() !== "")
+    .map((l) => JSON.parse(l));
+}
+
+function refById(bundle, nodeId, refId) {
+  const node = bundle.nodes.find((n) => n.id === nodeId);
+  return node?.metadata?.refs?.find((r) => r.id === refId);
+}
+
+/**
+ * Deterministic JSON with keys sorted at every level, for comparing values
+ * regardless of key order. serializeBundle canonicalizes nested object keys
+ * alphabetically (docs/spec/bundle-format.md § Canonical Serialization), so a
+ * ref's *value* survives a sync round-trip untouched even though its declared
+ * key order does not.
+ */
+function stableStringify(value) {
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  if (value !== null && typeof value === "object") {
+    const keys = Object.keys(value).sort();
+    return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(value[k])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function jsonResponse(status, body) {
+  return { ok: status >= 200 && status < 300, status, json: async () => body };
+}
+
+/** Mock GitHub httpClient: routes by URL suffix, records every call it saw. */
+function makeMockHttpClient() {
+  const calls = [];
+  const client = async (url, init) => {
+    calls.push({ url, init });
+    if (url.endsWith("/issues/42")) return jsonResponse(200, { state: "closed" });
+    if (url.endsWith("/issues/99")) return jsonResponse(404, {});
+    if (url.endsWith("/pulls/7")) return jsonResponse(200, { state: "open", merged: false });
+    return jsonResponse(500, {});
+  };
+  client.calls = calls;
+  return client;
+}
+
+async function main() {
+  // Bundle sync.ts into an importable ESM module (mirrors build.js's own
+  // esbuild invocation) so runSync can be called directly with a mock client.
+  mkdirSync(TEST_BUILD_DIR, { recursive: true });
+  await build({
+    entryPoints: [SYNC_ENTRY],
+    outfile: SYNC_BUNDLE,
+    bundle: true,
+    platform: "node",
+    target: "node18",
+    format: "esm",
+    legalComments: "none",
+  });
+  const { runSync } = await import(pathToFileURL(SYNC_BUNDLE).href);
+
+  // -------------------------------------------------------------------------
+  // Core run: mixed outcomes across one sync call.
+  // -------------------------------------------------------------------------
+  {
+    const { bundlePath, journalPath, originalBundle } = fixture();
+    const httpClient = makeMockHttpClient();
+    const fixedNow = () => new Date("2026-07-01T00:00:00.000Z");
+
+    const result = await runSync({ path: bundlePath, httpClient, now: fixedNow, env: {} });
+
+    check("runSync ok", result.ok === true, JSON.stringify(result));
+    check(
+      "reports exactly one changed ref (gh-issue-1: open -> closed)",
+      result.changed.length === 1 &&
+        result.changed[0].nodeId === "V-home" &&
+        result.changed[0].refId === "gh-issue-1" &&
+        result.changed[0].from === "open" &&
+        result.changed[0].to === "closed",
+      JSON.stringify(result.changed),
+    );
+    check(
+      "reports the unchanged github-pr ref",
+      result.unchanged.some((u) => u.refId === "gh-pr-1" && u.status === "open"),
+      JSON.stringify(result.unchanged),
+    );
+    check(
+      "reports the unknown-type ref (figma) as skipped/unknown-type",
+      result.skipped.some((s) => s.refId === "figma-1" && s.reason === "unknown-type"),
+      JSON.stringify(result.skipped),
+    );
+    check(
+      "reports the gitlab stub ref as skipped/stub-provider",
+      result.skipped.some((s) => s.refId === "gl-issue-1" && s.reason === "stub-provider" && s.provider === "gitlab"),
+      JSON.stringify(result.skipped),
+    );
+    check(
+      "reports the 404 fetch as an error, not a change",
+      result.errors.length === 1 && result.errors[0].refId === "gh-issue-404",
+      JSON.stringify(result.errors),
+    );
+
+    // --- snapshot: only the changed ref was touched ---
+    const after = readJson(bundlePath);
+    const changedRef = refById(after, "V-home", "gh-issue-1");
+    check("changed ref's external_status updated", changedRef.external_status === "closed", JSON.stringify(changedRef));
+    check("changed ref's synced_at stamped", changedRef.synced_at === "2026-07-01T00:00:00.000Z", JSON.stringify(changedRef));
+
+    const unchangedRef = refById(after, "V-home", "gh-pr-1");
+    check(
+      "unchanged ref is untouched by value (no synced_at added)",
+      stableStringify(unchangedRef) === stableStringify(refById(originalBundle, "V-home", "gh-pr-1")),
+      JSON.stringify(unchangedRef),
+    );
+
+    const erroredRef = refById(after, "V-home", "gh-issue-404");
+    check(
+      "errored ref is untouched by value",
+      stableStringify(erroredRef) === stableStringify(refById(originalBundle, "V-home", "gh-issue-404")),
+      JSON.stringify(erroredRef),
+    );
+
+    const figmaRef = refById(after, "V-home", "figma-1");
+    check(
+      "unknown-type ref round-trips untouched by value",
+      stableStringify(figmaRef) === stableStringify(refById(originalBundle, "V-home", "figma-1")),
+      JSON.stringify(figmaRef),
+    );
+
+    const gitlabRef = refById(after, "V-settings", "gl-issue-1");
+    check(
+      "stub-provider ref round-trips untouched by value",
+      stableStringify(gitlabRef) === stableStringify(refById(originalBundle, "V-settings", "gl-issue-1")),
+      JSON.stringify(gitlabRef),
+    );
+
+    // --- node.status / status_mapped invariants ---
+    check(
+      "node.status untouched on every node",
+      after.nodes.every((n) => n.status === "live"),
+      JSON.stringify(after.nodes.map((n) => n.status)),
+    );
+    check(
+      "status_mapped never set on any ref",
+      after.nodes.every((n) => (n.metadata?.refs ?? []).every((r) => r.status_mapped === undefined)),
+    );
+
+    // --- journal: exactly one new ref.status_changed event ---
+    const events = readJournalEvents(journalPath);
+    const newEvents = events.filter((e) => !JOURNAL_LINES.some((j) => j.id === e.id));
+    check("appends exactly one new journal event", newEvents.length === 1, JSON.stringify(newEvents));
+    const ev = newEvents[0];
+    check(
+      "appended event is a valid ref.status_changed",
+      ev &&
+        ev.type === "ref.status_changed" &&
+        ev.node_id === "V-home" &&
+        ev.ref_id === "gh-issue-1" &&
+        ev.from === "open" &&
+        ev.to === "closed" &&
+        ev.synced_at === "2026-07-01T00:00:00.000Z",
+      JSON.stringify(ev),
+    );
+    check("appended event has a ULID id (26 Crockford base32 chars)", ev && /^[0-9A-HJKMNP-TV-Z]{26}$/.test(ev.id), ev?.id);
+    check("appended event stamps an actor", ev && typeof ev.actor === "string" && ev.actor.length > 0, ev?.actor);
+
+    // --- bundle rewritten canonically ---
+    const raw = readFileSync(bundlePath, "utf8");
+    check("rewritten bundle ends with a trailing newline", raw.endsWith("\n"));
+    check("rewritten bundle is valid JSON", (() => {
+      try {
+        JSON.parse(raw);
+        return true;
+      } catch {
+        return false;
+      }
+    })());
+
+    // --- no request carried an Authorization header (no token supplied) ---
+    check(
+      "no Authorization header sent without a token",
+      httpClient.calls.every((c) => c.init?.headers?.Authorization === undefined),
+      JSON.stringify(httpClient.calls.map((c) => c.init?.headers)),
+    );
+
+    // --- validate stays green ---
+    const validate = runCli(["validate", bundlePath]);
+    check("validate stays VALID after sync", validate.status === 0 && /VALID/.test(validate.stdout), validate.stdout);
+  }
+
+  // -------------------------------------------------------------------------
+  // --dry-run: reports the same diff, writes nothing.
+  // -------------------------------------------------------------------------
+  {
+    const { bundlePath, journalPath } = fixture();
+    const bundleBefore = readFileSync(bundlePath, "utf8");
+    const journalBefore = readFileSync(journalPath, "utf8");
+    const httpClient = makeMockHttpClient();
+
+    const result = await runSync({
+      path: bundlePath,
+      httpClient,
+      dryRun: true,
+      now: () => new Date("2026-07-01T00:00:00.000Z"),
+      env: {},
+    });
+
+    check("dry-run still ok", result.ok === true);
+    check("dry-run flags result.dryRun", result.dryRun === true);
+    check(
+      "dry-run still reports the would-be change",
+      result.changed.length === 1 && result.changed[0].refId === "gh-issue-1" && result.changed[0].to === "closed",
+      JSON.stringify(result.changed),
+    );
+    check("dry-run does not write the bundle", readFileSync(bundlePath, "utf8") === bundleBefore);
+    check("dry-run does not write the journal", readFileSync(journalPath, "utf8") === journalBefore);
+  }
+
+  // -------------------------------------------------------------------------
+  // --provider filters processing to one provider's ref types.
+  // -------------------------------------------------------------------------
+  {
+    const { bundlePath } = fixture();
+    const httpClient = makeMockHttpClient();
+
+    const result = await runSync({
+      path: bundlePath,
+      httpClient,
+      provider: "gitlab",
+      now: () => new Date("2026-07-01T00:00:00.000Z"),
+      env: {},
+    });
+
+    check("runSync with --provider gitlab is ok", result.ok === true);
+    check("no github refs were fetched (0 HTTP calls)", httpClient.calls.length === 0, JSON.stringify(httpClient.calls));
+    check(
+      "github refs are reported as filtered-out",
+      result.skipped.some((s) => s.refId === "gh-issue-1" && s.reason === "filtered-out" && s.provider === "github"),
+      JSON.stringify(result.skipped),
+    );
+    check(
+      "the gitlab ref is still reported as a stub (filter matched, provider not live)",
+      result.skipped.some((s) => s.refId === "gl-issue-1" && s.reason === "stub-provider"),
+      JSON.stringify(result.skipped),
+    );
+
+    const unknown = await runSync({ path: bundlePath, httpClient, provider: "bogus-provider", env: {} });
+    check("an unknown --provider name is a fatal error", unknown.ok === false && /Unknown provider/.test(unknown.fatal ?? ""), JSON.stringify(unknown));
+  }
+
+  // -------------------------------------------------------------------------
+  // A token from `env` reaches the GitHub request as a Bearer header.
+  // -------------------------------------------------------------------------
+  {
+    const { bundlePath } = fixture();
+    const httpClient = makeMockHttpClient();
+
+    await runSync({
+      path: bundlePath,
+      httpClient,
+      provider: "github",
+      env: { GITHUB_TOKEN: "test-token-123" },
+      now: () => new Date("2026-07-01T00:00:00.000Z"),
+    });
+
+    check(
+      "GITHUB_TOKEN from env is sent as a Bearer token",
+      httpClient.calls.length > 0 && httpClient.calls.every((c) => c.init?.headers?.Authorization === "Bearer test-token-123"),
+      JSON.stringify(httpClient.calls.map((c) => c.init?.headers)),
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // CLI-level: argv parsing / exit codes, spawned — no live-provider refs in
+  // these fixtures, so a real (unmocked) subprocess run can never reach the
+  // network.
+  // -------------------------------------------------------------------------
+  {
+    const dir = mkdtempSync(path.join(tmpdir(), "arkaik-sync-cli-"));
+    createdDirs.push(dir);
+    const bundlePath = path.join(dir, "bundle.json");
+    const bundle = makeBundle();
+    // Strip every live-provider (github) ref — only figma + gitlab remain, so
+    // the spawned CLI never performs a real fetch.
+    bundle.nodes[0].metadata.refs = bundle.nodes[0].metadata.refs.filter((r) => r.type === "figma");
+    writeFileSync(bundlePath, JSON.stringify(bundle, null, 2) + "\n");
+
+    const help = runCli(["sync", "--help"]);
+    check("sync --help exits 0", help.status === 0 && /arkaik sync/.test(help.stdout), help.stdout);
+
+    const noNetwork = runCli(["sync", bundlePath]);
+    check("sync with no live refs exits 0 (no network reachable)", noNetwork.status === 0, `${noNetwork.stdout}\n${noNetwork.stderr}`);
+    check("sync reports no changes", /No ref status changes/.test(noNetwork.stdout), noNetwork.stdout);
+
+    const dryRun = runCli(["sync", "--dry-run", bundlePath]);
+    check("sync --dry-run exits 0", dryRun.status === 0, dryRun.stdout);
+
+    const badProvider = runCli(["sync", "--provider", "bogus", bundlePath]);
+    check("sync with an unknown --provider exits 1", badProvider.status === 1);
+
+    const badFlag = runCli(["sync", "--nope", bundlePath]);
+    check("sync with an unknown flag exits 1", badFlag.status === 1);
+  }
+
+  for (const dir of createdDirs) rmSync(dir, { recursive: true, force: true });
+  rmSync(TEST_BUILD_DIR, { recursive: true, force: true });
+
+  console.log(`\n${passes} passed, ${failures} failed.`);
+  process.exit(failures > 0 ? 1 : 0);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Closes #222. Adds `arkaik sync` — the Kommit-mode ref mirror. It enumerates node `metadata.refs`, queries the external issue/PR API for each supported ref type with a token from env, and dual-writes on change: updating the mirrored `external_status`/`synced_at` in the snapshot **and** appending a `ref.status_changed` event. No arkaik server; no interactive auth. `external_status` is a mirror (never authoritative), `node.status` is never auto-mutated, and `status_mapped` stays advisory (`bundle-format.md:72,74`).

## Key Changes

- **`packages/cli/src/lib/providers.ts`** (new): provider registry keyed by ref `type`.
  - **GitHub live** (`github-issue`, `github-pr`) against the REST API (issue `state`; PR `state`/`merged → "merged"`), token from `GITHUB_TOKEN`.
  - **GitLab / Linear** registered as documented stubs (recognized + reported, skipped in v1) — token vars `GITLAB_TOKEN` / `LINEAR_API_KEY` documented for when they go live.
  - All HTTP goes through an injected `HttpClient` seam (`fetchRefStatus(ref, {token, httpClient})`); the real `fetch` is wired only at the CLI entry.
- **`packages/cli/src/commands/sync.ts`** (new): `runSync(options)` is the testable core (injectable `httpClient`, `now` clock, `env`, `cwd`, `provider` filter, `dryRun`); `runSyncCli` handles argv/exit. On a changed ref it updates `external_status`+`synced_at` in place and appends one `ref.status_changed` via `makeEvent`+`appendJournalEvent`, rewriting `bundle.json` once via `serializeBundle` (only if something changed). `--dry-run` writes nothing.
- **Unknown ref types** round-trip untouched (never error). `node.status`/`status_mapped` untouched throughout.
- **`tests/cli/sync.test.js`** (39 checks, folded into `test:cli`): mocks the HTTP client **in-process** (no real network) — changed/unchanged/error/unknown/stub routing, exactly-one event per change, `node.status` invariants, `--dry-run`, `--provider` filter, token header plumbing, and `arkaik validate` stays VALID after sync.

## Test plan

- [x] `npm run generate` → no artifact drift
- [x] `npm run lint`, `npm run build`
- [x] `npm run validate:seeds`
- [x] all `test:*` including `test:cli` (138 assertions, incl. 39 sync) — no network in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HE4i4eGXnXqsuLZtQvyKgb

---
_Generated by [Claude Code](https://claude.ai/code/session_01HE4i4eGXnXqsuLZtQvyKgb)_