### PR TITLE
M3: arkaik pack + open — single-file interchange + app handoff

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:emit": "node tests/schema/emit.test.js",
     "test:screenshot-size": "node tests/schema/screenshot-size.test.js",
     "test:migrate": "node tests/data/migrate.test.js && node tests/data/import-roundtrip.test.js && node tests/data/seed-import.test.js",
-    "test:cli": "npm run build -w arkaik && node tests/cli/run-cli-tests.js && node tests/cli/init.test.js && node tests/cli/log-release.test.js && node tests/cli/sync.test.js"
+    "test:cli": "npm run build -w arkaik && node tests/cli/run-cli-tests.js && node tests/cli/init.test.js && node tests/cli/log-release.test.js && node tests/cli/sync.test.js && node tests/cli/pack-open.test.js"
   },
   "dependencies": {
     "@radix-ui/react-collapsible": "^1.1.12",

--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -1,0 +1,211 @@
+/**
+ * `arkaik open [--out <path>] [--no-open] [path]`.
+ *
+ * Validate, then hand off to arkaik.app import (docs/spec/toolchain.md § the
+ * CLI). Runs the exact same shape + semantic + snapshot<->journal cross-check
+ * as `arkaik validate` (`../lib/bundle-validate`'s `validateBundleAt`, shared
+ * so the two checks can never drift) and only on success proceeds:
+ *
+ *  1. INVALID bundle: print the findings, exit non-zero. Nothing is packed,
+ *     nothing is written, no browser is opened;
+ *  2. VALID bundle: pack it (`../commands/pack`'s `runPack`, default settings
+ *     — journal embedded, no asset inlining) to `--out` when given, else to a
+ *     fresh temp file under `os.tmpdir()` (the app needs a single file to
+ *     import; the CLI has no way to drop a stream into a browser's file
+ *     picker, so a real file on disk is the handoff artifact);
+ *  3. open the browser to the arkaik.app import surface
+ *     (https://arkaik.app/projects — the app's project list, which has an
+ *     "Import JSON" file picker; there is no dedicated /import route yet) via
+ *     the injectable `opener` seam, then print the packed file's path and the
+ *     URL so a human (or an agent) can complete the drag-in.
+ *
+ * The opener is ALWAYS an injected seam (`RunOpenOptions.opener`, defaulting
+ * to a real `open`/`xdg-open`/`start` spawn) and `--no-open` skips calling it
+ * entirely — together these are what keep tests/CI from ever launching a real
+ * browser.
+ */
+import { spawn } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { validateBundleAt, type BundleValidation } from "../lib/bundle-validate";
+import { formatFinding } from "./validate";
+import { runPack } from "./pack";
+
+const DEFAULT_BUNDLE_PATH = "docs/arkaik/bundle.json";
+
+/** The app's project list — has an "Import JSON" file picker. No dedicated /import route exists yet. */
+export const OPEN_URL = "https://arkaik.app/projects";
+
+const USAGE = `arkaik open [--out <path>] [--no-open] [path]
+
+Validate the bundle (shape + semantic + snapshot<->journal cross-checks, same
+as "arkaik validate"), and only on success pack it and hand off to arkaik.app
+import: the packed bundle is written to disk and a browser is opened to
+${OPEN_URL} (the project list's "Import JSON" picker). On an invalid bundle,
+findings are printed and nothing is packed, written, or opened.
+
+Arguments:
+  path            Path to the bundle JSON file (default: ${DEFAULT_BUNDLE_PATH}).
+
+Options:
+  --out <path>    Write the packed bundle here instead of a temp file.
+  --no-open       Skip launching the browser; still packs and reports the URL.
+  -h, --help      Show this help.`;
+
+function fail(message: string): never {
+  console.error(message);
+  process.exit(1);
+}
+
+/**
+ * The real platform opener — `open` (macOS), `start` (Windows), else
+ * `xdg-open`. Detached, best-effort: the URL is always printed too, so a
+ * missing opener binary (e.g. no `xdg-open` on a headless box) degrades to a
+ * silent no-op rather than an unhandled 'error' event crashing the CLI.
+ */
+function defaultOpener(url: string): void {
+  const platform = process.platform;
+  const child =
+    platform === "darwin"
+      ? spawn("open", [url], { detached: true, stdio: "ignore" })
+      : platform === "win32"
+        ? spawn("cmd", ["/c", "start", "", url], { detached: true, stdio: "ignore" })
+        : spawn("xdg-open", [url], { detached: true, stdio: "ignore" });
+  child.on("error", () => {});
+  child.unref();
+}
+
+export interface RunOpenOptions {
+  /** Path to the bundle JSON file (default: docs/arkaik/bundle.json), resolved against `cwd`. */
+  path?: string;
+  /** Write the packed bundle here instead of a fresh temp file. Resolved against `cwd`. */
+  out?: string;
+  /** Skip the handoff (no browser launch); still validates, packs, and reports. */
+  noOpen?: boolean;
+  /** Base directory `path`/`out` resolve against (default: process.cwd()). */
+  cwd?: string;
+  /** The browser-launch seam. Default: the real platform opener. Tests inject a mock/no-op. */
+  opener?: (url: string) => void | Promise<void>;
+}
+
+export interface RunOpenResult {
+  ok: boolean;
+  /** Set when `ok` is false — a fatal error (bad path/JSON) before validation could even run. */
+  fatal?: string;
+  bundlePath: string;
+  valid: boolean;
+  errorLines: string[];
+  warningLines: string[];
+  /** Set only when `valid` — the path the packed bundle was written to (temp file, or --out). */
+  outPath?: string;
+  /** Set only when `valid` — the arkaik.app URL the handoff points at. */
+  url?: string;
+  /** True iff the opener seam was actually invoked (never true with --no-open). */
+  opened: boolean;
+}
+
+function fatalResult(bundlePath: string, message: string): RunOpenResult {
+  return { ok: false, fatal: message, bundlePath, valid: false, errorLines: [], warningLines: [], opened: false };
+}
+
+/**
+ * Validate the bundle at `options.path`, and only on success pack + hand it
+ * off. On an invalid bundle, no file is written and the opener is never
+ * called.
+ */
+export async function runOpen(options: RunOpenOptions = {}): Promise<RunOpenResult> {
+  const cwd = options.cwd ?? process.cwd();
+  const filePath = resolve(cwd, options.path ?? DEFAULT_BUNDLE_PATH);
+  const noOpen = options.noOpen ?? false;
+
+  let v: BundleValidation;
+  try {
+    v = validateBundleAt(filePath);
+  } catch (e) {
+    return fatalResult(filePath, (e as Error).message);
+  }
+
+  const warningLines = v.result.warnings.map(formatFinding);
+  const errorLines = [
+    ...v.sidecarFindings.map((f) => `ERROR [${f.rule}] line ${f.line}: ${f.message}`),
+    ...v.result.errors.map(formatFinding),
+  ];
+
+  if (!v.valid) {
+    return { ok: true, bundlePath: filePath, valid: false, errorLines, warningLines, opened: false };
+  }
+
+  const packed = runPack({ path: filePath, out: options.out, cwd });
+  if (!packed.ok) {
+    return fatalResult(filePath, packed.fatal ?? "pack failed");
+  }
+
+  let outPath = packed.outPath;
+  if (outPath === undefined) {
+    const dir = mkdtempSync(join(tmpdir(), "arkaik-open-"));
+    outPath = join(dir, "bundle.json");
+    writeFileSync(outPath, packed.output);
+  }
+
+  let opened = false;
+  if (!noOpen) {
+    const opener = options.opener ?? defaultOpener;
+    await opener(OPEN_URL);
+    opened = true;
+  }
+
+  return { ok: true, bundlePath: filePath, valid: true, errorLines, warningLines, outPath, url: OPEN_URL, opened };
+}
+
+export function runOpenCli(args: string[]): void {
+  let out: string | undefined;
+  let noOpen = false;
+  const positionals: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "-h" || arg === "--help") {
+      console.log(USAGE);
+      process.exit(0);
+    } else if (arg === "--no-open") {
+      noOpen = true;
+    } else if (arg === "--out") {
+      const value = args[++i];
+      if (value === undefined) fail(`Missing value for --out\n\n${USAGE}`);
+      out = value;
+    } else if (arg.startsWith("-")) {
+      fail(`Unknown option: ${arg}\n\n${USAGE}`);
+    } else {
+      positionals.push(arg);
+    }
+  }
+
+  const filePath = positionals[0] ?? DEFAULT_BUNDLE_PATH;
+
+  runOpen({ path: filePath, out, noOpen })
+    .then((result) => {
+      if (!result.ok) fail(`FATAL: ${result.fatal}`);
+
+      if (result.warningLines.length > 0) {
+        console.error(`Warnings: ${result.warningLines.length}`);
+        result.warningLines.forEach((w) => console.error(`  ${w}`));
+      }
+
+      if (!result.valid) {
+        console.error(`Errors: ${result.errorLines.length}`);
+        result.errorLines.forEach((e) => console.error(`  ${e}`));
+        console.error("\nInvalid bundle — not packed, not opened.");
+        process.exit(1);
+      }
+
+      console.log(`Packed -> ${result.outPath}`);
+      if (result.opened) {
+        console.log(`Opened ${result.url}`);
+      } else {
+        console.log(`Import at ${result.url} (drag in ${result.outPath})`);
+      }
+      process.exit(0);
+    })
+    .catch((e: unknown) => fail(`FATAL: ${(e as Error).message}`));
+}

--- a/packages/cli/src/commands/pack.ts
+++ b/packages/cli/src/commands/pack.ts
@@ -1,0 +1,261 @@
+/**
+ * `arkaik pack [--no-journal] [--inline-assets] [--out <path>] [path]`.
+ *
+ * Produces a SINGLE self-contained interchange bundle (docs/spec/journal.md §
+ * Interchange: embedded journal[]; docs/spec/bundle-format.md § Asset Values):
+ *  1. read the bundle at `path` plus its sibling `journal.jsonl` sidecar;
+ *  2. journal embedding — by default the bundle's `journal[]` is set to
+ *     `loadJournalEvents(bundle, path)`: the embedded journal when the source
+ *     bundle already carries one, otherwise the sidecar (exactly the
+ *     embedded-wins-else-sidecar precedence `arkaik validate` folds by, see
+ *     lib/journal-io.ts). `--no-journal` strips `journal[]` instead — the
+ *     Publik-safe posture (docs/spec/journal.md:41);
+ *  3. `--inline-assets` (OFF by default, local-only in v1): every
+ *     `metadata.platformScreenshots` value that is a *relative path* (no URI
+ *     scheme, no leading `/` — docs/spec/bundle-format.md § Asset Values) is
+ *     read from disk (resolved against the bundle's directory) and rewritten
+ *     to a `data:` URI, base64-encoded, with a best-effort mime type from the
+ *     extension. Absolute `https://` URLs and existing `data:` URIs are left
+ *     untouched. Uploading to a hosted bucket is OUT OF SCOPE for v1 — only
+ *     local relative-path assets can be inlined;
+ *  4. the (possibly mutated) bundle object — never reconstructed as
+ *     `{project,nodes,edges}` — is written out via `serializeBundle`, so it
+ *     lands in canonical form (top-level key order incl. `journal`) and every
+ *     unknown top-level key / unknown field round-trips untouched (the
+ *     `rewriteBundleProjectId` defect, docs/spec/bundle-format.md:40, this
+ *     command must not repeat).
+ *
+ * Output goes to `--out <path>` when given, else to stdout (so `arkaik pack |
+ * ...` composes); status/warning lines always go to stderr so stdout stays
+ * pure bundle JSON in the no-`--out` case.
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, extname, resolve } from "node:path";
+import { serializeBundle } from "@arkaik/schema";
+import { readBundle } from "../lib/bundle-io";
+import { loadJournalEvents } from "../lib/journal-io";
+
+const DEFAULT_BUNDLE_PATH = "docs/arkaik/bundle.json";
+
+const USAGE = `arkaik pack [--no-journal] [--inline-assets] [--out <path>] [path]
+
+Produce a single self-contained interchange bundle: fold in the sidecar
+journal (or keep an existing embedded one) and, with --inline-assets, inline
+local screenshot files as data: URIs. Written canonically via serializeBundle.
+Unknown top-level keys and unknown fields always round-trip.
+
+Arguments:
+  path              Path to the bundle JSON file (default: ${DEFAULT_BUNDLE_PATH}).
+
+Options:
+  --no-journal      Omit the embedded journal[] (Publik-safe posture — history
+                     stays private unless explicitly included). Default: the
+                     journal IS embedded (that is the point of a single-file
+                     interchange) — embedded wins over the sidecar when the
+                     bundle already carries one, otherwise the sidecar is used
+                     (same precedence "arkaik validate" folds by).
+  --inline-assets   Convert relative-path metadata.platformScreenshots values
+                     into data: URIs by reading the file from disk (resolved
+                     against the bundle's directory). Absolute https:// URLs
+                     and existing data: URIs are left as-is. v1 scope: local
+                     files only — uploading a remote/hosted copy is not
+                     implemented.
+  --out <path>      Write the packed bundle here instead of stdout.
+  -h, --help        Show this help.`;
+
+function fail(message: string): never {
+  console.error(message);
+  process.exit(1);
+}
+
+const MIME_BY_EXTENSION: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".svg": "image/svg+xml",
+  ".avif": "image/avif",
+  ".bmp": "image/bmp",
+};
+
+function mimeForExtension(ext: string): string {
+  return MIME_BY_EXTENSION[ext.toLowerCase()] ?? "application/octet-stream";
+}
+
+/** No URI scheme and no leading `/` — docs/spec/bundle-format.md § Asset Values. */
+const URI_SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
+function isRelativeAssetPath(value: string): boolean {
+  return value.length > 0 && !URI_SCHEME_RE.test(value) && !value.startsWith("/");
+}
+
+export interface InlinedAsset {
+  nodeId: string;
+  platform: string;
+  path: string;
+}
+
+export interface RunPackOptions {
+  /** Path to the bundle JSON file (default: docs/arkaik/bundle.json), resolved against `cwd`. */
+  path?: string;
+  /** Write the packed bundle here instead of returning it for the caller to print. Resolved against `cwd`. */
+  out?: string;
+  /** Strip the embedded journal[] instead of embedding it. */
+  noJournal?: boolean;
+  /** Inline local relative-path screenshot assets as data: URIs. */
+  inlineAssets?: boolean;
+  /** Base directory `path`/`out` resolve against (default: process.cwd()). */
+  cwd?: string;
+}
+
+export interface RunPackResult {
+  ok: boolean;
+  /** Set when `ok` is false — a fatal error before packing could complete. */
+  fatal?: string;
+  bundlePath: string;
+  /** Set only when `--out` was given — the resolved path the packed bundle was written to. */
+  outPath?: string;
+  journalIncluded: boolean;
+  journalEventCount: number;
+  inlinedAssets: InlinedAsset[];
+  /** Non-fatal notices — e.g. an asset referenced by a relative path that was not found on disk. */
+  assetWarnings: string[];
+  /** The canonical packed bundle text (serializeBundle output), always populated on success. */
+  output: string;
+}
+
+function fatalResult(bundlePath: string, message: string): RunPackResult {
+  return {
+    ok: false,
+    fatal: message,
+    bundlePath,
+    journalIncluded: false,
+    journalEventCount: 0,
+    inlinedAssets: [],
+    assetWarnings: [],
+    output: "",
+  };
+}
+
+/**
+ * Pack the bundle at `options.path` into a single self-contained interchange
+ * file. Pure with respect to the source bundle file (never mutates it) — only
+ * `--out` writes anything to disk.
+ */
+export function runPack(options: RunPackOptions = {}): RunPackResult {
+  const cwd = options.cwd ?? process.cwd();
+  const filePath = resolve(cwd, options.path ?? DEFAULT_BUNDLE_PATH);
+  const noJournal = options.noJournal ?? false;
+  const inlineAssets = options.inlineAssets ?? false;
+
+  let bundle: Record<string, unknown>;
+  try {
+    bundle = readBundle(filePath);
+  } catch (e) {
+    return fatalResult(filePath, (e as Error).message);
+  }
+
+  let journalIncluded = false;
+  let journalEventCount = 0;
+  if (noJournal) {
+    delete bundle.journal;
+  } else {
+    const events = loadJournalEvents(bundle, filePath);
+    if (events.length > 0) {
+      bundle.journal = events;
+      journalIncluded = true;
+      journalEventCount = events.length;
+    }
+  }
+
+  const inlinedAssets: InlinedAsset[] = [];
+  const assetWarnings: string[] = [];
+  if (inlineAssets) {
+    const bundleDir = dirname(filePath);
+    const nodes = Array.isArray(bundle.nodes) ? (bundle.nodes as Record<string, unknown>[]) : [];
+    for (const node of nodes) {
+      const nodeId = typeof node.id === "string" ? node.id : "?";
+      const metadata = node.metadata;
+      if (metadata === null || typeof metadata !== "object") continue;
+      const screenshots = (metadata as Record<string, unknown>).platformScreenshots;
+      if (screenshots === null || typeof screenshots !== "object" || Array.isArray(screenshots)) continue;
+      const map = screenshots as Record<string, unknown>;
+
+      for (const [platform, value] of Object.entries(map)) {
+        if (typeof value !== "string" || !isRelativeAssetPath(value)) continue;
+        const assetPath = resolve(bundleDir, value);
+        if (!existsSync(assetPath)) {
+          assetWarnings.push(`${nodeId}/${platform}: asset not found at ${assetPath} — left as-is`);
+          continue;
+        }
+        const bytes = readFileSync(assetPath);
+        const mime = mimeForExtension(extname(assetPath));
+        map[platform] = `data:${mime};base64,${bytes.toString("base64")}`;
+        inlinedAssets.push({ nodeId, platform, path: value });
+      }
+    }
+  }
+
+  const output = serializeBundle(bundle as unknown as Parameters<typeof serializeBundle>[0]);
+
+  let outPath: string | undefined;
+  if (options.out !== undefined) {
+    outPath = resolve(cwd, options.out);
+    mkdirSync(dirname(outPath), { recursive: true });
+    writeFileSync(outPath, output);
+  }
+
+  return { ok: true, bundlePath: filePath, outPath, journalIncluded, journalEventCount, inlinedAssets, assetWarnings, output };
+}
+
+export function runPackCli(args: string[]): void {
+  let noJournal = false;
+  let inlineAssets = false;
+  let out: string | undefined;
+  const positionals: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "-h" || arg === "--help") {
+      console.log(USAGE);
+      process.exit(0);
+    } else if (arg === "--no-journal") {
+      noJournal = true;
+    } else if (arg === "--inline-assets") {
+      inlineAssets = true;
+    } else if (arg === "--out") {
+      const value = args[++i];
+      if (value === undefined) fail(`Missing value for --out\n\n${USAGE}`);
+      out = value;
+    } else if (arg.startsWith("-")) {
+      fail(`Unknown option: ${arg}\n\n${USAGE}`);
+    } else {
+      positionals.push(arg);
+    }
+  }
+
+  const filePath = positionals[0] ?? DEFAULT_BUNDLE_PATH;
+  const result = runPack({ path: filePath, out, noJournal, inlineAssets });
+  if (!result.ok) fail(`FATAL: ${result.fatal}`);
+
+  if (result.journalIncluded) {
+    console.error(`Journal: embedded ${result.journalEventCount} event(s)`);
+  } else if (noJournal) {
+    console.error("Journal: omitted (--no-journal)");
+  } else {
+    console.error("Journal: none to embed (no embedded journal, no sidecar)");
+  }
+  for (const asset of result.inlinedAssets) {
+    console.error(`Inlined asset: ${asset.nodeId}/${asset.platform} (${asset.path})`);
+  }
+  for (const warning of result.assetWarnings) {
+    console.error(`WARN: ${warning}`);
+  }
+
+  if (result.outPath !== undefined) {
+    console.error(`Packed -> ${result.outPath}`);
+  } else {
+    process.stdout.write(result.output);
+  }
+  process.exit(0);
+}

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -12,17 +12,10 @@
  * prints a report over the structured {path, rule, message, severity} findings.
  * Exit 0 when valid, 1 when invalid; warnings never fail.
  */
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import {
-  validateBundle,
-  parseJournalLines,
-  serializeBundle,
-  type JournalLineFinding,
-  type ValidationFinding,
-} from "@arkaik/schema";
-
-const JOURNAL_SIDECAR = "journal.jsonl";
+import { readFileSync, writeFileSync } from "node:fs";
+import { serializeBundle, type ValidationFinding } from "@arkaik/schema";
+import { readBundle } from "../lib/bundle-io";
+import { validateBundleAt, JOURNAL_SIDECAR } from "../lib/bundle-validate";
 
 const USAGE = `arkaik validate [--fix-format] [path]
 
@@ -45,36 +38,29 @@ function fail(message: string): never {
   process.exit(1);
 }
 
-/** Read + JSON.parse the bundle at `filePath`, exiting with a FATAL on error. */
-function readBundle(filePath: string): unknown {
-  if (!existsSync(filePath)) fail(`File not found: ${filePath}`);
-  const raw = readFileSync(filePath, "utf8");
-  try {
-    return JSON.parse(raw);
-  } catch (e) {
-    return fail(`FATAL: Cannot parse JSON — ${(e as Error).message}`);
-  }
-}
-
 function countBySpecies(nodes: unknown[], species: string): number {
   return nodes.filter((n) => (n as { species?: unknown } | null)?.species === species).length;
 }
 
-function formatFinding(f: ValidationFinding): string {
+/** Exported so `arkaik open` (packages/cli/src/commands/open.ts) can format the
+ * same findings it gates on without re-implementing the string shape. */
+export function formatFinding(f: ValidationFinding): string {
   const where = f.path ? ` ${f.path}` : "";
   return `${f.severity.toUpperCase()} [${f.rule}]${where}: ${f.message}`;
 }
 
 /** `--fix-format`: rewrite the bundle file to canonical serialization in place. */
 function fixFormat(filePath: string): never {
-  const bundle = readBundle(filePath);
-  if (typeof bundle !== "object" || bundle === null || Array.isArray(bundle)) {
-    fail("FATAL: Bundle must be a JSON object.");
+  let bundle: Record<string, unknown>;
+  try {
+    bundle = readBundle(filePath);
+  } catch (e) {
+    return fail(`FATAL: ${(e as Error).message}`);
   }
   const before = readFileSync(filePath, "utf8");
   // serializeBundle preserves unknown top-level keys (schema_version, journal)
   // and unknown fields, and is idempotent — running twice yields no change.
-  const after = serializeBundle(bundle as Parameters<typeof serializeBundle>[0]);
+  const after = serializeBundle(bundle as unknown as Parameters<typeof serializeBundle>[0]);
   if (after === before) {
     console.log(`Already canonical: ${filePath}`);
   } else {
@@ -86,58 +72,38 @@ function fixFormat(filePath: string): never {
 
 /** `validate`: validate the bundle (+ sidecar journal) and report findings. */
 function validate(filePath: string): never {
-  const bundle = readBundle(filePath);
-
-  const loose = bundle as
-    | { project?: unknown; nodes?: unknown; edges?: unknown; journal?: unknown }
-    | null;
-  if (typeof loose !== "object" || loose === null || !loose.project || !loose.nodes || !loose.edges) {
-    fail("FATAL: Missing top-level keys (project, nodes, edges).");
-  }
-
-  // Fold in the canonical JSONL sidecar when the bundle carries no embedded
-  // journal. An embedded `journal` (the packed interchange form) always wins.
-  let sidecarFindings: JournalLineFinding[] = [];
-  let sidecarLoaded = false;
-  if (loose.journal === undefined) {
-    const sidecarPath = join(dirname(filePath), JOURNAL_SIDECAR);
-    if (existsSync(sidecarPath)) {
-      const { events, findings } = parseJournalLines(readFileSync(sidecarPath, "utf8"));
-      sidecarFindings = findings;
-      sidecarLoaded = true;
-      loose.journal = events;
+  const v = (() => {
+    try {
+      return validateBundleAt(filePath);
+    } catch (e) {
+      return fail(`FATAL: ${(e as Error).message}`);
     }
-  }
-
-  const nodes = Array.isArray(loose.nodes) ? loose.nodes : [];
-  const edges = Array.isArray(loose.edges) ? loose.edges : [];
-  const journal = Array.isArray(loose.journal) ? loose.journal : [];
-  const result = validateBundle(bundle);
+  })();
 
   console.log("\n  Arkaik Bundle Validation");
   console.log("  =======================\n");
   console.log(
-    `  Nodes: ${nodes.length} (${countBySpecies(nodes, "view")} views, ${countBySpecies(nodes, "flow")} flows, ${countBySpecies(nodes, "data-model")} data-models, ${countBySpecies(nodes, "api-endpoint")} api-endpoints)`,
+    `  Nodes: ${v.nodes.length} (${countBySpecies(v.nodes, "view")} views, ${countBySpecies(v.nodes, "flow")} flows, ${countBySpecies(v.nodes, "data-model")} data-models, ${countBySpecies(v.nodes, "api-endpoint")} api-endpoints)`,
   );
-  console.log(`  Edges: ${edges.length}`);
-  if (sidecarLoaded) {
-    console.log(`  Journal: ${journal.length} event(s) from ${JOURNAL_SIDECAR} sidecar`);
-  } else if (journal.length > 0) {
-    console.log(`  Journal: ${journal.length} embedded event(s)`);
+  console.log(`  Edges: ${v.edges.length}`);
+  if (v.sidecarLoaded) {
+    console.log(`  Journal: ${v.journal.length} event(s) from ${JOURNAL_SIDECAR} sidecar`);
+  } else if (v.journal.length > 0) {
+    console.log(`  Journal: ${v.journal.length} embedded event(s)`);
   }
   console.log("");
 
-  if (result.warnings.length > 0) {
-    console.log(`  Warnings: ${result.warnings.length}`);
-    result.warnings.forEach((w) => console.log(`    ${formatFinding(w)}`));
+  if (v.result.warnings.length > 0) {
+    console.log(`  Warnings: ${v.result.warnings.length}`);
+    v.result.warnings.forEach((w) => console.log(`    ${formatFinding(w)}`));
     console.log("");
   }
 
   // Sidecar line-parse findings are hard errors, joined with the semantic
   // errors from validateBundle.
   const errorLines = [
-    ...sidecarFindings.map((f) => `ERROR [${f.rule}] line ${f.line}: ${f.message}`),
-    ...result.errors.map(formatFinding),
+    ...v.sidecarFindings.map((f) => `ERROR [${f.rule}] line ${f.line}: ${f.message}`),
+    ...v.result.errors.map(formatFinding),
   ];
 
   if (errorLines.length === 0) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,8 +3,8 @@
  *
  * A tiny hand-rolled command dispatcher — deliberately dependency-free (no
  * commander/yargs). Each command owns its own flag parsing so later commands
- * (log/release/sync/pack/open — separate issues) slot in by adding a `case`
- * here and a handler module under `./commands`.
+ * (push — Phase 4) slot in by adding a `case` here and a handler module under
+ * `./commands`.
  *
  * All schema behaviour is reused verbatim from `@arkaik/schema`; the commands
  * never re-implement validation or serialization.
@@ -14,6 +14,8 @@ import { runValidate } from "./commands/validate";
 import { runLog } from "./commands/log";
 import { runRelease } from "./commands/release";
 import { runSyncCli } from "./commands/sync";
+import { runPackCli } from "./commands/pack";
+import { runOpenCli } from "./commands/open";
 
 const USAGE = `arkaik — CLI for Arkaik project bundles
 
@@ -26,6 +28,8 @@ Commands:
   log [--node <id>] [path]    Print the journal: project changelog, or one node's timeline.
   release <version> [path]    Tag a release (append release.tagged) and draft its notes.
   sync [options] [path]       Mirror external ref status (GitHub issues/PRs) into node refs.
+  pack [options] [path]       Produce a single self-contained interchange bundle (embeds the journal).
+  open [options] [path]       Validate, then hand off the packed bundle to arkaik.app import.
 
 Options:
   -h, --help        Show this help.
@@ -55,6 +59,12 @@ function main(argv: string[]): void {
       return;
     case "sync":
       runSyncCli(rest);
+      return;
+    case "pack":
+      runPackCli(rest);
+      return;
+    case "open":
+      runOpenCli(rest);
       return;
     default:
       console.error(`Unknown command: ${command}\n`);

--- a/packages/cli/src/lib/bundle-validate.ts
+++ b/packages/cli/src/lib/bundle-validate.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared "read + fold + validate" for the `arkaik` CLI — shape + semantic +
+ * snapshot<->journal cross-checks (docs/spec/journal.md § Authority &
+ * Consistency Model), reused by both `arkaik validate` (reports + exits) and
+ * `arkaik open` (gates the handoff to arkaik.app import on this exact check).
+ *
+ * Mirrors packages/schema/src/cli/validate-bundle-cli.ts: fold in a sibling
+ * `journal.jsonl` sidecar when the bundle carries no embedded journal — an
+ * embedded `journal` (the packed interchange form) always wins — then run
+ * `validateBundle`. Kept as one shared implementation inside packages/cli (both
+ * callers are esbuild-bundled into the same CLI binary, unlike the standalone
+ * schema artifact) so the fold logic can't drift between `validate` and `open`.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import {
+  validateBundle,
+  parseJournalLines,
+  type JournalLineFinding,
+  type ValidationResult,
+} from "@arkaik/schema";
+import { readBundle } from "./bundle-io";
+
+/** The canonical JSONL sidecar name, sibling to the bundle (mirrors journal-io.ts). */
+export const JOURNAL_SIDECAR = "journal.jsonl";
+
+export interface BundleValidation {
+  bundle: Record<string, unknown>;
+  nodes: unknown[];
+  edges: unknown[];
+  journal: unknown[];
+  /** True when a sibling journal.jsonl sidecar was folded in (no embedded journal was present). */
+  sidecarLoaded: boolean;
+  /** Line-level parse findings from the sidecar (bad JSON, missing envelope fields) — hard errors. */
+  sidecarFindings: JournalLineFinding[];
+  result: ValidationResult;
+  /** No sidecar line-parse findings and no validateBundle errors. Warnings never fail. */
+  valid: boolean;
+}
+
+/**
+ * Read `filePath`, fold in a sibling journal.jsonl sidecar when the bundle has
+ * no embedded journal, and run `validateBundle`. Throws (readBundle's errors,
+ * or a "Missing top-level keys" Error) on a fatal read/shape problem — callers
+ * decide how to report it (message + exit code).
+ */
+export function validateBundleAt(filePath: string): BundleValidation {
+  const bundle = readBundle(filePath);
+
+  const loose = bundle as { project?: unknown; nodes?: unknown; edges?: unknown; journal?: unknown };
+  if (!loose.project || !loose.nodes || !loose.edges) {
+    throw new Error("Missing top-level keys (project, nodes, edges).");
+  }
+
+  let sidecarFindings: JournalLineFinding[] = [];
+  let sidecarLoaded = false;
+  if (loose.journal === undefined) {
+    const sidecarPath = join(dirname(filePath), JOURNAL_SIDECAR);
+    if (existsSync(sidecarPath)) {
+      const { events, findings } = parseJournalLines(readFileSync(sidecarPath, "utf8"));
+      sidecarFindings = findings;
+      sidecarLoaded = true;
+      loose.journal = events;
+    }
+  }
+
+  const nodes = Array.isArray(loose.nodes) ? loose.nodes : [];
+  const edges = Array.isArray(loose.edges) ? loose.edges : [];
+  const journal = Array.isArray(loose.journal) ? loose.journal : [];
+  const result = validateBundle(bundle);
+  const valid = sidecarFindings.length === 0 && result.errors.length === 0;
+
+  return { bundle, nodes, edges, journal, sidecarLoaded, sidecarFindings, result, valid };
+}

--- a/tests/cli/pack-open.test.js
+++ b/tests/cli/pack-open.test.js
@@ -1,0 +1,386 @@
+#!/usr/bin/env node
+
+/**
+ * Exercises `arkaik pack` + `arkaik open` (issue #223).
+ *
+ * Two layers, mirroring tests/cli/sync.test.js:
+ *  - `runPack()`/`runOpen()` exercised in-process: packages/cli/src/commands/
+ *    {pack,open}.ts are esbuild-bundled (same technique build.js uses for the
+ *    real CLI, just to a throwaway `.test-build/` dir) into importable ESM
+ *    modules, so a mock `opener` seam can be injected straight into `runOpen`
+ *    — no subprocess, no real browser launch, ever.
+ *  - the built CLI binary (packages/cli/dist/index.js) spawned for the
+ *    argv-parsing / exit-code / --help contract. The one CLI-level `open` case
+ *    without `--no-open` uses a deliberately INVALID bundle: `runOpen`
+ *    validates before ever touching the opener seam, so that path can never
+ *    reach the real browser-launch code even unmocked.
+ *
+ * Covers:
+ *  - pack embeds the sidecar journal by default; output is canonical
+ *    (matches serializeBundle), parses, and passes validateBundle;
+ *  - pack --no-journal omits journal[] entirely;
+ *  - pack --inline-assets turns a local relative-path screenshot into a
+ *    data: URI (byte-for-byte base64 of the file on disk) while leaving an
+ *    https:// URL untouched; without the flag, screenshots are untouched;
+ *  - an unknown top-level key and an unknown node field both survive packing
+ *    (the bundle-format.md:40 defect this command must not repeat);
+ *  - open on an INVALID bundle: ok, valid:false, reports findings, never sets
+ *    outPath, never calls the opener;
+ *  - open on a VALID bundle with --no-open: writes the packed file, reports
+ *    the arkaik.app URL, opener seam NOT called;
+ *  - open on a VALID bundle without --no-open: the injected opener IS called
+ *    with the URL;
+ *  - open --out writes the packed bundle to the given path instead of a temp
+ *    file.
+ */
+
+const { build } = require("esbuild");
+const { spawnSync } = require("child_process");
+const {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} = require("fs");
+const { tmpdir } = require("os");
+const path = require("path");
+const { pathToFileURL } = require("url");
+
+const ROOT = path.join(__dirname, "..", "..");
+const CLI = path.join(ROOT, "packages", "cli", "dist", "index.js");
+const FIXTURES = path.join(ROOT, "tests", "fixtures");
+const PACK_ENTRY = path.join(ROOT, "packages", "cli", "src", "commands", "pack.ts");
+const OPEN_ENTRY = path.join(ROOT, "packages", "cli", "src", "commands", "open.ts");
+const TEST_BUILD_DIR = path.join(ROOT, "packages", "cli", ".test-build");
+const PACK_BUNDLE = path.join(TEST_BUILD_DIR, "pack.mjs");
+const OPEN_BUNDLE = path.join(TEST_BUILD_DIR, "open.mjs");
+
+if (!existsSync(CLI)) {
+  console.error(`CLI not built at ${CLI}. Run \`npm run build -w arkaik\` first.`);
+  process.exit(1);
+}
+
+const { serializeBundle, validateBundle } = require("../schema/load-schema").loadSchema();
+
+function runCli(args) {
+  return spawnSync(process.execPath, [CLI, ...args], { encoding: "utf8" });
+}
+
+let failures = 0;
+let passes = 0;
+function check(name, cond, detail) {
+  if (cond) {
+    passes++;
+    console.log(`PASS: ${name}`);
+  } else {
+    failures++;
+    console.log(`FAIL: ${name}`);
+    if (detail) console.log(detail);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: one node with a relative-path screenshot and an https one, a
+// snapshot<->journal-consistent sidecar, and a real asset file on disk.
+// ---------------------------------------------------------------------------
+function makeBundle() {
+  return {
+    schema_version: 1,
+    project: {
+      id: "demo",
+      title: "Demo",
+      created_at: "2026-01-01T00:00:00.000Z",
+      updated_at: "2026-01-03T00:00:00.000Z",
+    },
+    nodes: [
+      {
+        id: "V-home",
+        project_id: "demo",
+        species: "view",
+        title: "Home",
+        status: "live",
+        platforms: ["web", "ios"],
+        metadata: {
+          platformScreenshots: {
+            web: "assets/home.png",
+            ios: "https://cdn.example.com/home-ios.png",
+          },
+        },
+      },
+    ],
+    edges: [],
+  };
+}
+
+const JOURNAL_LINES = [
+  { id: "01J9ZK4E4N0000000000000001", ts: "2026-01-01T00:00:00.000Z", actor: "claude-code", type: "node.created", node_id: "V-home", species: "view", title: "Home" },
+  { id: "01J9ZK4E4N0000000000000002", ts: "2026-01-02T00:00:00.000Z", actor: "claude-code", type: "node.status_changed", node_id: "V-home", from: "idea", to: "development" },
+  { id: "01J9ZK4E4N0000000000000003", ts: "2026-01-03T00:00:00.000Z", actor: "claude-code", type: "node.status_changed", node_id: "V-home", from: "development", to: "live" },
+];
+const JOURNAL = JOURNAL_LINES.map((e) => JSON.stringify(e)).join("\n") + "\n";
+const ASSET_BYTES = Buffer.from("FAKE-PNG-BYTES");
+
+const createdDirs = [];
+
+/** Fresh temp dir with bundle.json + journal.jsonl + assets/home.png. */
+function fixture() {
+  const dir = mkdtempSync(path.join(tmpdir(), "arkaik-pack-"));
+  createdDirs.push(dir);
+  const bundlePath = path.join(dir, "bundle.json");
+  const journalPath = path.join(dir, "journal.jsonl");
+  const bundle = makeBundle();
+  writeFileSync(bundlePath, JSON.stringify(bundle, null, 2) + "\n");
+  writeFileSync(journalPath, JOURNAL);
+  mkdirSync(path.join(dir, "assets"), { recursive: true });
+  writeFileSync(path.join(dir, "assets", "home.png"), ASSET_BYTES);
+  return { dir, bundlePath, journalPath, originalBundle: bundle };
+}
+
+async function main() {
+  mkdirSync(TEST_BUILD_DIR, { recursive: true });
+  await Promise.all([
+    build({
+      entryPoints: [PACK_ENTRY],
+      outfile: PACK_BUNDLE,
+      bundle: true,
+      platform: "node",
+      target: "node18",
+      format: "esm",
+      legalComments: "none",
+    }),
+    build({
+      entryPoints: [OPEN_ENTRY],
+      outfile: OPEN_BUNDLE,
+      bundle: true,
+      platform: "node",
+      target: "node18",
+      format: "esm",
+      legalComments: "none",
+    }),
+  ]);
+  const { runPack } = await import(pathToFileURL(PACK_BUNDLE).href);
+  const { runOpen, OPEN_URL } = await import(pathToFileURL(OPEN_BUNDLE).href);
+
+  // -------------------------------------------------------------------------
+  // pack: embeds the sidecar journal by default; canonical + parses + valid.
+  // -------------------------------------------------------------------------
+  {
+    const { bundlePath } = fixture();
+    const result = runPack({ path: bundlePath });
+
+    check("runPack ok", result.ok === true, JSON.stringify(result));
+    check(
+      "journal embedded by default (3 sidecar events)",
+      result.journalIncluded === true && result.journalEventCount === 3,
+      JSON.stringify(result),
+    );
+
+    const parsed = JSON.parse(result.output);
+    check("packed output is canonical (matches serializeBundle)", serializeBundle(parsed) === result.output);
+    check(
+      "packed output embeds journal[] with all 3 sidecar events",
+      Array.isArray(parsed.journal) && parsed.journal.length === 3,
+      JSON.stringify(parsed.journal),
+    );
+    const validation = validateBundle(parsed);
+    check("packed output passes validateBundle", validation.valid, JSON.stringify(validation.errors));
+    check("no --out given: result.outPath is unset", result.outPath === undefined);
+  }
+
+  // -------------------------------------------------------------------------
+  // pack --no-journal: omits journal[] entirely.
+  // -------------------------------------------------------------------------
+  {
+    const { bundlePath } = fixture();
+    const result = runPack({ path: bundlePath, noJournal: true });
+
+    check("runPack --no-journal ok", result.ok === true);
+    check("journalIncluded is false", result.journalIncluded === false);
+    const parsed = JSON.parse(result.output);
+    check("no journal key in the output at all", parsed.journal === undefined, JSON.stringify(Object.keys(parsed)));
+  }
+
+  // -------------------------------------------------------------------------
+  // pack --inline-assets: local relative path -> data: URI; https:// untouched.
+  // Without the flag, assets are left exactly as-is.
+  // -------------------------------------------------------------------------
+  {
+    const { bundlePath, originalBundle } = fixture();
+
+    const inlined = runPack({ path: bundlePath, inlineAssets: true });
+    check("runPack --inline-assets ok", inlined.ok === true);
+    const parsedInlined = JSON.parse(inlined.output);
+    const shots = parsedInlined.nodes[0].metadata.platformScreenshots;
+    const expectedDataUri = `data:image/png;base64,${ASSET_BYTES.toString("base64")}`;
+    check(
+      "relative-path screenshot became a byte-accurate data: URI",
+      shots.web === expectedDataUri,
+      shots.web,
+    );
+    check("https:// screenshot left untouched", shots.ios === "https://cdn.example.com/home-ios.png");
+    check(
+      "reports the inlined asset",
+      inlined.inlinedAssets.some((a) => a.nodeId === "V-home" && a.platform === "web" && a.path === "assets/home.png"),
+      JSON.stringify(inlined.inlinedAssets),
+    );
+
+    const plain = runPack({ path: bundlePath });
+    const parsedPlain = JSON.parse(plain.output);
+    const plainShots = parsedPlain.nodes[0].metadata.platformScreenshots;
+    const originalShots = originalBundle.nodes[0].metadata.platformScreenshots;
+    check(
+      "without --inline-assets, screenshots are left exactly as-is (by value — canonicalization reorders keys, not values)",
+      plainShots.web === originalShots.web && plainShots.ios === originalShots.ios,
+      JSON.stringify(plainShots),
+    );
+    check("without --inline-assets, nothing reported as inlined", plain.inlinedAssets.length === 0);
+  }
+
+  // -------------------------------------------------------------------------
+  // Unknown top-level key + unknown node field survive packing (never
+  // reconstructed as {project,nodes,edges} — bundle-format.md:40's defect).
+  // -------------------------------------------------------------------------
+  {
+    const { bundlePath } = fixture();
+    const raw = JSON.parse(readFileSync(bundlePath, "utf8"));
+    raw.custom_top_level = { z: 1, a: 2 };
+    raw.nodes[0].custom_node_field = "kept";
+    writeFileSync(bundlePath, JSON.stringify(raw, null, 2) + "\n");
+
+    const result = runPack({ path: bundlePath });
+    const parsed = JSON.parse(result.output);
+    check(
+      "unknown top-level key survives packing",
+      parsed.custom_top_level && parsed.custom_top_level.a === 2 && parsed.custom_top_level.z === 1,
+      JSON.stringify(parsed.custom_top_level),
+    );
+    check("unknown node field survives packing", parsed.nodes[0].custom_node_field === "kept");
+  }
+
+  // -------------------------------------------------------------------------
+  // open on an INVALID bundle: findings reported, never packs/writes/opens.
+  // -------------------------------------------------------------------------
+  {
+    const invalidPath = path.join(FIXTURES, "duplicate-node-id.json");
+    const openerCalls = [];
+    const opener = async (url) => openerCalls.push(url);
+
+    const result = await runOpen({ path: invalidPath, opener });
+
+    check("runOpen ok (validation itself ran without a fatal error)", result.ok === true, JSON.stringify(result));
+    check("runOpen reports the bundle invalid", result.valid === false);
+    check("runOpen reports at least one error finding", result.errorLines.length > 0, JSON.stringify(result.errorLines));
+    check("runOpen does not set outPath for an invalid bundle", result.outPath === undefined);
+    check("runOpen does not call the opener for an invalid bundle", openerCalls.length === 0, JSON.stringify(openerCalls));
+    check("runOpen reports opened:false for an invalid bundle", result.opened === false);
+  }
+
+  // -------------------------------------------------------------------------
+  // open on a VALID bundle: --no-open writes the packed file + reports the
+  // URL without calling the opener; without --no-open the seam IS called.
+  // -------------------------------------------------------------------------
+  {
+    const { bundlePath } = fixture();
+
+    const openerCallsA = [];
+    const openerA = async (url) => openerCallsA.push(url);
+    const noOpenResult = await runOpen({ path: bundlePath, noOpen: true, opener: openerA });
+
+    check("runOpen (valid, --no-open) ok", noOpenResult.ok === true, JSON.stringify(noOpenResult));
+    check("runOpen (valid, --no-open) reports valid:true", noOpenResult.valid === true);
+    check("--no-open: opener seam NOT called", openerCallsA.length === 0, JSON.stringify(openerCallsA));
+    check("--no-open: opened flag is false", noOpenResult.opened === false);
+    check(
+      "--no-open: packed file was written to disk",
+      typeof noOpenResult.outPath === "string" && existsSync(noOpenResult.outPath),
+      JSON.stringify(noOpenResult),
+    );
+    check("--no-open: reports the arkaik.app URL", noOpenResult.url === OPEN_URL, noOpenResult.url);
+    const packed = JSON.parse(readFileSync(noOpenResult.outPath, "utf8"));
+    check("the packed handoff file itself passes validateBundle", validateBundle(packed).valid, JSON.stringify(validateBundle(packed).errors));
+
+    const openerCallsB = [];
+    const openerB = async (url) => openerCallsB.push(url);
+    const openResult = await runOpen({ path: bundlePath, opener: openerB });
+
+    check(
+      "without --no-open: the injected opener IS called, with the URL",
+      openerCallsB.length === 1 && openerCallsB[0] === OPEN_URL,
+      JSON.stringify(openerCallsB),
+    );
+    check("without --no-open: opened flag is true", openResult.opened === true);
+  }
+
+  // -------------------------------------------------------------------------
+  // open --out writes the packed bundle to the given path.
+  // -------------------------------------------------------------------------
+  {
+    const { bundlePath, dir } = fixture();
+    const outPath = path.join(dir, "handoff.json");
+    const opener = async () => {};
+
+    const result = await runOpen({ path: bundlePath, out: outPath, noOpen: true, opener });
+    check("open --out writes to the given path", result.outPath === outPath, JSON.stringify(result));
+    check("the file exists at --out", existsSync(outPath));
+  }
+
+  // -------------------------------------------------------------------------
+  // CLI-level: argv parsing / exit codes / --help, spawned. The one `open`
+  // case run WITHOUT --no-open here uses a deliberately invalid bundle, so it
+  // can never reach the real (unmocked) browser-launch code either.
+  // -------------------------------------------------------------------------
+  {
+    const { bundlePath } = fixture();
+
+    const packHelp = runCli(["pack", "--help"]);
+    check("pack --help exits 0", packHelp.status === 0 && /arkaik pack/.test(packHelp.stdout), packHelp.stdout);
+
+    const openHelp = runCli(["open", "--help"]);
+    check("open --help exits 0", openHelp.status === 0 && /arkaik open/.test(openHelp.stdout), openHelp.stdout);
+
+    const packBadFlag = runCli(["pack", "--nope", bundlePath]);
+    check("pack with an unknown flag exits 1", packBadFlag.status === 1);
+
+    const openBadFlag = runCli(["open", "--nope", bundlePath]);
+    check("open with an unknown flag exits 1", openBadFlag.status === 1);
+
+    const packStdout = runCli(["pack", bundlePath]);
+    check("pack via CLI (no --out) exits 0", packStdout.status === 0, `${packStdout.stdout}\n${packStdout.stderr}`);
+    const parsedStdout = JSON.parse(packStdout.stdout);
+    check(
+      "pack via CLI prints the canonical bundle (with embedded journal) to stdout",
+      Array.isArray(parsedStdout.journal) && parsedStdout.journal.length === 3,
+      packStdout.stdout,
+    );
+
+    const openNoOpenCli = runCli(["open", "--no-open", bundlePath]);
+    check(
+      "open --no-open via CLI exits 0 (real opener never invoked)",
+      openNoOpenCli.status === 0,
+      `${openNoOpenCli.stdout}\n${openNoOpenCli.stderr}`,
+    );
+    check("open --no-open via CLI reports the packed path", /Packed ->/.test(openNoOpenCli.stdout), openNoOpenCli.stdout);
+
+    // No --no-open here — safe only because the bundle is invalid, so runOpen
+    // returns before ever touching the opener (verified above, in-process).
+    const invalidCli = runCli(["open", path.join(FIXTURES, "duplicate-node-id.json")]);
+    check(
+      "open on an invalid bundle via CLI (no --no-open) exits 1 without opening a browser",
+      invalidCli.status === 1,
+      `${invalidCli.stdout}\n${invalidCli.stderr}`,
+    );
+  }
+
+  for (const dir of createdDirs) rmSync(dir, { recursive: true, force: true });
+  rmSync(TEST_BUILD_DIR, { recursive: true, force: true });
+
+  console.log(`\n${passes} passed, ${failures} failed.`);
+  process.exit(failures > 0 ? 1 : 0);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Closes #223. Adds `arkaik pack` (produce a single-file interchange bundle) and `arkaik open` (validate, then hand the packed bundle off to arkaik.app import). Together they close the loop from a repo-native bundle+journal back into the app.

## Key Changes

- **`arkaik pack [--no-journal] [--inline-assets] [--out <path>] [path]`**: reads `bundle.json` + its `journal.jsonl` sidecar and emits a single self-contained bundle via `serializeBundle` (so `journal` lands in canonical key order). **Embeds the journal by default** (`loadJournalEvents` precedence, matching `validate`); `--no-journal` strips it (the Publik-safe posture, `journal.md:41`). `--inline-assets` converts **local relative-path** assets in `metadata.platformScreenshots` to `data:` URIs (best-effort mime); `https://` and existing `data:` values are left as-is (remote upload is out of scope for v1, documented in `--help`). Unknown top-level keys **and** unknown fields round-trip (no `rewriteBundleProjectId`-style strip, `bundle-format.md:40`). Default output is stdout (warnings to stderr, so it composes in a pipe); `--out` writes a file.
- **`arkaik open [--out <path>] [--no-open] [path]`**: validates (shape + semantic + snapshot↔journal cross-check via the shared `validateBundleAt` helper) and **only on success** packs (journal embedded) and hands off to arkaik.app import through an **injectable opener seam** (default `open`/`xdg-open`/`start`, spawned detached; `--no-open` skips it). An invalid bundle exits non-zero with findings and does not hand off or write output.
- **`packages/cli/src/lib/bundle-validate.ts`** (new): shared `validateBundleAt(path)` so `validate` and `open` gate on the identical check (no drift); `validate.ts` refactored to use it (behavior-preserving).
- **`tests/cli/pack-open.test.js`** (43 assertions, folded into `test:cli`): journal-embed default + `--no-journal`, `--inline-assets` local-only conversion, unknown-key/field round-trip, `open` refusing an invalid bundle, and `open --no-open` packing without launching a browser (opener mocked in-process — no browser/network in CI).

## Test plan

- [x] `npm run generate` → no artifact drift
- [x] `npm run lint`, `npm run build`
- [x] `npm run validate:seeds`
- [x] all `test:*` including `test:cli` (161 CLI assertions across validate/init/log-release/sync/pack-open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HE4i4eGXnXqsuLZtQvyKgb

---
_Generated by [Claude Code](https://claude.ai/code/session_01HE4i4eGXnXqsuLZtQvyKgb)_