### PR TITLE
M3: IndexedDB (Dexie) migration of the local provider

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -161,7 +161,7 @@ LLM affordance assets:
 - `public/robots.txt` and `app/sitemap.ts` support discoverability.
 ```
 
-All data mutations flow through the `DataProvider` interface (`lib/data/data-provider.ts`). The current implementation is `localProvider` backed by `localStorage`. The interface is designed for a future Supabase migration — swap the provider, keep the hooks and UI unchanged.
+All data mutations flow through the `DataProvider` interface (`lib/data/data-provider.ts`). The current implementation is `localProvider` backed by IndexedDB (Dexie — `lib/data/db.ts`), which writes per project rather than rewriting the whole store on every mutation. The interface is designed for a future Supabase migration — swap the provider, keep the hooks and UI unchanged.
 
 ## Playlist Expansion
 

--- a/docs/data-layer.md
+++ b/docs/data-layer.md
@@ -185,7 +185,7 @@ The `NodeDetailPanel` is the primary UI for editing nodes. The mutation path:
 NodeDetailPanel (title, description, platforms, metadata)
   → useNodes.updateNode(id, patch)
     → localProvider.updateNode(id, patch)
-      → localStorage
+      → IndexedDB (Dexie)
 ```
 
 Views store editable per-platform statuses in `node.metadata.platformStatuses`. When legacy data does not have that field yet, the UI derives platform statuses from `node.status` + `node.platforms` and writes the richer metadata shape back on the next edit.
@@ -198,10 +198,12 @@ Flows do not expose an editable rollup status in UI. Flow cards and panel gauges
 
 The `DataProvider` interface abstracts storage so the backend can change without touching hooks or UI:
 
-1. **Current:** `localStorage` via `localProvider`
+1. **Current:** IndexedDB via `localProvider` (Dexie — `lib/data/db.ts`). The `localProvider` export name is kept; it is repointed at the IndexedDB implementation, so the hooks and UI are unchanged.
 2. **Planned:** Supabase (auth, RLS, realtime sync)
 
-To add a new provider: implement the `DataProvider` interface and swap the import in the hooks.
+Storage layout: a `projects` table keyed by `id` holds one row per project (the bundle snapshot minus its journal), so a mutation to project A rewrites only project A's row — not the whole store as the previous `localStorage` backend did. The embedded journal lives in its own `journals` table (keyed by `projectId`), leaving room for a future app-side journal append that need not rewrite the graph snapshot. On first load, any legacy `arkaik:store` `localStorage` payload is imported once into IndexedDB (running `migrateBundle` per bundle) and the source payload is kept as a passive backup.
+
+To add a new provider: implement the `DataProvider` interface and repoint the `localProvider` export (or introduce a provider seam).
 
 ## Seed Data
 

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -160,7 +160,7 @@ graph LR
 Not a tier. A **Try Lokal** button next to Sign in on the landing page.
 
 - No account, no server, no sign-up
-- Full editor experience in browser storage — `localStorage` today (`lib/data/local-provider.ts`, key `arkaik:store`); an IndexedDB (Dexie.js) migration is planned and is a prerequisite for journal writes in the app (see Roadmap)
+- Full editor experience in browser storage — IndexedDB via Dexie.js (`lib/data/local-provider.ts` + `lib/data/db.ts`); a legacy `localStorage` store (key `arkaik:store`) is imported once on first load. This per-project store is the prerequisite for journal writes in the app (see Roadmap)
 - Limited features (no AI, no hosted assets, no version history)
 - Manual JSON export to save work
 - Clear warning that browser cache clearing can remove local data
@@ -286,7 +286,7 @@ The bundle contract currently lives in five places that drift independently: `li
 
 - `packages/cli`: `init`, `validate`, `log`, `release` (tagging, release notes, compaction), `sync`, `pack`, `open`; skill distribution as a Claude Code plugin as a second channel
 - Deterministic IDs adopted **in the app** for nodes and edges (today `lib/utils/id.ts` generates random UUID suffixes and canvas edges use raw UUIDs, so any app round-trip violates the conventions the skill enforces), plus canonical serialization (sorted keys/nodes/edges) so app exports diff cleanly in git
-- App-side event emission, gated on the IndexedDB (Dexie) migration — localStorage rewrites the whole store on every mutation and cannot absorb a growing journal
+- App-side event emission, unblocked by the IndexedDB (Dexie) migration that landed — the old localStorage backend rewrote the whole store on every mutation and could not absorb a growing journal; the per-project store (with a separate journal table) now can
 - `arkaik dev` (local viewer) decision: requires making `/project/[id]` routing static-export friendly; evaluated on its own merits, not assumed
 
 ### Phase 4 — Services Re-Based

--- a/lib/data/db.ts
+++ b/lib/data/db.ts
@@ -1,0 +1,174 @@
+import Dexie, { type Table } from "dexie";
+import type { JournalEvent, ProjectBundle } from "./types";
+import { migrateBundle } from "./migrate";
+
+/**
+ * IndexedDB storage layer (Dexie) for the local `DataProvider`.
+ *
+ * Why Dexie / IndexedDB instead of the previous `localStorage` whole-store
+ * rewrite: `localStorage` persisted the *entire* store as one JSON string, so
+ * every mutation — even editing one node in project A — re-serialized every
+ * project. IndexedDB gives us row-level, per-project writes.
+ *
+ * ## Tables
+ * - `projects`  — one row per project, keyed by `id` (= `project.id`). The row
+ *   holds a {@link BundleSnapshot}: the full {@link ProjectBundle} *minus* its
+ *   `journal`. A mutation to project A writes only project A's row, never
+ *   touching project B (the core win over the old backend).
+ * - `journals`  — one row per project, keyed by `projectId`, holding the
+ *   embedded journal events. The journal lives in its *own* row so a future
+ *   app-side journal append (#218) can rewrite just the journal, not the graph
+ *   snapshot. It is read-only here; nothing in this issue writes journal events
+ *   beyond mirroring what save/import already carried.
+ * - `meta`      — small key/value table for provider bookkeeping (currently
+ *   just the one-time legacy-migration flag).
+ *
+ * ## SSR / prerender safety
+ * IndexedDB is browser-only. The Dexie instance is created **lazily** inside
+ * {@link getDb} and only when a real `indexedDB` exists, so importing this
+ * module (or the provider) during Next's server render / prerender touches no
+ * browser API. On the server {@link getDb} resolves to `null` and every
+ * provider read no-ops to an empty result.
+ */
+
+/** The `arkaik:store` payload written by the previous localStorage backend. */
+export const LEGACY_STORAGE_KEY = "arkaik:store";
+
+/** A {@link ProjectBundle} without its `journal` — the graph snapshot we store per project. */
+export type BundleSnapshot = Omit<ProjectBundle, "journal">;
+
+export interface ProjectRecord {
+  /** Equal to `snapshot.project.id`. */
+  id: string;
+  snapshot: BundleSnapshot;
+}
+
+export interface JournalRecord {
+  projectId: string;
+  events: JournalEvent[];
+}
+
+export interface MetaRecord {
+  key: string;
+  value: unknown;
+}
+
+const DB_NAME = "arkaik";
+const LEGACY_MIGRATION_FLAG = "legacyLocalStorageMigrated";
+
+class ArkaikDB extends Dexie {
+  projects!: Table<ProjectRecord, string>;
+  journals!: Table<JournalRecord, string>;
+  meta!: Table<MetaRecord, string>;
+
+  constructor() {
+    super(DB_NAME);
+    this.version(1).stores({
+      projects: "id",
+      journals: "projectId",
+      meta: "key",
+    });
+  }
+}
+
+/** Split a bundle into the stored snapshot (no journal) and its journal events. */
+export function splitBundle(bundle: ProjectBundle): {
+  snapshot: BundleSnapshot;
+  journal: JournalEvent[] | undefined;
+} {
+  const { journal, ...snapshot } = bundle;
+  return { snapshot, journal };
+}
+
+/** Reassemble a stored snapshot with its journal events, preserving the
+ * "no journal key at all" vs "empty journal array" distinction (fidelity for
+ * export / round-trip): `journal` is only re-attached when a journal row
+ * existed for this project. */
+export function assembleBundle(
+  snapshot: BundleSnapshot,
+  events: JournalEvent[] | undefined,
+): ProjectBundle {
+  return events !== undefined ? { ...snapshot, journal: events } : snapshot;
+}
+
+function isBrowser(): boolean {
+  return typeof window !== "undefined" && typeof indexedDB !== "undefined";
+}
+
+let readyPromise: Promise<ArkaikDB | null> | null = null;
+
+async function openDb(): Promise<ArkaikDB | null> {
+  if (!isBrowser()) return null;
+  const db = new ArkaikDB();
+  await db.open();
+  // A migration failure must never lock the DB out, so it swallows its own
+  // errors and leaves the legacy payload intact for a later retry.
+  await migrateLegacyLocalStorage(db);
+  return db;
+}
+
+/**
+ * Shared readiness gate. Resolves to the open {@link ArkaikDB} in the browser,
+ * or `null` during SSR / prerender. Memoized so the DB opens (and the one-time
+ * legacy migration runs) at most once per page. On an open failure the promise
+ * is reset so a later call can retry.
+ */
+export function getDb(): Promise<ArkaikDB | null> {
+  if (!isBrowser()) return Promise.resolve(null);
+  if (!readyPromise) {
+    readyPromise = openDb().catch((err) => {
+      console.error("[LocalProvider] Failed to open IndexedDB:", err);
+      readyPromise = null;
+      return null;
+    });
+  }
+  return readyPromise;
+}
+
+/**
+ * One-time data migration: import the legacy `arkaik:store` localStorage
+ * payload into Dexie on first load, running {@link migrateBundle} per bundle
+ * (older bundles upgrade). Idempotent via a `meta` flag.
+ *
+ * Failure handling / data safety:
+ * - The legacy localStorage payload is **kept, not cleared** — it is a passive
+ *   backup. If IndexedDB is later wiped, the `meta` flag goes with it and this
+ *   migration re-runs from the still-present localStorage.
+ * - The bulk import and the flag write share one transaction, so a partial
+ *   import can never leave the flag set. Any error is swallowed (logged) with
+ *   the flag unset, so the next load retries — no data loss either way.
+ */
+async function migrateLegacyLocalStorage(db: ArkaikDB): Promise<void> {
+  try {
+    const done = await db.meta.get(LEGACY_MIGRATION_FLAG);
+    if (done?.value) return;
+
+    const raw = typeof localStorage !== "undefined" ? localStorage.getItem(LEGACY_STORAGE_KEY) : null;
+    if (!raw) {
+      // Nothing to migrate — record that so we don't re-read the key forever.
+      await db.meta.put({ key: LEGACY_MIGRATION_FLAG, value: true });
+      return;
+    }
+
+    const parsed = JSON.parse(raw) as Record<string, ProjectBundle>;
+    const projectRecords: ProjectRecord[] = [];
+    const journalRecords: JournalRecord[] = [];
+
+    for (const rawBundle of Object.values(parsed)) {
+      const { snapshot, journal } = splitBundle(migrateBundle(rawBundle));
+      projectRecords.push({ id: snapshot.project.id, snapshot });
+      if (journal !== undefined) {
+        journalRecords.push({ projectId: snapshot.project.id, events: journal });
+      }
+    }
+
+    await db.transaction("rw", db.projects, db.journals, db.meta, async () => {
+      if (projectRecords.length > 0) await db.projects.bulkPut(projectRecords);
+      if (journalRecords.length > 0) await db.journals.bulkPut(journalRecords);
+      await db.meta.put({ key: LEGACY_MIGRATION_FLAG, value: true });
+    });
+  } catch (err) {
+    // Leave the flag unset and localStorage untouched: retry on the next load.
+    console.error("[LocalProvider] Legacy localStorage migration failed (will retry):", err);
+  }
+}

--- a/lib/data/local-provider.ts
+++ b/lib/data/local-provider.ts
@@ -2,6 +2,28 @@ import type { DataProvider } from "./data-provider";
 import type { Node, Edge, ProjectBundle, PlaylistEntry } from "./types";
 import { migrateBundle } from "./migrate";
 import { wouldCreateCycle } from "@/lib/utils/cycle";
+import {
+  assembleBundle,
+  getDb,
+  splitBundle,
+  type ProjectRecord,
+} from "./db";
+
+/**
+ * The app's `DataProvider`, backed by IndexedDB (Dexie — see `./db.ts`).
+ *
+ * It keeps the exact `DataProvider` method signatures (all async), so the hooks
+ * and UI that import `localProvider` need no change: the export name is
+ * preserved and simply repointed at the IndexedDB implementation. `localStorage`
+ * is gone except for the one-time import in `./db.ts`.
+ *
+ * SSR / prerender: `getDb()` resolves to `null` off the browser, so every
+ * **read** below no-ops to an empty result and never touches a browser API at
+ * import time. **Mutations** run only from client event handlers / effects,
+ * which never execute during Next's server render or prerender; off the browser
+ * they throw the same "not found"-style errors the previous provider did (an
+ * unreachable path at build time — `npm run build` prerenders clean).
+ */
 
 function collectReferencedFlowIds(entries: PlaylistEntry[]): string[] {
   const result: string[] = [];
@@ -28,191 +50,213 @@ function collectReferencedFlowIds(entries: PlaylistEntry[]): string[] {
   return result;
 }
 
-const STORAGE_KEY = "arkaik:store";
-
-function loadStore(): Map<string, ProjectBundle> {
-  if (typeof window === "undefined") return new Map();
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return new Map();
-    const obj = JSON.parse(raw) as Record<string, ProjectBundle>;
-    return new Map(
-      Object.entries(obj).map(([projectId, bundle]) => [projectId, migrateBundle(bundle)]),
-    );
-  } catch (err) {
-    console.error("[LocalProvider] Failed to load store from localStorage:", err);
-    return new Map();
-  }
-}
-
-function persistStore(store: Map<string, ProjectBundle>): void {
-  if (typeof window === "undefined") return;
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(Object.fromEntries(store)));
-  } catch (err) {
-    console.error("[LocalProvider] Failed to persist store:", err);
-    throw new Error("Failed to save data. Your browser storage may be full.", {
-      cause: err,
-    });
-  }
-}
-
-const store = loadStore();
-/** Maps node id → project id for O(1) lookup. */
-const nodeIndex = new Map<string, string>();
-/** Maps edge id → project id for O(1) lookup. */
-const edgeIndex = new Map<string, string>();
-
-function isArchived(bundle: ProjectBundle): boolean {
-  return Boolean(bundle.project.archived_at);
-}
-
-// Rebuild indexes from persisted data
-for (const bundle of store.values()) {
-  bundle.nodes.forEach((n) => nodeIndex.set(n.id, bundle.project.id));
-  bundle.edges.forEach((e) => edgeIndex.set(e.id, bundle.project.id));
+function isArchived(record: ProjectRecord): boolean {
+  return Boolean(record.snapshot.project.archived_at);
 }
 
 export const localProvider: DataProvider = {
   async getProject(id: string) {
-    return store.get(id);
+    const db = await getDb();
+    if (!db) return undefined;
+    const record = await db.projects.get(id);
+    if (!record) return undefined;
+    const journalRow = await db.journals.get(id);
+    return assembleBundle(record.snapshot, journalRow?.events);
   },
+
   async listProjects() {
-    return Array.from(store.values()).filter((bundle) => !isArchived(bundle));
+    const db = await getDb();
+    if (!db) return [];
+    const [records, journals] = await Promise.all([
+      db.projects.toArray(),
+      db.journals.toArray(),
+    ]);
+    const journalByProject = new Map(journals.map((row) => [row.projectId, row.events]));
+    return records
+      .filter((record) => !isArchived(record))
+      .map((record) => assembleBundle(record.snapshot, journalByProject.get(record.id)));
   },
+
   async saveProject(bundle: ProjectBundle) {
-    const normalized = migrateBundle(bundle);
-    store.set(normalized.project.id, normalized);
-    normalized.nodes.forEach((n) => nodeIndex.set(n.id, normalized.project.id));
-    normalized.edges.forEach((e) => edgeIndex.set(e.id, normalized.project.id));
-    persistStore(store);
+    const db = await getDb();
+    if (!db) return;
+    const { snapshot, journal } = splitBundle(migrateBundle(bundle));
+    const projectId = snapshot.project.id;
+    await db.transaction("rw", db.projects, db.journals, async () => {
+      await db.projects.put({ id: projectId, snapshot });
+      if (journal !== undefined) {
+        await db.journals.put({ projectId, events: journal });
+      } else {
+        await db.journals.delete(projectId);
+      }
+    });
   },
+
   async archiveProject(id: string) {
-    const bundle = store.get(id);
-    if (!bundle) throw new Error(`Project ${id} not found`);
-    const now = new Date().toISOString();
-    bundle.project = {
-      ...bundle.project,
-      archived_at: now,
-      updated_at: now,
-    };
-    persistStore(store);
+    const db = await getDb();
+    if (!db) return;
+    await db.transaction("rw", db.projects, async () => {
+      const record = await db.projects.get(id);
+      if (!record) throw new Error(`Project ${id} not found`);
+      const now = new Date().toISOString();
+      record.snapshot.project = {
+        ...record.snapshot.project,
+        archived_at: now,
+        updated_at: now,
+      };
+      await db.projects.put(record);
+    });
   },
 
   async getNodes(projectId: string) {
-    return store.get(projectId)?.nodes ?? [];
+    const db = await getDb();
+    if (!db) return [];
+    const record = await db.projects.get(projectId);
+    return record?.snapshot.nodes ?? [];
   },
+
   async getEdges(projectId: string) {
-    return store.get(projectId)?.edges ?? [];
+    const db = await getDb();
+    if (!db) return [];
+    const record = await db.projects.get(projectId);
+    return record?.snapshot.edges ?? [];
   },
+
   async getJournal(projectId: string) {
-    return store.get(projectId)?.journal ?? [];
+    const db = await getDb();
+    if (!db) return [];
+    const row = await db.journals.get(projectId);
+    return row?.events ?? [];
   },
 
   async createNode(node: Node) {
-    const bundle = store.get(node.project_id);
-    if (!bundle) throw new Error(`Project ${node.project_id} not found`);
-    bundle.nodes.push(node);
-    nodeIndex.set(node.id, node.project_id);
-    persistStore(store);
+    const db = await getDb();
+    if (!db) throw new Error(`Project ${node.project_id} not found`);
+    await db.transaction("rw", db.projects, async () => {
+      const record = await db.projects.get(node.project_id);
+      if (!record) throw new Error(`Project ${node.project_id} not found`);
+      record.snapshot.nodes.push(node);
+      await db.projects.put(record);
+    });
     return node;
   },
+
   async updateNode(id: string, patch: Partial<Omit<Node, "id" | "project_id">>) {
-    const projectId = nodeIndex.get(id);
-    if (!projectId) throw new Error(`Node ${id} not found`);
-    const bundle = store.get(projectId)!;
-    const idx = bundle.nodes.findIndex((n) => n.id === id);
-    const nextNode = { ...bundle.nodes[idx], ...patch };
+    const db = await getDb();
+    if (!db) throw new Error(`Node ${id} not found`);
+    let updated: Node | undefined;
+    await db.transaction("rw", db.projects, async () => {
+      const records = await db.projects.toArray();
+      const record = records.find((r) => r.snapshot.nodes.some((n) => n.id === id));
+      if (!record) throw new Error(`Node ${id} not found`);
 
-    if (nextNode.species === "flow") {
-      const entries = nextNode.metadata?.playlist?.entries;
-      if (Array.isArray(entries)) {
-        const nextNodes = [...bundle.nodes];
-        nextNodes[idx] = nextNode;
-        const candidateFlowIds = collectReferencedFlowIds(entries);
+      const nodes = record.snapshot.nodes;
+      const idx = nodes.findIndex((n) => n.id === id);
+      const nextNode = { ...nodes[idx], ...patch };
 
-        for (const candidateFlowId of candidateFlowIds) {
-          if (wouldCreateCycle(nextNode.id, candidateFlowId, nextNodes)) {
-            throw new Error(`Cannot add Flow ${candidateFlowId}: it would create a circular reference.`);
+      if (nextNode.species === "flow") {
+        const entries = nextNode.metadata?.playlist?.entries;
+        if (Array.isArray(entries)) {
+          const nextNodes = [...nodes];
+          nextNodes[idx] = nextNode;
+          const candidateFlowIds = collectReferencedFlowIds(entries);
+
+          for (const candidateFlowId of candidateFlowIds) {
+            if (wouldCreateCycle(nextNode.id, candidateFlowId, nextNodes)) {
+              throw new Error(`Cannot add Flow ${candidateFlowId}: it would create a circular reference.`);
+            }
           }
         }
       }
-    }
 
-    bundle.nodes[idx] = nextNode;
-    persistStore(store);
-    return bundle.nodes[idx];
-  },
-  async deleteNode(id: string) {
-    const projectId = nodeIndex.get(id);
-    if (!projectId) throw new Error(`Node ${id} not found`);
-    const bundle = store.get(projectId)!;
-    bundle.nodes = bundle.nodes.filter((n) => n.id !== id);
-    bundle.edges = bundle.edges.filter((e) => {
-      if (e.source_id === id || e.target_id === id) {
-        edgeIndex.delete(e.id);
-        return false;
-      }
-      return true;
+      nodes[idx] = nextNode;
+      updated = nextNode;
+      await db.projects.put(record);
     });
-    nodeIndex.delete(id);
-    persistStore(store);
+    return updated!;
+  },
+
+  async deleteNode(id: string) {
+    const db = await getDb();
+    if (!db) throw new Error(`Node ${id} not found`);
+    await db.transaction("rw", db.projects, async () => {
+      const records = await db.projects.toArray();
+      const record = records.find((r) => r.snapshot.nodes.some((n) => n.id === id));
+      if (!record) throw new Error(`Node ${id} not found`);
+      record.snapshot.nodes = record.snapshot.nodes.filter((n) => n.id !== id);
+      record.snapshot.edges = record.snapshot.edges.filter(
+        (e) => e.source_id !== id && e.target_id !== id,
+      );
+      await db.projects.put(record);
+    });
   },
 
   async deleteNodes(ids: string[]) {
     if (ids.length === 0) return;
+    const db = await getDb();
+    if (!db) return;
     const idSet = new Set(ids);
-    const affectedProjects = new Set<string>();
-    for (const id of ids) {
-      const projectId = nodeIndex.get(id);
-      if (projectId) affectedProjects.add(projectId);
-    }
-    for (const projectId of affectedProjects) {
-      const bundle = store.get(projectId);
-      if (!bundle) continue;
-      bundle.nodes = bundle.nodes.filter((n) => !idSet.has(n.id));
-      bundle.edges = bundle.edges.filter((e) => {
-        if (idSet.has(e.source_id) || idSet.has(e.target_id)) {
-          edgeIndex.delete(e.id);
-          return false;
-        }
-        return true;
-      });
-    }
-    for (const id of ids) {
-      nodeIndex.delete(id);
-    }
-    persistStore(store);
+    await db.transaction("rw", db.projects, async () => {
+      const records = await db.projects.toArray();
+      for (const record of records) {
+        const hasAffected = record.snapshot.nodes.some((n) => idSet.has(n.id));
+        if (!hasAffected) continue;
+        record.snapshot.nodes = record.snapshot.nodes.filter((n) => !idSet.has(n.id));
+        record.snapshot.edges = record.snapshot.edges.filter(
+          (e) => !idSet.has(e.source_id) && !idSet.has(e.target_id),
+        );
+        await db.projects.put(record);
+      }
+    });
   },
 
   async createEdge(edge: Edge) {
-    const bundle = store.get(edge.project_id);
-    if (!bundle) throw new Error(`Project ${edge.project_id} not found`);
-    bundle.edges.push(edge);
-    edgeIndex.set(edge.id, edge.project_id);
-    persistStore(store);
+    const db = await getDb();
+    if (!db) throw new Error(`Project ${edge.project_id} not found`);
+    await db.transaction("rw", db.projects, async () => {
+      const record = await db.projects.get(edge.project_id);
+      if (!record) throw new Error(`Project ${edge.project_id} not found`);
+      record.snapshot.edges.push(edge);
+      await db.projects.put(record);
+    });
     return edge;
   },
+
   async deleteEdge(id: string) {
-    const projectId = edgeIndex.get(id);
-    if (!projectId) throw new Error(`Edge ${id} not found`);
-    const bundle = store.get(projectId)!;
-    bundle.edges = bundle.edges.filter((e) => e.id !== id);
-    edgeIndex.delete(id);
-    persistStore(store);
+    const db = await getDb();
+    if (!db) throw new Error(`Edge ${id} not found`);
+    await db.transaction("rw", db.projects, async () => {
+      const records = await db.projects.toArray();
+      const record = records.find((r) => r.snapshot.edges.some((e) => e.id === id));
+      if (!record) throw new Error(`Edge ${id} not found`);
+      record.snapshot.edges = record.snapshot.edges.filter((e) => e.id !== id);
+      await db.projects.put(record);
+    });
   },
 
   async exportProject(id: string) {
-    const bundle = store.get(id);
-    if (!bundle) throw new Error(`Project ${id} not found`);
-    return bundle;
+    const db = await getDb();
+    if (!db) throw new Error(`Project ${id} not found`);
+    const record = await db.projects.get(id);
+    if (!record) throw new Error(`Project ${id} not found`);
+    const journalRow = await db.journals.get(id);
+    return assembleBundle(record.snapshot, journalRow?.events);
   },
+
   async importProject(bundle: ProjectBundle) {
+    const db = await getDb();
     const normalized = migrateBundle(bundle);
-    store.set(normalized.project.id, normalized);
-    normalized.nodes.forEach((n) => nodeIndex.set(n.id, normalized.project.id));
-    normalized.edges.forEach((e) => edgeIndex.set(e.id, normalized.project.id));
-    persistStore(store);
+    const { snapshot, journal } = splitBundle(normalized);
+    const projectId = snapshot.project.id;
+    if (!db) return normalized.project;
+    await db.transaction("rw", db.projects, db.journals, async () => {
+      await db.projects.put({ id: projectId, snapshot });
+      if (journal !== undefined) {
+        await db.journals.put({ projectId, events: journal });
+      } else {
+        await db.journals.delete(projectId);
+      }
+    });
     return normalized.project;
   },
 };

--- a/lib/hooks/useNodes.ts
+++ b/lib/hooks/useNodes.ts
@@ -25,11 +25,11 @@ export function useNodes(projectId: string) {
 
   const addNode = useCallback(async (node: Node) => {
     const created = await localProvider.createNode(node);
-    // localProvider.createNode mutates bundle.nodes in place, so prev may
-    // already contain the new node. Always return a new array reference so
-    // React re-renders even when the provider mutated state in place.
+    // The provider returns a fresh node and does not mutate this hook's state
+    // (the IndexedDB backend hands back new objects, not shared references).
+    // The id guard stays as a defensive no-op against a double add.
     setNodes((prev) => {
-      if (prev.some((n) => n.id === created.id)) return [...prev];
+      if (prev.some((n) => n.id === created.id)) return prev;
       return [...prev, created];
     });
     return created;

--- a/lib/hooks/useProject.ts
+++ b/lib/hooks/useProject.ts
@@ -26,11 +26,19 @@ export function useProject(id: string) {
         throw new Error("Cannot update project before it is loaded");
       }
 
+      // Re-read the current bundle before saving. With the IndexedDB provider,
+      // getProject returns a fresh snapshot, so this hook's `project` state does
+      // not reflect node/edge edits made concurrently via useNodes/useEdges
+      // (which the old shared-in-memory store surfaced automatically). Saving
+      // our own stale `project.nodes`/`edges` would clobber those edits, so we
+      // patch project-level fields onto the freshest stored bundle instead.
+      const current = (await localProvider.getProject(project.project.id)) ?? project;
+
       const now = new Date().toISOString();
       const nextBundle: ProjectBundle = {
-        ...project,
+        ...current,
         project: {
-          ...project.project,
+          ...current.project,
           ...patch,
           updated_at: now,
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@xyflow/react": "^12.10.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "dexie": "^4.4.4",
         "elkjs": "^0.11.1",
         "geist": "^1.7.0",
         "gray-matter": "^4.0.3",
@@ -4701,6 +4702,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/dexie": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.4.4.tgz",
+      "integrity": "sha512-jIwsYI8Os2hgnqc6O49YwFDKGc5v5QjGx0wPVp543ip1F53VFAKMLthV2pQosQcVTv3eAskTWYspOx195PM0FQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/doctrine": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@xyflow/react": "^12.10.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "dexie": "^4.4.4",
     "elkjs": "^0.11.1",
     "geist": "^1.7.0",
     "gray-matter": "^4.0.3",


### PR DESCRIPTION
## Summary

Closes #217. Replaces the `localStorage` whole-store-rewrite backend with **Dexie/IndexedDB** behind the same `DataProvider` interface — the UI/hooks stay backend-agnostic. This is the prerequisite for app-side journal writes (#218).

> ⚠️ **Held for your review — high blast radius** (the app's only storage backend). CI-gated and reasoned through, but I couldn't drive a real browser here (see "Risks").

## Key Changes

- **`lib/data/db.ts`** (new): Dexie DB `version(1).stores({ projects: "id", journals: "projectId", meta: "key" })`.
  - `projects` — one row per project holding the snapshot (`ProjectBundle` **minus** `journal`). A mutation to project A rewrites only A's row (**per-project writes** — the core win over `localStorage.setItem`).
  - `journals` — each project's events in their **own** row, so a future append (#218) needn't rewrite the snapshot. Read-only here.
  - `split`/`assemble` preserve the no-`journal`-key vs empty-array distinction + unknown top-level keys.
- **`lib/data/local-provider.ts`** (rewritten on Dexie): the `localProvider` **export name is preserved** (repoint = zero import churn for the 7 consumers, and the `import-roundtrip.test.js` stub still intercepts by module name). Async **ready-gate + SSR no-op** (no IndexedDB at module load or during prerender). `migrateBundle` still runs on load/import; `updateNode` cycle validation, `archiveProject` soft-delete, and read-only `getJournal` preserved.
- **One-time migration**: on first load, the legacy `arkaik:store` payload is imported into Dexie in a single flagged transaction (kept as a passive backup; the flag lives in Dexie so a wiped IndexedDB re-migrates).
- **In-place-mutation coupling fixed** at the hook layer: `useProject.updateProject` re-reads the freshest bundle before saving (Dexie returns fresh objects, so the old shared-array assumption is gone).
- **`dexie ^4.4.4`** added.

## Risks / notes for review

- **Scan-based lookup** in `updateNode`/`deleteNode`/`deleteEdge`: the interface passes only the entity id, so these scan `projects` to find the owner — O(projects) per mutation. Fine for a local single-user tool; a `nodes`/`edges` table with a `project_id` index would restore O(1) if project counts grow (deferred to keep this diff smaller). `createNode`/`createEdge` are O(1).
- **No cross-tab live sync** (same limitation class as the old backend).
- Not exercised in a real browser here — correctness rests on sound types (build passes), preserved semantics, and the reasoning above.

## Test plan

- [x] `npm run generate` → no drift
- [x] `npm run lint`, `npm run build` (TypeScript + static prerender clean — Dexie is browser-only / SSR-safe)
- [x] `npm run validate:seeds`
- [x] all `test:*` including `test:migrate` (migrate + import-roundtrip + seed-import) + `test:cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HE4i4eGXnXqsuLZtQvyKgb

---
_Generated by [Claude Code](https://claude.ai/code/session_01HE4i4eGXnXqsuLZtQvyKgb)_