### PR TITLE
M3: App-side event emission (centralized in provider mutations)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Journal write-primitive (emit) tests
         run: npm run test:emit
 
+      - name: App-side journal emission tests
+        run: npm run test:emit-events
+
       - name: Screenshot data-URI size warning tests
         run: npm run test:screenshot-size
 

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 /tests/data/.test-build/
 /tests/data/.test-build-export/
 /tests/data/.test-build-journal/
+/tests/data/.test-build-emit-events/
 /packages/cli/.test-build/
 
 # next.js

--- a/lib/data/db.ts
+++ b/lib/data/db.ts
@@ -16,10 +16,10 @@ import { migrateBundle } from "./migrate";
  *   `journal`. A mutation to project A writes only project A's row, never
  *   touching project B (the core win over the old backend).
  * - `journals`  — one row per project, keyed by `projectId`, holding the
- *   embedded journal events. The journal lives in its *own* row so a future
- *   app-side journal append (#218) can rewrite just the journal, not the graph
- *   snapshot. It is read-only here; nothing in this issue writes journal events
- *   beyond mirroring what save/import already carried.
+ *   embedded journal events. The journal lives in its *own* row so an app-side
+ *   journal append ({@link appendJournalEvents}, #218) can grow just the
+ *   journal, never rewriting the graph snapshot. The provider's mutations write
+ *   here as the app half of the dual-write (docs/spec/journal.md).
  * - `meta`      — small key/value table for provider bookkeeping (currently
  *   just the one-time legacy-migration flag).
  *
@@ -56,7 +56,7 @@ export interface MetaRecord {
 const DB_NAME = "arkaik";
 const LEGACY_MIGRATION_FLAG = "legacyLocalStorageMigrated";
 
-class ArkaikDB extends Dexie {
+export class ArkaikDB extends Dexie {
   projects!: Table<ProjectRecord, string>;
   journals!: Table<JournalRecord, string>;
   meta!: Table<MetaRecord, string>;
@@ -89,6 +89,29 @@ export function assembleBundle(
   events: JournalEvent[] | undefined,
 ): ProjectBundle {
   return events !== undefined ? { ...snapshot, journal: events } : snapshot;
+}
+
+/**
+ * Append `events` to a project's journal row (the `journals` store) WITHOUT
+ * touching its snapshot (`projects` row) — the app half of the snapshot+journal
+ * dual-write (docs/spec/journal.md § Authority & Consistency Model, issue #218).
+ *
+ * MUST be called inside a `readwrite` transaction whose scope already includes
+ * `db.journals`, so the caller's snapshot write and this append commit
+ * atomically (both or neither). Reads the project's current events — empty when
+ * it has no journal row yet, so the first append *starts* the journal — and
+ * writes back the concatenation. History only ever grows here; the snapshot is
+ * never re-serialized, which is the whole point of the separate journal row.
+ */
+export async function appendJournalEvents(
+  db: ArkaikDB,
+  projectId: string,
+  events: readonly JournalEvent[],
+): Promise<void> {
+  if (events.length === 0) return;
+  const row = await db.journals.get(projectId);
+  const existing = row?.events ?? [];
+  await db.journals.put({ projectId, events: [...existing, ...events] });
 }
 
 function isBrowser(): boolean {

--- a/lib/data/emit-events.ts
+++ b/lib/data/emit-events.ts
@@ -1,0 +1,260 @@
+/**
+ * App-side journal event derivation (issue #218) — the pure, browser-safe half
+ * of the app's journal *write* path. Given a provider mutation (a create, a
+ * delete, or an update patch), these functions produce the matching journal
+ * event(s) the app must append so an app-exported bundle passes the same
+ * `crossCheckJournal` the skill/CLI dual-write is held to
+ * (docs/spec/journal.md § Authority & Consistency Model,
+ * docs/arkaik-skill/skill.md § Which events to append).
+ *
+ * Deliberately free of any IndexedDB / Dexie import: this module only computes
+ * event payloads and stamps them via {@link makeEvent}. The *append* (the
+ * `journals` store write) lives in `./db.ts`; the wiring into each mutation
+ * lives in `./local-provider.ts`. Keeping the derivation pure means it is
+ * SSR-safe and unit-testable without a real IndexedDB (tests/data/emit-events).
+ *
+ * ## Op → event mapping (mirrors docs/arkaik-skill/skill.md:81-90)
+ * - createNode          → `node.created`
+ * - createEdge          → `edge.added`
+ * - deleteNode(s)       → `node.deleted` (one per node; the edge cascade is
+ *                         implied — NO `edge.removed` for cascaded edges,
+ *                         docs/spec/journal.md:71)
+ * - deleteEdge          → `edge.removed`
+ * - updateNode(patch)   → {@link diffNodeUpdate}: `status` → `node.status_changed`
+ *                         (project-level); a `metadata.platformStatuses[p]` delta
+ *                         → `node.status_changed` + `platform`; `metadata.refs`
+ *                         gained/lost → `ref.added` / `ref.removed`; any other
+ *                         changed field path → `node.updated` with `fields[]`.
+ *
+ * ## Asset exclusion (hard rule, docs/spec/journal.md:61, docs/vision.md:124)
+ * Events MUST NOT embed asset payloads. `NodeDetailPanel` rewrites the *whole*
+ * `metadata` object on any platform-variant edit, so {@link diffNodeUpdate}
+ * diffs metadata **per key** (and per platform for the map-typed keys): a note
+ * edit records only the note's path, never dragging the sibling screenshot's
+ * data-URI into the event. `node.updated` only ever carries `from`/`to` for a
+ * single short top-level scalar (e.g. a title rename), never for a metadata
+ * path — so a screenshot blob can never appear in an event.
+ */
+
+import { makeEvent, type JournalEvent } from "@arkaik/schema";
+import type { Node, Edge } from "./types";
+
+/**
+ * Stable actor stamped on every app-emitted event (the envelope's `actor`,
+ * docs/spec/journal.md § Event Envelope) — the app's counterpart to the CLI's
+ * `"arkaik-cli"` and the skill's `"claude-code"`.
+ */
+export const APP_ACTOR = "arkaik-app";
+
+/** A single event before the envelope is stamped: its `type` and flat payload. */
+export interface EventInput {
+  type: string;
+  payload: Record<string, unknown>;
+}
+
+/** Stamp each {@link EventInput} into a validated {@link JournalEvent} via
+ * `makeEvent` (ULID id, ISO ts, the app actor), throwing on a malformed
+ * payload so a bad event is never appended. */
+export function toJournalEvents(inputs: readonly EventInput[]): JournalEvent[] {
+  return inputs.map((input) => makeEvent(input.type, input.payload, { actor: APP_ACTOR }));
+}
+
+/** `node.created` for a newly created node. */
+export function nodeCreatedInput(node: Node): EventInput {
+  return {
+    type: "node.created",
+    payload: { node_id: node.id, species: node.species, title: node.title },
+  };
+}
+
+/** `node.deleted` for a removed node. The edge cascade is implied — callers
+ * MUST NOT emit `edge.removed` for the cascaded edges (docs/spec/journal.md:71). */
+export function nodeDeletedInput(nodeId: string): EventInput {
+  return { type: "node.deleted", payload: { node_id: nodeId } };
+}
+
+/** `edge.added` for a newly created edge. */
+export function edgeAddedInput(edge: Edge): EventInput {
+  return {
+    type: "edge.added",
+    payload: {
+      edge_id: edge.id,
+      source_id: edge.source_id,
+      target_id: edge.target_id,
+      edge_type: edge.edge_type,
+    },
+  };
+}
+
+/** `edge.removed` for an edge removed on its own (the node stays). */
+export function edgeRemovedInput(edgeId: string): EventInput {
+  return { type: "edge.removed", payload: { edge_id: edgeId } };
+}
+
+/** Top-level Node fields (excluding id/project_id/metadata) worth diffing. */
+const TOP_LEVEL_FIELDS = ["species", "title", "description", "status", "platforms"] as const;
+
+/** Cap for a `from`/`to` scalar so `node.updated` stays a "short scalar" record
+ * (docs/spec/journal.md:61) and never an unbounded blob. */
+const MAX_SCALAR_LEN = 512;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** A short scalar safe to record verbatim as `node.updated.from`/`to`. */
+function isShortScalar(value: unknown): boolean {
+  if (typeof value === "number" || typeof value === "boolean") return true;
+  return typeof value === "string" && value.length <= MAX_SCALAR_LEN;
+}
+
+/** Structural equality, sufficient for change detection (values come from React
+ * state spreads). Order-independent at the top of each compared value because
+ * metadata is diffed per key, so a parent key reorder never masquerades as a
+ * change. */
+function valueEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/** Platform keys whose value differs between two map-typed metadata values. */
+function changedMapKeys(prev: unknown, next: unknown): string[] {
+  const p = isRecord(prev) ? prev : {};
+  const n = isRecord(next) ? next : {};
+  const changed: string[] = [];
+  for (const key of new Set([...Object.keys(p), ...Object.keys(n)])) {
+    if (!valueEqual(p[key], n[key])) changed.push(key);
+  }
+  return changed.sort();
+}
+
+/** Per-platform `node.status_changed` events for a `platformStatuses` delta.
+ * A newly added / removed override has only one endpoint, so the missing side
+ * falls back to the node's project-level status — keeping both `from` and `to`
+ * valid statuses (the schema requires it) without inventing a "none" status. */
+function diffPlatformStatuses(
+  nodeId: string,
+  currentBase: unknown,
+  nextBase: unknown,
+  prev: unknown,
+  next: unknown,
+): EventInput[] {
+  const p = isRecord(prev) ? prev : {};
+  const n = isRecord(next) ? next : {};
+  const events: EventInput[] = [];
+  for (const platform of [...new Set([...Object.keys(p), ...Object.keys(n)])].sort()) {
+    const from = p[platform];
+    const to = n[platform];
+    if (valueEqual(from, to)) continue;
+    events.push({
+      type: "node.status_changed",
+      payload: {
+        node_id: nodeId,
+        from: from ?? currentBase,
+        to: to ?? nextBase,
+        platform,
+      },
+    });
+  }
+  return events;
+}
+
+/** `ref.added` / `ref.removed` for entries gained/lost in `metadata.refs`
+ * (matched by ref `id`). A ref modified in place with no id change is out of
+ * scope for v1 emission (docs/arkaik-skill/skill.md:89 covers attach/detach). */
+function diffRefs(nodeId: string, prev: unknown, next: unknown): EventInput[] {
+  const prevArr = Array.isArray(prev) ? prev : [];
+  const nextArr = Array.isArray(next) ? next : [];
+  const byId = (arr: unknown[]) => {
+    const map = new Map<string, Record<string, unknown>>();
+    for (const item of arr) {
+      if (isRecord(item) && typeof item.id === "string") map.set(item.id, item);
+    }
+    return map;
+  };
+  const prevById = byId(prevArr);
+  const nextById = byId(nextArr);
+  const events: EventInput[] = [];
+  for (const [id, ref] of nextById) {
+    if (!prevById.has(id)) {
+      events.push({
+        type: "ref.added",
+        payload: { node_id: nodeId, ref_id: id, ref_type: ref.type, url: ref.url },
+      });
+    }
+  }
+  for (const id of prevById.keys()) {
+    if (!nextById.has(id)) {
+      events.push({ type: "ref.removed", payload: { node_id: nodeId, ref_id: id } });
+    }
+  }
+  return events;
+}
+
+/**
+ * Derive the journal events for an `updateNode(current, patch)` call. `patch`
+ * carries only the fields being changed (metadata, when present, is the *whole*
+ * new metadata object — see the module header). Returns events in emit order;
+ * an unchanged patch yields `[]`.
+ */
+export function diffNodeUpdate(current: Node, patch: Partial<Node>): EventInput[] {
+  const events: EventInput[] = [];
+  const nodeId = current.id;
+  const changedPaths: string[] = [];
+  const cur = current as unknown as Record<string, unknown>;
+  const pat = patch as unknown as Record<string, unknown>;
+
+  // --- Top-level fields ---
+  for (const field of TOP_LEVEL_FIELDS) {
+    if (!(field in pat)) continue;
+    const prev = cur[field];
+    const nextVal = pat[field];
+    if (valueEqual(prev, nextVal)) continue;
+
+    if (field === "status") {
+      // Project-level lifecycle transition (no platform).
+      events.push({ type: "node.status_changed", payload: { node_id: nodeId, from: prev, to: nextVal } });
+    } else {
+      changedPaths.push(field);
+    }
+  }
+
+  // --- Metadata, diffed per key (NodeDetailPanel rewrites the whole object) ---
+  if ("metadata" in pat) {
+    const prevMeta = isRecord(current.metadata) ? current.metadata : {};
+    const nextMeta = isRecord(patch.metadata) ? patch.metadata : {};
+    const currentBase = current.status;
+    const nextBase = "status" in pat && pat.status !== undefined ? pat.status : current.status;
+
+    for (const key of new Set([...Object.keys(prevMeta), ...Object.keys(nextMeta)])) {
+      if (key === "platformStatuses") {
+        events.push(...diffPlatformStatuses(nodeId, currentBase, nextBase, prevMeta[key], nextMeta[key]));
+      } else if (key === "refs") {
+        events.push(...diffRefs(nodeId, prevMeta[key], nextMeta[key]));
+      } else if (key === "platformScreenshots" || key === "platformNotes") {
+        // Map-typed: record only each changed platform PATH — never the value,
+        // so a screenshot data-URI is structurally excluded from the event.
+        for (const platform of changedMapKeys(prevMeta[key], nextMeta[key])) {
+          changedPaths.push(`metadata.${key}.${platform}`);
+        }
+      } else if (!valueEqual(prevMeta[key], nextMeta[key])) {
+        changedPaths.push(`metadata.${key}`);
+      }
+    }
+  }
+
+  // --- Everything else → one node.updated with the changed paths ---
+  if (changedPaths.length > 0) {
+    changedPaths.sort();
+    const payload: Record<string, unknown> = { node_id: nodeId, fields: changedPaths };
+    // from/to only for a single top-level scalar change (e.g. a title rename):
+    // a metadata path (contains ".") never carries a value, so no blob leaks.
+    const only = changedPaths.length === 1 ? changedPaths[0] : undefined;
+    if (only !== undefined && !only.includes(".") && isShortScalar(cur[only]) && isShortScalar(pat[only])) {
+      payload.from = cur[only];
+      payload.to = pat[only];
+    }
+    events.push({ type: "node.updated", payload });
+  }
+
+  return events;
+}

--- a/lib/data/local-provider.ts
+++ b/lib/data/local-provider.ts
@@ -3,11 +3,20 @@ import type { Node, Edge, ProjectBundle, PlaylistEntry } from "./types";
 import { migrateBundle } from "./migrate";
 import { wouldCreateCycle } from "@/lib/utils/cycle";
 import {
+  appendJournalEvents,
   assembleBundle,
   getDb,
   splitBundle,
   type ProjectRecord,
 } from "./db";
+import {
+  diffNodeUpdate,
+  edgeAddedInput,
+  edgeRemovedInput,
+  nodeCreatedInput,
+  nodeDeletedInput,
+  toJournalEvents,
+} from "./emit-events";
 
 /**
  * The app's `DataProvider`, backed by IndexedDB (Dexie — see `./db.ts`).
@@ -23,6 +32,21 @@ import {
  * which never execute during Next's server render or prerender; off the browser
  * they throw the same "not found"-style errors the previous provider did (an
  * unreachable path at build time — `npm run build` prerenders clean).
+ *
+ * ## Journal emission (issue #218)
+ * The app is a journal *writer*: every graph mutation dual-writes — it patches
+ * the snapshot AND appends the matching event to the project's `journals` row
+ * (via {@link appendJournalEvents}, in the *same* transaction so both commit
+ * atomically). The event derivation is centralized here (not in hooks) through
+ * the pure helpers in `./emit-events.ts`. No snapshot rewrite happens on the
+ * append — the journal grows in its own row.
+ *
+ * **No-emit list** (deliberately emit nothing): `saveProject`, `archiveProject`,
+ * and `importProject`. `saveProject` persists a whole re-read bundle (project-
+ * field edits) with no clean per-field v1 mapping; `archiveProject` toggles a
+ * timestamp with no v1 event; `importProject` already carries its own journal
+ * (re-emitting would double-count). They still *preserve* an existing journal
+ * row so history round-trips.
  */
 
 function collectReferencedFlowIds(entries: PlaylistEntry[]): string[] {
@@ -132,11 +156,12 @@ export const localProvider: DataProvider = {
   async createNode(node: Node) {
     const db = await getDb();
     if (!db) throw new Error(`Project ${node.project_id} not found`);
-    await db.transaction("rw", db.projects, async () => {
+    await db.transaction("rw", db.projects, db.journals, async () => {
       const record = await db.projects.get(node.project_id);
       if (!record) throw new Error(`Project ${node.project_id} not found`);
       record.snapshot.nodes.push(node);
       await db.projects.put(record);
+      await appendJournalEvents(db, node.project_id, toJournalEvents([nodeCreatedInput(node)]));
     });
     return node;
   },
@@ -145,14 +170,15 @@ export const localProvider: DataProvider = {
     const db = await getDb();
     if (!db) throw new Error(`Node ${id} not found`);
     let updated: Node | undefined;
-    await db.transaction("rw", db.projects, async () => {
+    await db.transaction("rw", db.projects, db.journals, async () => {
       const records = await db.projects.toArray();
       const record = records.find((r) => r.snapshot.nodes.some((n) => n.id === id));
       if (!record) throw new Error(`Node ${id} not found`);
 
       const nodes = record.snapshot.nodes;
       const idx = nodes.findIndex((n) => n.id === id);
-      const nextNode = { ...nodes[idx], ...patch };
+      const current = nodes[idx];
+      const nextNode = { ...current, ...patch };
 
       if (nextNode.species === "flow") {
         const entries = nextNode.metadata?.playlist?.entries;
@@ -169,9 +195,15 @@ export const localProvider: DataProvider = {
         }
       }
 
+      // Diff the patch against the pre-update node (per-key for metadata) and
+      // append the derived event(s). Computed only after the cycle validation
+      // above, so a rejected update never emits.
+      const events = toJournalEvents(diffNodeUpdate(current, patch));
+
       nodes[idx] = nextNode;
       updated = nextNode;
       await db.projects.put(record);
+      await appendJournalEvents(db, record.snapshot.project.id, events);
     });
     return updated!;
   },
@@ -179,15 +211,18 @@ export const localProvider: DataProvider = {
   async deleteNode(id: string) {
     const db = await getDb();
     if (!db) throw new Error(`Node ${id} not found`);
-    await db.transaction("rw", db.projects, async () => {
+    await db.transaction("rw", db.projects, db.journals, async () => {
       const records = await db.projects.toArray();
       const record = records.find((r) => r.snapshot.nodes.some((n) => n.id === id));
       if (!record) throw new Error(`Node ${id} not found`);
       record.snapshot.nodes = record.snapshot.nodes.filter((n) => n.id !== id);
+      // Cascade-remove attached edges. The journal's node.deleted IMPLIES this
+      // cascade, so we do NOT emit edge.removed for them (docs/spec/journal.md:71).
       record.snapshot.edges = record.snapshot.edges.filter(
         (e) => e.source_id !== id && e.target_id !== id,
       );
       await db.projects.put(record);
+      await appendJournalEvents(db, record.snapshot.project.id, toJournalEvents([nodeDeletedInput(id)]));
     });
   },
 
@@ -196,16 +231,24 @@ export const localProvider: DataProvider = {
     const db = await getDb();
     if (!db) return;
     const idSet = new Set(ids);
-    await db.transaction("rw", db.projects, async () => {
+    await db.transaction("rw", db.projects, db.journals, async () => {
       const records = await db.projects.toArray();
       for (const record of records) {
-        const hasAffected = record.snapshot.nodes.some((n) => idSet.has(n.id));
-        if (!hasAffected) continue;
+        // Only ids actually present in this project's snapshot are deleted (and
+        // emitted), so a node.deleted never references a node that never existed.
+        const deletedIds = record.snapshot.nodes.filter((n) => idSet.has(n.id)).map((n) => n.id);
+        if (deletedIds.length === 0) continue;
         record.snapshot.nodes = record.snapshot.nodes.filter((n) => !idSet.has(n.id));
+        // Cascade-remove edges without emitting edge.removed (docs/spec/journal.md:71).
         record.snapshot.edges = record.snapshot.edges.filter(
           (e) => !idSet.has(e.source_id) && !idSet.has(e.target_id),
         );
         await db.projects.put(record);
+        await appendJournalEvents(
+          db,
+          record.snapshot.project.id,
+          toJournalEvents(deletedIds.map(nodeDeletedInput)),
+        );
       }
     });
   },
@@ -213,11 +256,12 @@ export const localProvider: DataProvider = {
   async createEdge(edge: Edge) {
     const db = await getDb();
     if (!db) throw new Error(`Project ${edge.project_id} not found`);
-    await db.transaction("rw", db.projects, async () => {
+    await db.transaction("rw", db.projects, db.journals, async () => {
       const record = await db.projects.get(edge.project_id);
       if (!record) throw new Error(`Project ${edge.project_id} not found`);
       record.snapshot.edges.push(edge);
       await db.projects.put(record);
+      await appendJournalEvents(db, edge.project_id, toJournalEvents([edgeAddedInput(edge)]));
     });
     return edge;
   },
@@ -225,12 +269,13 @@ export const localProvider: DataProvider = {
   async deleteEdge(id: string) {
     const db = await getDb();
     if (!db) throw new Error(`Edge ${id} not found`);
-    await db.transaction("rw", db.projects, async () => {
+    await db.transaction("rw", db.projects, db.journals, async () => {
       const records = await db.projects.toArray();
       const record = records.find((r) => r.snapshot.edges.some((e) => e.id === id));
       if (!record) throw new Error(`Edge ${id} not found`);
       record.snapshot.edges = record.snapshot.edges.filter((e) => e.id !== id);
       await db.projects.put(record);
+      await appendJournalEvents(db, record.snapshot.project.id, toJournalEvents([edgeRemovedInput(id)]));
     });
   },
 

--- a/lib/utils/export.ts
+++ b/lib/utils/export.ts
@@ -131,11 +131,37 @@ export function downloadJson(bundle: ProjectBundle): ExportDownloadResult {
 }
 
 /**
+ * Dev-time cross-check for the app's journal *writer* role (issue #218). The
+ * exported bundle now carries the app-emitted journal, so we run the same
+ * `validateBundle` — which includes `crossCheckJournal` — the CLI/skill
+ * dual-write is held to. A real emission bug (a `node.status_changed.to` that
+ * disagrees with the snapshot, a dangling ref) surfaces here as a console
+ * warning.
+ *
+ * Deliberately **non-blocking**: a project imported without a journal and then
+ * edited legitimately has a *partial* journal (its pre-existing nodes lack a
+ * `node.created`) — the expected Level 0/1 → 2 transition, not a corruption. We
+ * never fail an export over it; a fully app-authored graph stays green by
+ * construction (every node was created through `createNode`).
+ */
+function warnOnInvalidExport(bundle: ProjectBundle): void {
+  const { valid, errors } = validateBundle(bundle);
+  if (!valid) {
+    console.warn(
+      `[export] Bundle ${bundle.project.id} failed validation (${errors.length} error(s)):`,
+      errors.map((f) => (f.path ? `${f.path}: ${f.message}` : f.message)),
+    );
+  }
+}
+
+/**
  * Exports a project by ID, returning a {@link ProjectBundle} containing the
- * project metadata, all nodes, and all edges.
+ * project metadata, all nodes, edges, and the app-emitted journal.
  */
 export async function exportProject(id: string): Promise<ProjectBundle> {
-  return localProvider.exportProject(id);
+  const bundle = await localProvider.exportProject(id);
+  warnOnInvalidExport(bundle);
+  return bundle;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:journal": "node tests/schema/journal.test.js",
     "test:journal-projections": "node tests/data/journal-projections.test.js",
     "test:emit": "node tests/schema/emit.test.js",
+    "test:emit-events": "node tests/data/emit-events.test.js",
     "test:screenshot-size": "node tests/schema/screenshot-size.test.js",
     "test:migrate": "node tests/data/migrate.test.js && node tests/data/import-roundtrip.test.js && node tests/data/seed-import.test.js",
     "test:cli": "npm run build -w arkaik && node tests/cli/run-cli-tests.js && node tests/cli/init.test.js && node tests/cli/log-release.test.js && node tests/cli/sync.test.js && node tests/cli/pack-open.test.js"

--- a/tests/data/emit-events.test.js
+++ b/tests/data/emit-events.test.js
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+
+/**
+ * Unit tests for the app-side journal event derivation (lib/data/emit-events.ts,
+ * issue #218) — the pure half of the provider's dual-write. Structured as a pure
+ * function precisely so it can be exercised WITHOUT a real IndexedDB (no
+ * fake-indexeddb dev dependency): the Dexie append is a thin `journals`-row
+ * write covered by the append helper's contract; the interesting logic (the
+ * per-key diff, the screenshot exclusion, the status-vs-updated-vs-ref decision)
+ * lives here and is tested directly.
+ *
+ * Covers the issue's acceptance list:
+ *  - create → node.created;
+ *  - status change → project-level node.status_changed (no platform);
+ *  - per-platform status → node.status_changed + platform;
+ *  - note edit on a node WITH a screenshot → node.updated with the PATH only and
+ *    NO data-URI anywhere in the event;
+ *  - delete node with edges → single node.deleted, no edge.removed;
+ *  - ref add/remove → ref.added / ref.removed;
+ *  - the resulting (snapshot, journal) passes crossCheckJournal + validateBundle.
+ */
+
+const path = require("path");
+const fs = require("fs");
+const { loadEmitEvents, BUILD_DIR, SCHEMA_BUILD_DIR } = require("./load-emit-events");
+
+let failures = 0;
+function check(name, cond, detail) {
+  if (cond) {
+    console.log(`PASS: ${name}`);
+  } else {
+    failures++;
+    console.log(`FAIL: ${name}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+const ULID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+
+function main() {
+  const emit = loadEmitEvents();
+  // Built by loadEmitEvents() above; require the same instance so makeEvent and
+  // crossCheckJournal share module state.
+  const { crossCheckJournal, validateBundle } = require(path.join(SCHEMA_BUILD_DIR, "index.js"));
+  const {
+    nodeCreatedInput,
+    nodeDeletedInput,
+    edgeAddedInput,
+    edgeRemovedInput,
+    diffNodeUpdate,
+    toJournalEvents,
+    APP_ACTOR,
+  } = emit;
+
+  const PROJECT_ID = "p1";
+  const baseNode = {
+    id: "V-home",
+    project_id: PROJECT_ID,
+    species: "view",
+    title: "Home",
+    status: "idea",
+    platforms: ["web", "ios"],
+  };
+
+  // --- create → node.created ------------------------------------------------
+  {
+    const [ev] = toJournalEvents([nodeCreatedInput(baseNode)]);
+    check(
+      "createNode → node.created with node_id/species/title",
+      ev.type === "node.created" && ev.node_id === "V-home" && ev.species === "view" && ev.title === "Home",
+      JSON.stringify(ev),
+    );
+    check("node.created carries the app actor + a ULID id", ev.actor === APP_ACTOR && ULID_RE.test(ev.id));
+  }
+
+  // --- status change → project-level node.status_changed --------------------
+  {
+    const inputs = diffNodeUpdate({ ...baseNode, status: "development" }, { status: "live" });
+    check("status change yields exactly one event", inputs.length === 1, JSON.stringify(inputs));
+    const p = inputs[0];
+    check(
+      "status change → node.status_changed (project-level, no platform)",
+      p.type === "node.status_changed" &&
+        p.payload.from === "development" &&
+        p.payload.to === "live" &&
+        p.payload.platform === undefined,
+      JSON.stringify(p),
+    );
+    // The to must equal the new snapshot status — the cross-check's anchor.
+    const [ev] = toJournalEvents(inputs);
+    check("makeEvent validates the status_changed payload", ev.type === "node.status_changed" && ev.to === "live");
+  }
+
+  // --- per-platform status → node.status_changed + platform -----------------
+  {
+    const current = { ...baseNode, status: "development", metadata: { platformStatuses: { ios: "development" } } };
+    const patch = { metadata: { platformStatuses: { ios: "live" }, platformNotes: {}, platformScreenshots: {} } };
+    const inputs = diffNodeUpdate(current, patch);
+    check("per-platform status change yields one event", inputs.length === 1, JSON.stringify(inputs));
+    const p = inputs[0];
+    check(
+      "per-platform status → node.status_changed with platform",
+      p.type === "node.status_changed" && p.payload.platform === "ios" && p.payload.from === "development" && p.payload.to === "live",
+      JSON.stringify(p),
+    );
+
+    // Newly-added platform override: missing endpoint falls back to node status,
+    // so both from/to stay valid statuses (schema requires it).
+    const added = diffNodeUpdate(
+      { ...baseNode, status: "development" },
+      { metadata: { platformStatuses: { ios: "live" } } },
+    );
+    check(
+      "added platform override falls back to node status for `from`",
+      added.length === 1 && added[0].payload.from === "development" && added[0].payload.to === "live" && added[0].payload.platform === "ios",
+      JSON.stringify(added),
+    );
+    // And it must survive makeEvent validation.
+    let ok = true;
+    try {
+      toJournalEvents(added);
+    } catch {
+      ok = false;
+    }
+    check("added platform override validates via makeEvent", ok);
+  }
+
+  // --- note edit on a node WITH a screenshot: path only, NO data-URI --------
+  {
+    const dataUri = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+    // NodeDetailPanel.handleNotesChange rewrites the WHOLE metadata object,
+    // carrying the untouched screenshot forward — the exact drag-in hazard.
+    const current = {
+      ...baseNode,
+      metadata: { platformNotes: { web: "old" }, platformScreenshots: { web: dataUri } },
+    };
+    const patch = {
+      metadata: { platformNotes: { web: "new" }, platformStatuses: {}, platformScreenshots: { web: dataUri } },
+    };
+    const inputs = diffNodeUpdate(current, patch);
+    const events = toJournalEvents(inputs);
+    check("note edit → exactly one node.updated", inputs.length === 1 && inputs[0].type === "node.updated", JSON.stringify(inputs));
+    check(
+      "node.updated records only the note PATH",
+      JSON.stringify(inputs[0].payload.fields) === JSON.stringify(["metadata.platformNotes.web"]),
+      JSON.stringify(inputs[0].payload),
+    );
+    check("node.updated for a metadata path carries no from/to", inputs[0].payload.from === undefined && inputs[0].payload.to === undefined);
+    check("the screenshot data-URI is NOWHERE in the emitted event", !JSON.stringify(events).includes(dataUri));
+
+    // And a screenshot CHANGE records only its path — never the old/new blob.
+    const scOld = "data:image/png;base64,OLDSHOT";
+    const scNew = "data:image/png;base64,NEWSHOT";
+    const scInputs = diffNodeUpdate(
+      { ...baseNode, metadata: { platformScreenshots: { web: scOld } } },
+      { metadata: { platformScreenshots: { web: scNew }, platformNotes: {}, platformStatuses: {} } },
+    );
+    const scStr = JSON.stringify(toJournalEvents(scInputs));
+    check(
+      "screenshot change → node.updated path only, no blob",
+      scInputs.length === 1 &&
+        JSON.stringify(scInputs[0].payload.fields) === JSON.stringify(["metadata.platformScreenshots.web"]) &&
+        !scStr.includes(scOld) &&
+        !scStr.includes(scNew),
+      scStr,
+    );
+  }
+
+  // --- a title rename keeps from/to (single short top-level scalar) ----------
+  {
+    const inputs = diffNodeUpdate(baseNode, { title: "Home v2" });
+    check(
+      "title rename → node.updated fields:[title] with from/to",
+      inputs.length === 1 &&
+        inputs[0].type === "node.updated" &&
+        JSON.stringify(inputs[0].payload.fields) === JSON.stringify(["title"]) &&
+        inputs[0].payload.from === "Home" &&
+        inputs[0].payload.to === "Home v2",
+      JSON.stringify(inputs),
+    );
+  }
+
+  // --- delete node with edges → single node.deleted, no edge.removed --------
+  {
+    // The provider cascade-deletes edges but emits ONLY node.deleted; there is
+    // no edge.removed builder invoked on that path (docs/spec/journal.md:71).
+    const events = toJournalEvents([nodeDeletedInput("V-home")]);
+    check(
+      "deleteNode with edges → single node.deleted, no edge.removed",
+      events.length === 1 && events[0].type === "node.deleted" && events[0].node_id === "V-home" && !JSON.stringify(events).includes("edge.removed"),
+      JSON.stringify(events),
+    );
+  }
+
+  // --- ref add / remove → ref.added / ref.removed ---------------------------
+  {
+    const refA = { id: "gh-1", type: "github-issue", url: "https://example.com/1" };
+    const refB = { id: "gh-2", type: "github-pr", url: "https://example.com/2" };
+    const added = diffNodeUpdate({ ...baseNode, metadata: { refs: [refA] } }, { metadata: { refs: [refA, refB] } });
+    check(
+      "ref gained → ref.added with ref_id/ref_type/url",
+      added.length === 1 && added[0].type === "ref.added" && added[0].payload.ref_id === "gh-2" && added[0].payload.ref_type === "github-pr" && added[0].payload.url === "https://example.com/2",
+      JSON.stringify(added),
+    );
+    const removed = diffNodeUpdate({ ...baseNode, metadata: { refs: [refA, refB] } }, { metadata: { refs: [refA] } });
+    check(
+      "ref lost → ref.removed with ref_id",
+      removed.length === 1 && removed[0].type === "ref.removed" && removed[0].payload.ref_id === "gh-2",
+      JSON.stringify(removed),
+    );
+  }
+
+  // --- the full app-authored (snapshot, journal) passes the cross-check -----
+  {
+    const iso = "2026-01-01T00:00:00.000Z";
+    const nHome = { id: "V-home", project_id: PROJECT_ID, species: "view", title: "Home", status: "live", platforms: ["web"] };
+    const nSet = { id: "V-settings", project_id: PROJECT_ID, species: "view", title: "Settings", status: "development", platforms: ["web"] };
+    const edge = { id: "e-V-home-V-settings", project_id: PROJECT_ID, source_id: "V-home", target_id: "V-settings", edge_type: "composes" };
+
+    // Replay emission in creation order, exactly as the provider would.
+    const journal = [
+      ...toJournalEvents([nodeCreatedInput({ ...nHome, status: "idea" })]),
+      ...toJournalEvents([nodeCreatedInput({ ...nSet, status: "idea" })]),
+      ...toJournalEvents([edgeAddedInput(edge)]),
+      ...toJournalEvents(diffNodeUpdate({ ...nHome, status: "idea" }, { status: "live" })),
+      ...toJournalEvents(diffNodeUpdate({ ...nSet, status: "idea" }, { status: "development" })),
+    ];
+
+    const bundle = {
+      project: { id: PROJECT_ID, title: "P", created_at: iso, updated_at: iso, archived_at: null },
+      nodes: [nHome, nSet],
+      edges: [edge],
+      journal,
+    };
+
+    const crossFindings = crossCheckJournal(bundle);
+    check("app-emitted journal passes crossCheckJournal", crossFindings.length === 0, JSON.stringify(crossFindings));
+    const { valid, errors } = validateBundle(bundle);
+    check("app-authored bundle passes validateBundle", valid, JSON.stringify(errors));
+  }
+
+  fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+  fs.rmSync(SCHEMA_BUILD_DIR, { recursive: true, force: true });
+
+  if (failures > 0) {
+    console.log(`\n${failures} emit-events test(s) failed.`);
+    process.exit(1);
+  }
+  console.log(`\nAll emit-events tests passed.`);
+}
+
+main();

--- a/tests/data/load-emit-events.js
+++ b/tests/data/load-emit-events.js
@@ -1,0 +1,53 @@
+/**
+ * Loads lib/data/emit-events.ts (the pure app-side event derivation, issue
+ * #218) into a running Node process without a bundler — the same
+ * transpile-on-the-fly approach as load-journal-projections.js.
+ *
+ * emit-events.ts's only runtime import is `makeEvent` from @arkaik/schema (its
+ * `import type` lines erase); we build the schema package with load-schema.js
+ * and rewrite that bare specifier to the built CJS index so the require
+ * resolves. Deliberately IndexedDB-free, so it needs no fake-indexeddb.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const ts = require("typescript");
+const { loadSchema, BUILD_DIR: SCHEMA_BUILD_DIR } = require("../schema/load-schema");
+
+const ROOT = path.join(__dirname, "..", "..");
+const SRC_FILE = path.join(ROOT, "lib", "data", "emit-events.ts");
+const BUILD_DIR = path.join(__dirname, ".test-build-emit-events");
+
+function loadEmitEvents() {
+  // Build the schema package so `require(...schema index)` resolves at runtime.
+  loadSchema();
+
+  fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+  fs.mkdirSync(BUILD_DIR, { recursive: true });
+  fs.writeFileSync(path.join(BUILD_DIR, "package.json"), JSON.stringify({ type: "commonjs" }));
+
+  const source = fs.readFileSync(SRC_FILE, "utf8");
+  const { outputText } = ts.transpileModule(source, {
+    fileName: "emit-events.ts",
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+      esModuleInterop: true,
+    },
+  });
+
+  // Point the bare @arkaik/schema require at the built CJS index (absolute,
+  // JSON-encoded so it survives on any OS).
+  const schemaIndex = path.join(SCHEMA_BUILD_DIR, "index.js");
+  const rewritten = outputText.replace(
+    /require\((['"])@arkaik\/schema\1\)/g,
+    `require(${JSON.stringify(schemaIndex)})`,
+  );
+
+  const outFile = path.join(BUILD_DIR, "emit-events.js");
+  fs.writeFileSync(outFile, rewritten);
+  delete require.cache[outFile];
+  return require(outFile);
+}
+
+module.exports = { loadEmitEvents, BUILD_DIR, SCHEMA_BUILD_DIR };


### PR DESCRIPTION
## Summary

Closes #218. Turns the app into a journal **writer** — every provider mutation emits the matching journal event, mirroring the skill/CLI dual-write so an app-exported bundle passes the same `crossCheckJournal`.

> ⚠️ **Held + stacked on #217.** This PR's base is `claude/issue-217-indexeddb` (it needs the Dexie `journals` store), so the diff below is **only #218's changes**. Merge #217 first; GitHub will retarget this to `main`. Held for your review.

## Key Changes

- **`lib/data/emit-events.ts`** (new, pure / IndexedDB-free): `diffNodeUpdate(current, patch)` + `toJournalEvents`. The interesting logic (diffing, screenshot exclusion, status/updated/ref decisions) is a pure module — unit-tested directly, **no `fake-indexeddb` dep added**.
- **Emission wired into every Dexie mutation** (`local-provider.ts`), appended to the project's `journals` row via `appendJournalEvents` **inside the existing `rw` transaction** (snapshot write + journal append commit atomically; the snapshot row is never re-serialized on an append):
  - `createNode`→`node.created`; `deleteNode`/`deleteNodes`→`node.deleted` (**no** cascaded `edge.removed`); `createEdge`→`edge.added`; `deleteEdge`→`edge.removed`.
  - `updateNode` diffs patch vs current: `status`→project-level `node.status_changed`; `platformStatuses[p]`→`node.status_changed`+`platform`; `refs` attach/detach→`ref.added`/`ref.removed`; other paths→one `node.updated` with `fields[]`.
- **Screenshot/asset exclusion (hard rule)**: `metadata` is diffed **per key**, so a changed `platformScreenshots.<p>` records only the path string; `from`/`to` are only ever set for a single short top-level scalar (title, capped) — a data-URI is structurally excluded (asserted by a test).
- **No-emit list** (documented): `saveProject`, `archiveProject`, `importProject`.
- **Cross-checks green by construction** + `validateBundle` (`crossCheckJournal`) wired into `exportProject` as a **non-blocking** dev warning (see risk).
- **`tests/data/emit-events.test.js`** (`test:emit-events`, 20 assertions): create/status/per-platform/note-with-screenshot/delete-with-edges/ref, and an app-emitted (snapshot, journal) passing both `crossCheckJournal` and `validateBundle`.

## Risk / note for review

Export validation is **non-blocking** (`console.warn`, not throw): a project imported *without* a journal and then edited has a legitimately partial journal (pre-existing nodes lack `node.created`), which `crossCheckJournal` flags — that's the expected Level 0/1→2 transition, not corruption, so failing the export would break a real flow. The from-scratch cross-check is proven green by the new test. Also: `makeEvent` validates on emit, so an out-of-vocabulary `status`/`platform` would abort the mutation (UI never produces those).

## Test plan

- [x] `npm run generate` → no drift
- [x] `npm run lint`, `npm run build` (emit stays browser-only / SSR-safe)
- [x] `npm run validate:seeds`
- [x] all `test:*` including `test:emit-events` + `test:migrate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HE4i4eGXnXqsuLZtQvyKgb

---
_Generated by [Claude Code](https://claude.ai/code/session_01HE4i4eGXnXqsuLZtQvyKgb)_