### PR TITLE
M4: Provider-injection seam + mutation notifications

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,5 +69,8 @@ jobs:
       - name: Bundle migration chain tests
         run: npm run test:migrate
 
+      - name: Provider-injection seam + mutation-notification tests
+        run: npm run test:provider
+
       - name: CLI tests
         run: npm run test:cli

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@
 /tests/data/.test-build-export/
 /tests/data/.test-build-journal/
 /tests/data/.test-build-emit-events/
+/tests/data/.test-build-local-provider/
+/tests/data/.test-build-provider-registry/
 /packages/cli/.test-build/
 
 # next.js

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/components/ui/card";
 import { ArkaikLogo } from "@/components/branding/ArkaikLogo";
 import { ThemeToggle } from "@/components/theme-toggle";
-import { localProvider } from "@/lib/data/local-provider";
+import { getProvider } from "@/lib/data/provider-registry";
 import type { Project, ProjectBundle } from "@/lib/data/types";
 import { archiveProject, importProjectFromFile } from "@/lib/utils/export";
 import { DeleteConfirmDialog } from "@/components/graph/DeleteConfirmDialog";
@@ -50,7 +50,7 @@ export default function ProjectsPage() {
   async function loadProjects() {
     setLoading(true);
     try {
-      const list = await localProvider.listProjects();
+      const list = await getProvider().listProjects();
       setProjects(list);
     } catch (err) {
       console.error("[ProjectsPage] Failed to load projects:", err);
@@ -84,7 +84,7 @@ export default function ProjectsPage() {
       edges: [],
     };
 
-    await localProvider.saveProject(bundle);
+    await getProvider().saveProject(bundle);
     await loadProjects();
     router.push(`/project/${id}`);
   }

--- a/lib/data/local-provider.ts
+++ b/lib/data/local-provider.ts
@@ -48,6 +48,24 @@ import {
  * timestamp with no v1 event; `importProject` already carries its own journal
  * (re-emitting would double-count). They still *preserve* an existing journal
  * row so history round-trips.
+ *
+ * ## Mutation notifications (issue #243)
+ * A lightweight, dependency-free pub/sub — {@link subscribeToMutations} — is a
+ * capability of *this module*, not a new `DataProvider` method, so other
+ * providers (a future repo-bundle viewer, `docs/rfcs/arkaik-dev.md` Option
+ * B.1) stay unburdened by a concern only the local provider has today. Synk's
+ * `SyncManager` (`docs/spec/services.md` § Synk) is the first consumer: it
+ * debounces a backup on each notification.
+ *
+ * Every mutation below that changes stored data (create/update/delete node,
+ * create/delete edge, `importProject`, `saveProject`) calls
+ * {@link notifyMutation} exactly once per affected project, and always AFTER
+ * its `db.transaction(...)` has resolved successfully — never inside the
+ * transaction, and never when the transaction throws (an uncaught rejection
+ * propagates out of the method before the notify call is reached).
+ * `archiveProject` is deliberately not wired to notifications, matching the
+ * "no-emit" journal list above — it is not part of issue #243's acceptance
+ * list either.
  */
 
 function collectReferencedFlowIds(entries: PlaylistEntry[]): string[] {
@@ -77,6 +95,35 @@ function collectReferencedFlowIds(entries: PlaylistEntry[]): string[] {
 
 function isArchived(record: ProjectRecord): boolean {
   return Boolean(record.snapshot.project.archived_at);
+}
+
+/** A single mutation notification: which project changed. */
+export interface MutationEvent {
+  projectId: string;
+}
+
+type MutationListener = (event: MutationEvent) => void;
+
+const mutationListeners = new Set<MutationListener>();
+
+/**
+ * Subscribe to local-provider mutation notifications (issue #243) — see the
+ * module doc above for exactly which methods fire and when. Returns an
+ * unsubscribe function.
+ */
+export function subscribeToMutations(cb: MutationListener): () => void {
+  mutationListeners.add(cb);
+  return () => {
+    mutationListeners.delete(cb);
+  };
+}
+
+/** Notify subscribers that `projectId` changed. Called only after a
+ * mutation's `db.transaction(...)` has resolved successfully. */
+function notifyMutation(projectId: string): void {
+  for (const listener of mutationListeners) {
+    listener({ projectId });
+  }
 }
 
 export const localProvider: DataProvider = {
@@ -115,6 +162,7 @@ export const localProvider: DataProvider = {
         await db.journals.delete(projectId);
       }
     });
+    notifyMutation(projectId);
   },
 
   async archiveProject(id: string) {
@@ -164,6 +212,7 @@ export const localProvider: DataProvider = {
       await db.projects.put(record);
       await appendJournalEvents(db, node.project_id, toJournalEvents([nodeCreatedInput(node)]));
     });
+    notifyMutation(node.project_id);
     return node;
   },
 
@@ -171,10 +220,12 @@ export const localProvider: DataProvider = {
     const db = await getDb();
     if (!db) throw new Error(`Node ${id} not found`);
     let updated: Node | undefined;
+    let projectId: string | undefined;
     await db.transaction("rw", db.projects, db.journals, async () => {
       const records = await db.projects.toArray();
       const record = records.find((r) => r.snapshot.nodes.some((n) => n.id === id));
       if (!record) throw new Error(`Node ${id} not found`);
+      projectId = record.snapshot.project.id;
 
       const nodes = record.snapshot.nodes;
       const idx = nodes.findIndex((n) => n.id === id);
@@ -206,16 +257,19 @@ export const localProvider: DataProvider = {
       await db.projects.put(record);
       await appendJournalEvents(db, record.snapshot.project.id, events);
     });
+    notifyMutation(projectId!);
     return updated!;
   },
 
   async deleteNode(id: string) {
     const db = await getDb();
     if (!db) throw new Error(`Node ${id} not found`);
+    let projectId: string | undefined;
     await db.transaction("rw", db.projects, db.journals, async () => {
       const records = await db.projects.toArray();
       const record = records.find((r) => r.snapshot.nodes.some((n) => n.id === id));
       if (!record) throw new Error(`Node ${id} not found`);
+      projectId = record.snapshot.project.id;
       record.snapshot.nodes = record.snapshot.nodes.filter((n) => n.id !== id);
       // Cascade-remove attached edges. The journal's node.deleted IMPLIES this
       // cascade, so we do NOT emit edge.removed for them (docs/spec/journal.md:71).
@@ -225,6 +279,7 @@ export const localProvider: DataProvider = {
       await db.projects.put(record);
       await appendJournalEvents(db, record.snapshot.project.id, toJournalEvents([nodeDeletedInput(id)]));
     });
+    notifyMutation(projectId!);
   },
 
   async deleteNodes(ids: string[]) {
@@ -232,6 +287,9 @@ export const localProvider: DataProvider = {
     const db = await getDb();
     if (!db) return;
     const idSet = new Set(ids);
+    // One notification per affected project, not one per node (issue #243) —
+    // collected during the transaction, fired after it commits.
+    const affectedProjectIds: string[] = [];
     await db.transaction("rw", db.projects, db.journals, async () => {
       const records = await db.projects.toArray();
       for (const record of records) {
@@ -250,8 +308,12 @@ export const localProvider: DataProvider = {
           record.snapshot.project.id,
           toJournalEvents(deletedIds.map(nodeDeletedInput)),
         );
+        affectedProjectIds.push(record.snapshot.project.id);
       }
     });
+    for (const projectId of affectedProjectIds) {
+      notifyMutation(projectId);
+    }
   },
 
   async createEdge(edge: Edge) {
@@ -269,20 +331,24 @@ export const localProvider: DataProvider = {
       await db.projects.put(record);
       await appendJournalEvents(db, normalized.project_id, toJournalEvents([edgeAddedInput(normalized)]));
     });
+    notifyMutation(normalized.project_id);
     return normalized;
   },
 
   async deleteEdge(id: string) {
     const db = await getDb();
     if (!db) throw new Error(`Edge ${id} not found`);
+    let projectId: string | undefined;
     await db.transaction("rw", db.projects, db.journals, async () => {
       const records = await db.projects.toArray();
       const record = records.find((r) => r.snapshot.edges.some((e) => e.id === id));
       if (!record) throw new Error(`Edge ${id} not found`);
+      projectId = record.snapshot.project.id;
       record.snapshot.edges = record.snapshot.edges.filter((e) => e.id !== id);
       await db.projects.put(record);
       await appendJournalEvents(db, record.snapshot.project.id, toJournalEvents([edgeRemovedInput(id)]));
     });
+    notifyMutation(projectId!);
   },
 
   async exportProject(id: string) {
@@ -308,6 +374,7 @@ export const localProvider: DataProvider = {
         await db.journals.delete(projectId);
       }
     });
+    notifyMutation(projectId);
     return normalized.project;
   },
 };

--- a/lib/data/provider-registry.ts
+++ b/lib/data/provider-registry.ts
@@ -1,0 +1,36 @@
+import type { DataProvider } from "./data-provider";
+import { localProvider } from "./local-provider";
+
+/**
+ * The provider-injection seam (issue #243) — the exact prerequisite
+ * `docs/spec/services.md` § Synk "Client sync engine" and
+ * `docs/rfcs/arkaik-dev.md` (Option B.1) both call for, built once to serve
+ * both consumers:
+ *
+ * - Synk's `SyncManager` needs a stable place to read "the current provider"
+ *   without caring whether it's local or (eventually) a synced/remote one.
+ * - `arkaik dev`'s read-only repo-bundle viewer needs to swap in a different
+ *   `DataProvider` implementation at build/hydration time without touching
+ *   every hook/UI call site.
+ *
+ * `getProvider()` is the one seam every consumer should read through instead
+ * of importing `localProvider` directly. It defaults to `localProvider`, so
+ * today's behavior is unchanged; `setProvider()` is the escape hatch a future
+ * provider (or a test) uses to swap it.
+ */
+
+let currentProvider: DataProvider = localProvider;
+
+/** The active `DataProvider`. Defaults to `localProvider`. */
+export function getProvider(): DataProvider {
+  return currentProvider;
+}
+
+/**
+ * Swap the active provider. Not needed for today's local-only app — this is
+ * the injection point future providers (or tests) use. Production call sites
+ * should read through {@link getProvider} rather than call this.
+ */
+export function setProvider(provider: DataProvider): void {
+  currentProvider = provider;
+}

--- a/lib/hooks/useEdges.ts
+++ b/lib/hooks/useEdges.ts
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import type { Edge } from "@/lib/data/types";
-import { localProvider } from "@/lib/data/local-provider";
+import { getProvider } from "@/lib/data/provider-registry";
 
 export function useEdges(projectId: string) {
   const [edges, setEdges] = useState<Edge[]>([]);
@@ -10,7 +10,7 @@ export function useEdges(projectId: string) {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    localProvider
+    getProvider()
       .getEdges(projectId)
       .then((e) => {
         setEdges(e);
@@ -24,13 +24,13 @@ export function useEdges(projectId: string) {
   }, [projectId]);
 
   const addEdge = useCallback(async (edge: Edge) => {
-    const created = await localProvider.createEdge(edge);
+    const created = await getProvider().createEdge(edge);
     setEdges((prev) => [...prev, created]);
     return created;
   }, []);
 
   const removeEdge = useCallback(async (id: string) => {
-    await localProvider.deleteEdge(id);
+    await getProvider().deleteEdge(id);
     setEdges((prev) => prev.filter((e) => e.id !== id));
   }, []);
 

--- a/lib/hooks/useJournal.ts
+++ b/lib/hooks/useJournal.ts
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import type { JournalEvent } from "@/lib/data/types";
-import { localProvider } from "@/lib/data/local-provider";
+import { getProvider } from "@/lib/data/provider-registry";
 
 /**
  * Loads a project's embedded `journal[]` — consistent with {@link useNodes} /
@@ -17,7 +17,7 @@ export function useJournal(projectId: string) {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    localProvider
+    getProvider()
       .getJournal(projectId)
       .then((j) => {
         setJournal(j);

--- a/lib/hooks/useNodes.ts
+++ b/lib/hooks/useNodes.ts
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import type { Node } from "@/lib/data/types";
-import { localProvider } from "@/lib/data/local-provider";
+import { getProvider } from "@/lib/data/provider-registry";
 
 export function useNodes(projectId: string) {
   const [nodes, setNodes] = useState<Node[]>([]);
@@ -10,7 +10,7 @@ export function useNodes(projectId: string) {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    localProvider
+    getProvider()
       .getNodes(projectId)
       .then((n) => {
         setNodes(n);
@@ -24,7 +24,7 @@ export function useNodes(projectId: string) {
   }, [projectId]);
 
   const addNode = useCallback(async (node: Node) => {
-    const created = await localProvider.createNode(node);
+    const created = await getProvider().createNode(node);
     // The provider returns a fresh node and does not mutate this hook's state
     // (the IndexedDB backend hands back new objects, not shared references).
     // The id guard stays as a defensive no-op against a double add.
@@ -36,19 +36,19 @@ export function useNodes(projectId: string) {
   }, []);
 
   const removeNode = useCallback(async (id: string) => {
-    await localProvider.deleteNode(id);
+    await getProvider().deleteNode(id);
     setNodes((prev) => prev.filter((n) => n.id !== id));
   }, []);
 
   const removeNodes = useCallback(async (ids: string[]) => {
-    await localProvider.deleteNodes(ids);
+    await getProvider().deleteNodes(ids);
     const idSet = new Set(ids);
     setNodes((prev) => prev.filter((n) => !idSet.has(n.id)));
   }, []);
 
   const updateNode = useCallback(
     async (id: string, patch: Partial<Omit<Node, "id" | "project_id">>) => {
-      const updated = await localProvider.updateNode(id, patch);
+      const updated = await getProvider().updateNode(id, patch);
       setNodes((prev) => prev.map((n) => (n.id === id ? updated : n)));
       return updated;
     },

--- a/lib/hooks/useProject.ts
+++ b/lib/hooks/useProject.ts
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import type { Project, ProjectBundle } from "@/lib/data/types";
-import { localProvider } from "@/lib/data/local-provider";
+import { getProvider } from "@/lib/data/provider-registry";
 
 export function useProject(id: string) {
   const [project, setProject] = useState<ProjectBundle | undefined>(undefined);
@@ -10,7 +10,7 @@ export function useProject(id: string) {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    localProvider.getProject(id).then((p) => {
+    getProvider().getProject(id).then((p) => {
       setProject(p);
       setLoading(false);
     }).catch((err) => {
@@ -32,7 +32,7 @@ export function useProject(id: string) {
       // (which the old shared-in-memory store surfaced automatically). Saving
       // our own stale `project.nodes`/`edges` would clobber those edits, so we
       // patch project-level fields onto the freshest stored bundle instead.
-      const current = (await localProvider.getProject(project.project.id)) ?? project;
+      const current = (await getProvider().getProject(project.project.id)) ?? project;
 
       const now = new Date().toISOString();
       const nextBundle: ProjectBundle = {
@@ -44,7 +44,7 @@ export function useProject(id: string) {
         },
       };
 
-      await localProvider.saveProject(nextBundle);
+      await getProvider().saveProject(nextBundle);
       setProject(nextBundle);
       return nextBundle.project;
     },

--- a/lib/hooks/useProjects.ts
+++ b/lib/hooks/useProjects.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { localProvider } from "@/lib/data/local-provider";
+import { getProvider } from "@/lib/data/provider-registry";
 import type { ProjectBundle } from "@/lib/data/types";
 
 export function useProjects() {
@@ -12,7 +12,7 @@ export function useProjects() {
   useEffect(() => {
     let cancelled = false;
 
-    localProvider
+    getProvider()
       .listProjects()
       .then((nextProjects) => {
         if (cancelled) return;

--- a/lib/utils/export.ts
+++ b/lib/utils/export.ts
@@ -1,6 +1,6 @@
 import type { Project, ProjectBundle } from "@/lib/data/types";
 import { parseBundle, serializeBundle, validateBundle, type ValidationFinding } from "@arkaik/schema";
-import { localProvider } from "@/lib/data/local-provider";
+import { getProvider } from "@/lib/data/provider-registry";
 
 const MAX_RECOMMENDED_EXPORT_BYTES = 4 * 1024 * 1024;
 
@@ -75,7 +75,7 @@ export function parseAndValidateBundle(value: unknown): ProjectBundle {
 
 async function ensureUniqueProjectId(initialId: string): Promise<string> {
   let candidate = initialId;
-  while (await localProvider.getProject(candidate)) {
+  while (await getProvider().getProject(candidate)) {
     candidate = crypto.randomUUID();
   }
   return candidate;
@@ -159,7 +159,7 @@ function warnOnInvalidExport(bundle: ProjectBundle): void {
  * project metadata, all nodes, edges, and the app-emitted journal.
  */
 export async function exportProject(id: string): Promise<ProjectBundle> {
-  const bundle = await localProvider.exportProject(id);
+  const bundle = await getProvider().exportProject(id);
   warnOnInvalidExport(bundle);
   return bundle;
 }
@@ -169,11 +169,11 @@ export async function exportProject(id: string): Promise<ProjectBundle> {
  * storage. Returns the created {@link Project}.
  */
 export async function importProject(bundle: ProjectBundle): Promise<Project> {
-  return localProvider.importProject(bundle);
+  return getProvider().importProject(bundle);
 }
 
 export async function archiveProject(id: string): Promise<void> {
-  return localProvider.archiveProject(id);
+  return getProvider().archiveProject(id);
 }
 
 /**
@@ -203,5 +203,5 @@ export async function importProjectFromFile(file: File): Promise<Project> {
       ? normalizedBundle
       : rewriteBundleProjectId(normalizedBundle, resolvedProjectId);
 
-  return localProvider.importProject(finalBundle);
+  return getProvider().importProject(finalBundle);
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:emit-events": "node tests/data/emit-events.test.js",
     "test:screenshot-size": "node tests/schema/screenshot-size.test.js",
     "test:migrate": "node tests/data/migrate.test.js && node tests/data/import-roundtrip.test.js && node tests/data/seed-import.test.js",
+    "test:provider": "node tests/data/provider-registry.test.js && node tests/data/mutation-notifications.test.js",
     "test:cli": "npm run build -w arkaik && node tests/cli/run-cli-tests.js && node tests/cli/init.test.js && node tests/cli/log-release.test.js && node tests/cli/sync.test.js && node tests/cli/pack-open.test.js"
   },
   "dependencies": {

--- a/tests/data/import-roundtrip.test.js
+++ b/tests/data/import-roundtrip.test.js
@@ -14,8 +14,9 @@
  *
  * export.ts is loaded by transpiling it and intercepting its two runtime
  * imports: the real `@arkaik/schema` (so parse/validate behave exactly as in
- * the app) and a stub `localProvider` that forces one id collision and captures
- * what gets imported.
+ * the app) and a stub `provider-registry` module (export.ts reads its provider
+ * through `getProvider()`, issue #243) whose stub provider forces one id
+ * collision and captures what gets imported.
  */
 
 const fs = require("fs");
@@ -41,13 +42,18 @@ const COLLIDING_ID = "existing-project";
 let captured = null;
 
 const stubProvider = {
-  localProvider: {
-    getProject: async (id) => (id === COLLIDING_ID ? { project: { id } } : undefined),
-    importProject: async (bundle) => {
-      captured = bundle;
-      return bundle.project;
-    },
+  getProject: async (id) => (id === COLLIDING_ID ? { project: { id } } : undefined),
+  importProject: async (bundle) => {
+    captured = bundle;
+    return bundle.project;
   },
+};
+
+// export.ts reads its provider through the getProvider() seam (issue #243)
+// rather than importing local-provider directly, so the stub is shaped like
+// provider-registry's export.
+const stubProviderRegistry = {
+  getProvider: () => stubProvider,
 };
 
 function loadExportModule() {
@@ -73,7 +79,7 @@ function loadExportModule() {
   const originalLoad = Module._load;
   Module._load = function (request, parent, isMain) {
     if (request === "@arkaik/schema") return schemaExports;
-    if (request.includes("local-provider")) return stubProvider;
+    if (request.includes("provider-registry")) return stubProviderRegistry;
     return originalLoad.call(this, request, parent, isMain);
   };
   try {
@@ -110,7 +116,7 @@ async function main() {
   const file = { text: async () => JSON.stringify(bundle) };
   const createdProject = await exportModule.importProjectFromFile(file);
 
-  assert(captured !== null, "import path reached localProvider.importProject");
+  assert(captured !== null, "import path reached the provider's importProject");
   assert(
     captured.project.id !== COLLIDING_ID && createdProject.id === captured.project.id,
     "id-collision: project id was rewritten to a fresh id",

--- a/tests/data/load-local-provider.js
+++ b/tests/data/load-local-provider.js
@@ -1,0 +1,181 @@
+/**
+ * Loads lib/data/local-provider.ts into a running Node process without a
+ * bundler, the same transpile-on-the-fly approach the other tests/data
+ * loaders use — plus a hand-written in-memory fake for `./db` (lib/data/db.ts)
+ * so the provider's real create/update/delete transactions run for real in
+ * plain Node.
+ *
+ * Deliberately no `fake-indexeddb` dev dependency: db.ts's runtime surface
+ * that local-provider.ts actually calls (`getDb`, `appendJournalEvents`,
+ * `assembleBundle`, `splitBundle`) is small and simple enough to reimplement
+ * faithfully by hand — the same "stub the seam, not the browser API" approach
+ * tests/data/import-roundtrip.test.js takes for `local-provider` itself, and
+ * the same reasoning tests/data/load-emit-events.js documents for staying
+ * IndexedDB-free. The fake's `transaction()` just runs its callback (no real
+ * atomicity), which is enough to prove the ordering this suite cares about:
+ * notifications fire after the transaction's callback resolves, never inside
+ * it, never on a thrown error.
+ *
+ * All of local-provider.ts's *other* runtime dependencies are loaded for
+ * real: `./migrate` and `./emit-events` are transpiled fresh (their own
+ * `@arkaik/schema` requires rewritten to the built schema package, exactly
+ * like load-migrate.js / load-emit-events.js do standalone), and
+ * `lib/utils/cycle.ts` is transpiled as-is (its only import is `import type`,
+ * which erases, so it has no runtime dependencies to stub).
+ */
+
+const fs = require("fs");
+const path = require("path");
+const ts = require("typescript");
+const { loadSchema, BUILD_DIR: SCHEMA_BUILD_DIR } = require("../schema/load-schema");
+
+const ROOT = path.join(__dirname, "..", "..");
+const BUILD_DIR = path.join(__dirname, ".test-build-local-provider");
+
+const COMPILER_OPTIONS = {
+  module: ts.ModuleKind.CommonJS,
+  target: ts.ScriptTarget.ES2020,
+  esModuleInterop: true,
+};
+
+function transpile(srcFile, fileName) {
+  const source = fs.readFileSync(srcFile, "utf8");
+  return ts.transpileModule(source, { fileName, compilerOptions: COMPILER_OPTIONS }).outputText;
+}
+
+// Hand-written fake for lib/data/db.ts — see the module doc above. Faithfully
+// mirrors the real splitBundle/assembleBundle/appendJournalEvents logic
+// (they're simple and pure); `getDb`/`__setFakeDb`/`__makeFakeDb` replace the
+// real Dexie-backed readiness gate with a settable in-memory store.
+const FAKE_DB_SOURCE = `
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+
+function clone(value) {
+  return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+}
+
+function makeTable(keyOf) {
+  const rows = new Map();
+  return {
+    async get(key) {
+      return clone(rows.get(key));
+    },
+    async put(row) {
+      rows.set(keyOf(row), clone(row));
+      return keyOf(row);
+    },
+    async delete(key) {
+      rows.delete(key);
+    },
+    async toArray() {
+      return Array.from(rows.values()).map(clone);
+    },
+  };
+}
+
+function __makeFakeDb() {
+  return {
+    projects: makeTable((row) => row.id),
+    journals: makeTable((row) => row.projectId),
+    async transaction(mode, ...args) {
+      const callback = args[args.length - 1];
+      return await callback();
+    },
+  };
+}
+
+let currentDb = null;
+function __setFakeDb(db) {
+  currentDb = db;
+}
+
+async function getDb() {
+  return currentDb;
+}
+
+function splitBundle(bundle) {
+  const { journal, ...snapshot } = bundle;
+  return { snapshot, journal };
+}
+
+function assembleBundle(snapshot, events) {
+  return events !== undefined ? Object.assign({}, snapshot, { journal: events }) : snapshot;
+}
+
+async function appendJournalEvents(db, projectId, events) {
+  if (events.length === 0) return;
+  const row = await db.journals.get(projectId);
+  const existing = (row && row.events) || [];
+  await db.journals.put({ projectId, events: existing.concat(events) });
+}
+
+exports.getDb = getDb;
+exports.appendJournalEvents = appendJournalEvents;
+exports.assembleBundle = assembleBundle;
+exports.splitBundle = splitBundle;
+exports.__setFakeDb = __setFakeDb;
+exports.__makeFakeDb = __makeFakeDb;
+`;
+
+function loadLocalProvider() {
+  loadSchema();
+
+  fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+  fs.mkdirSync(BUILD_DIR, { recursive: true });
+  fs.writeFileSync(path.join(BUILD_DIR, "package.json"), JSON.stringify({ type: "commonjs" }));
+
+  const schemaIndex = path.join(SCHEMA_BUILD_DIR, "index.js");
+  const rewriteSchemaRequire = (text) =>
+    text.replace(/require\((['"])@arkaik\/schema\1\)/g, `require(${JSON.stringify(schemaIndex)})`);
+
+  // db.js — hand-written fake (FAKE_DB_SOURCE above).
+  fs.writeFileSync(path.join(BUILD_DIR, "db.js"), FAKE_DB_SOURCE);
+
+  // cycle.js — transpiled as-is; only `import type` deps, so no rewrite needed.
+  fs.writeFileSync(
+    path.join(BUILD_DIR, "cycle.js"),
+    transpile(path.join(ROOT, "lib", "utils", "cycle.ts"), "cycle.ts"),
+  );
+
+  // emit-events.js — transpiled, @arkaik/schema require rewritten to the real build.
+  fs.writeFileSync(
+    path.join(BUILD_DIR, "emit-events.js"),
+    rewriteSchemaRequire(transpile(path.join(ROOT, "lib", "data", "emit-events.ts"), "emit-events.ts")),
+  );
+
+  // migrate.js — transpiled, @arkaik/schema require rewritten to the real build.
+  fs.writeFileSync(
+    path.join(BUILD_DIR, "migrate.js"),
+    rewriteSchemaRequire(transpile(path.join(ROOT, "lib", "data", "migrate.ts"), "migrate.ts")),
+  );
+
+  // local-provider.js — transpiled; @arkaik/schema and the `@/lib/utils/cycle`
+  // alias rewritten (the alias isn't resolvable by plain Node require, so it's
+  // pointed at the sibling cycle.js written above; every other import is a
+  // real relative path ("./migrate", "./db", "./emit-events") that resolves
+  // naturally since all these files live in the same BUILD_DIR).
+  let localProviderOut = transpile(path.join(ROOT, "lib", "data", "local-provider.ts"), "local-provider.ts");
+  localProviderOut = rewriteSchemaRequire(localProviderOut);
+  localProviderOut = localProviderOut.replace(
+    /require\((['"])@\/lib\/utils\/cycle\1\)/g,
+    `require("./cycle")`,
+  );
+  const outFile = path.join(BUILD_DIR, "local-provider.js");
+  fs.writeFileSync(outFile, localProviderOut);
+
+  for (const name of ["db", "cycle", "emit-events", "migrate", "local-provider"]) {
+    delete require.cache[path.join(BUILD_DIR, `${name}.js`)];
+  }
+
+  const localProviderModule = require(outFile);
+  const dbModule = require(path.join(BUILD_DIR, "db.js"));
+  return {
+    localProvider: localProviderModule.localProvider,
+    subscribeToMutations: localProviderModule.subscribeToMutations,
+    __makeFakeDb: dbModule.__makeFakeDb,
+    __setFakeDb: dbModule.__setFakeDb,
+  };
+}
+
+module.exports = { loadLocalProvider, BUILD_DIR, SCHEMA_BUILD_DIR };

--- a/tests/data/load-provider-registry.js
+++ b/tests/data/load-provider-registry.js
@@ -1,0 +1,59 @@
+/**
+ * Loads lib/data/provider-registry.ts (the getProvider()/setProvider()
+ * injection seam, issue #243) into a running Node process without a bundler —
+ * the same transpile-on-the-fly approach as the other tests/data loaders.
+ *
+ * provider-registry.ts's only runtime import is `./local-provider` (its
+ * `DataProvider` import is `import type`, which erases). We stub that sibling
+ * with a small marker object rather than loading the real Dexie-backed
+ * provider, since this loader only needs to prove the registry's own
+ * default/override behavior — the real local-provider is exercised directly
+ * by load-local-provider.js / mutation-notifications.test.js.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const ts = require("typescript");
+
+const ROOT = path.join(__dirname, "..", "..");
+const SRC_FILE = path.join(ROOT, "lib", "data", "provider-registry.ts");
+const BUILD_DIR = path.join(__dirname, ".test-build-provider-registry");
+
+const COMPILER_OPTIONS = {
+  module: ts.ModuleKind.CommonJS,
+  target: ts.ScriptTarget.ES2020,
+  esModuleInterop: true,
+};
+
+/** Marker stand-in for the real `localProvider` singleton. */
+const DEFAULT_PROVIDER_MARKER = { __marker: "default-local-provider" };
+
+function loadProviderRegistry() {
+  fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+  fs.mkdirSync(BUILD_DIR, { recursive: true });
+  fs.writeFileSync(path.join(BUILD_DIR, "package.json"), JSON.stringify({ type: "commonjs" }));
+
+  // A sibling "./local-provider" file so the transpiled provider-registry.js's
+  // relative require resolves without any Module._load interception.
+  fs.writeFileSync(
+    path.join(BUILD_DIR, "local-provider.js"),
+    `"use strict";\nObject.defineProperty(exports, "__esModule", { value: true });\nexports.localProvider = ${JSON.stringify(DEFAULT_PROVIDER_MARKER)};\n`,
+  );
+
+  const source = fs.readFileSync(SRC_FILE, "utf8");
+  const { outputText } = ts.transpileModule(source, { fileName: "provider-registry.ts", compilerOptions: COMPILER_OPTIONS });
+  const outFile = path.join(BUILD_DIR, "provider-registry.js");
+  fs.writeFileSync(outFile, outputText);
+
+  const localProviderFile = path.join(BUILD_DIR, "local-provider.js");
+  delete require.cache[localProviderFile];
+  delete require.cache[outFile];
+
+  // Hand back the *same* object instance the registry closure captured (the
+  // generated local-provider.js's module.exports.localProvider), not a
+  // separately-parsed copy, so identity checks in the test are meaningful.
+  const defaultProviderMarker = require(localProviderFile).localProvider;
+  return { ...require(outFile), defaultProviderMarker };
+}
+
+module.exports = { loadProviderRegistry, BUILD_DIR };

--- a/tests/data/mutation-notifications.test.js
+++ b/tests/data/mutation-notifications.test.js
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+
+/**
+ * Unit tests for the mutation-notification channel (lib/data/local-provider.ts
+ * `subscribeToMutations`, issue #243) — the other half of the provider-
+ * injection seam `docs/spec/services.md` § Synk "Client sync engine" needs to
+ * trigger its debounced backup, and the exact seam `docs/rfcs/arkaik-dev.md`
+ * (Option B.1) calls for.
+ *
+ * Exercises the real local-provider.ts mutation methods (via
+ * load-local-provider.js's hand-written in-memory fake `./db`, deliberately
+ * IndexedDB-free) and asserts, per issue #243's acceptance criteria:
+ *  - a node update fires exactly one notification with the right projectId;
+ *  - the notification fires AFTER the mutation's transaction resolves, never
+ *    on a failed/thrown mutation;
+ *  - create/delete node, create/delete edge, importProject, and saveProject
+ *    each fire exactly one notification for their project;
+ *  - deleteNodes (batch) fires one notification per affected project, not one
+ *    per node;
+ *  - archiveProject does not fire a notification (deliberately excluded from
+ *    the acceptance list — see local-provider.ts's module doc);
+ *  - unsubscribe() actually stops delivery.
+ */
+
+const fs = require("fs");
+const { loadLocalProvider, BUILD_DIR, SCHEMA_BUILD_DIR } = require("./load-local-provider");
+
+let failures = 0;
+function check(name, cond, detail) {
+  if (cond) {
+    console.log(`PASS: ${name}`);
+  } else {
+    failures++;
+    console.log(`FAIL: ${name}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+const ISO = "2026-01-01T00:00:00.000Z";
+
+function makeBundle(projectId, nodes = [], edges = []) {
+  return {
+    schema_version: 2, // current — migrateBundle returns it untouched
+    project: {
+      id: projectId,
+      title: `Project ${projectId}`,
+      created_at: ISO,
+      updated_at: ISO,
+      archived_at: null,
+    },
+    nodes,
+    edges,
+  };
+}
+
+function makeNode(id, projectId, overrides = {}) {
+  return {
+    id,
+    project_id: projectId,
+    species: "view",
+    title: id,
+    status: "idea",
+    platforms: ["web"],
+    ...overrides,
+  };
+}
+
+async function main() {
+  const { localProvider, subscribeToMutations, __makeFakeDb, __setFakeDb } = loadLocalProvider();
+
+  function withRecorder() {
+    const received = [];
+    const unsubscribe = subscribeToMutations((e) => received.push(e));
+    return { received, unsubscribe };
+  }
+
+  // --- setup: a fresh fake db seeded with one project/node via saveProject ---
+  const db = __makeFakeDb();
+  __setFakeDb(db);
+
+  const PROJECT_A = "p-a";
+  await localProvider.saveProject(makeBundle(PROJECT_A, [makeNode("V-home", PROJECT_A)]));
+
+  // --- updateNode: exactly one notification, right projectId (the acceptance
+  // criteria's named unit test) ---
+  {
+    const { received, unsubscribe } = withRecorder();
+    const updated = await localProvider.updateNode("V-home", { title: "Home v2" });
+    unsubscribe();
+    check("updateNode returns the updated node", updated.title === "Home v2");
+    check("updateNode fires exactly one notification", received.length === 1, JSON.stringify(received));
+    check(
+      "updateNode's notification carries the right projectId",
+      received[0]?.projectId === PROJECT_A,
+      JSON.stringify(received),
+    );
+  }
+
+  // --- unsubscribe actually stops delivery ---
+  {
+    const { received, unsubscribe } = withRecorder();
+    unsubscribe();
+    await localProvider.updateNode("V-home", { title: "Home v3" });
+    check("no notification is delivered after unsubscribe()", received.length === 0, JSON.stringify(received));
+  }
+
+  // --- createNode fires exactly one notification ---
+  {
+    const { received, unsubscribe } = withRecorder();
+    await localProvider.createNode(makeNode("V-settings", PROJECT_A));
+    unsubscribe();
+    check("createNode fires exactly one notification", received.length === 1, JSON.stringify(received));
+    check("createNode's notification carries the right projectId", received[0]?.projectId === PROJECT_A);
+  }
+
+  // --- createEdge / deleteEdge fire exactly one notification each ---
+  {
+    const { received, unsubscribe } = withRecorder();
+    const edge = await localProvider.createEdge({
+      id: "ignored-on-create",
+      project_id: PROJECT_A,
+      source_id: "V-home",
+      target_id: "V-settings",
+      edge_type: "composes",
+    });
+    check("createEdge fires exactly one notification", received.length === 1, JSON.stringify(received));
+    check("createEdge's notification carries the right projectId", received[0]?.projectId === PROJECT_A);
+
+    received.length = 0;
+    await localProvider.deleteEdge(edge.id);
+    check("deleteEdge fires exactly one notification", received.length === 1, JSON.stringify(received));
+    check("deleteEdge's notification carries the right projectId", received[0]?.projectId === PROJECT_A);
+    unsubscribe();
+  }
+
+  // --- deleteNode fires exactly one notification ---
+  {
+    const { received, unsubscribe } = withRecorder();
+    await localProvider.deleteNode("V-settings");
+    unsubscribe();
+    check("deleteNode fires exactly one notification", received.length === 1, JSON.stringify(received));
+    check("deleteNode's notification carries the right projectId", received[0]?.projectId === PROJECT_A);
+  }
+
+  // --- importProject fires exactly one notification ---
+  {
+    const { received, unsubscribe } = withRecorder();
+    const PROJECT_IMPORTED = "p-imported";
+    await localProvider.importProject(makeBundle(PROJECT_IMPORTED, [makeNode("V-x", PROJECT_IMPORTED)]));
+    unsubscribe();
+    check("importProject fires exactly one notification", received.length === 1, JSON.stringify(received));
+    check("importProject's notification carries the right projectId", received[0]?.projectId === PROJECT_IMPORTED);
+  }
+
+  // --- saveProject fires exactly one notification ---
+  {
+    const { received, unsubscribe } = withRecorder();
+    const current = await localProvider.getProject(PROJECT_A);
+    await localProvider.saveProject({
+      ...current,
+      project: { ...current.project, title: "Renamed" },
+    });
+    unsubscribe();
+    check("saveProject fires exactly one notification", received.length === 1, JSON.stringify(received));
+    check("saveProject's notification carries the right projectId", received[0]?.projectId === PROJECT_A);
+  }
+
+  // --- archiveProject deliberately does NOT fire (not in issue #243's list) ---
+  {
+    const { received, unsubscribe } = withRecorder();
+    await localProvider.archiveProject(PROJECT_A);
+    unsubscribe();
+    check("archiveProject fires no notification", received.length === 0, JSON.stringify(received));
+  }
+
+  // --- a failed mutation never fires (thrown before/without a resolved transaction) ---
+  {
+    const { received, unsubscribe } = withRecorder();
+    let threw = false;
+    try {
+      await localProvider.updateNode("does-not-exist", { title: "x" });
+    } catch {
+      threw = true;
+    }
+    unsubscribe();
+    check("updating a nonexistent node throws", threw);
+    check("a failed mutation fires no notification", received.length === 0, JSON.stringify(received));
+  }
+
+  // --- deleteNodes (batch) fires one notification per affected project, not
+  // one per node ---
+  {
+    const PROJECT_B = "p-b";
+    const PROJECT_C = "p-c";
+    await localProvider.saveProject(
+      makeBundle(PROJECT_B, [makeNode("V-b1", PROJECT_B), makeNode("V-b2", PROJECT_B)]),
+    );
+    await localProvider.saveProject(makeBundle(PROJECT_C, [makeNode("V-c1", PROJECT_C)]));
+
+    const { received, unsubscribe } = withRecorder();
+    await localProvider.deleteNodes(["V-b1", "V-b2", "V-c1"]);
+    unsubscribe();
+
+    check(
+      "deleteNodes fires exactly one notification per affected project (2 projects, 3 nodes)",
+      received.length === 2,
+      JSON.stringify(received),
+    );
+    const projectIds = received.map((e) => e.projectId).sort();
+    check(
+      "deleteNodes' notifications name exactly the affected projects",
+      JSON.stringify(projectIds) === JSON.stringify([PROJECT_B, PROJECT_C]),
+      JSON.stringify(projectIds),
+    );
+  }
+
+  // --- deleteNodes with no ids affected fires nothing ---
+  {
+    const { received, unsubscribe } = withRecorder();
+    await localProvider.deleteNodes(["does-not-exist"]);
+    unsubscribe();
+    check("deleteNodes affecting no project fires no notification", received.length === 0, JSON.stringify(received));
+  }
+
+  fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+  fs.rmSync(SCHEMA_BUILD_DIR, { recursive: true, force: true });
+
+  if (failures > 0) {
+    console.log(`\n${failures} mutation-notification test(s) failed.`);
+    process.exit(1);
+  }
+  console.log("\nAll mutation-notification tests passed.");
+}
+
+main();

--- a/tests/data/provider-registry.test.js
+++ b/tests/data/provider-registry.test.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+/**
+ * Unit tests for the provider-injection seam (lib/data/provider-registry.ts,
+ * issue #243) — the exact prerequisite `docs/spec/services.md` § Synk "Client
+ * sync engine" and `docs/rfcs/arkaik-dev.md` (Option B.1) both call for.
+ *
+ * Covers the acceptance list:
+ *  - getProvider() defaults to the local provider singleton;
+ *  - setProvider() swaps the active provider, and getProvider() reflects it
+ *    immediately (module-level injection point, not a cached snapshot).
+ */
+
+const fs = require("fs");
+const { loadProviderRegistry, BUILD_DIR } = require("./load-provider-registry");
+
+let failures = 0;
+function check(name, cond, detail) {
+  if (cond) {
+    console.log(`PASS: ${name}`);
+  } else {
+    failures++;
+    console.log(`FAIL: ${name}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+function main() {
+  const { getProvider, setProvider, defaultProviderMarker } = loadProviderRegistry();
+
+  check(
+    "getProvider() defaults to the local provider singleton",
+    getProvider() === defaultProviderMarker,
+    JSON.stringify(getProvider()),
+  );
+
+  const customProvider = { __marker: "custom-provider" };
+  setProvider(customProvider);
+  check("setProvider() swaps the active provider", getProvider() === customProvider);
+  check(
+    "getProvider() keeps returning the swapped provider on repeated calls",
+    getProvider() === customProvider,
+  );
+
+  // Restore the default so this module's global state doesn't leak into any
+  // other test sharing the same process (each test file here runs standalone
+  // via `node`, but this keeps the file correct if that ever changes).
+  setProvider(defaultProviderMarker);
+  check("setProvider() can restore the default provider", getProvider() === defaultProviderMarker);
+
+  fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+
+  if (failures > 0) {
+    console.log(`\n${failures} provider-registry test(s) failed.`);
+    process.exit(1);
+  }
+  console.log("\nAll provider-registry tests passed.");
+}
+
+main();


### PR DESCRIPTION
## Summary

Client-side prerequisite for the Synk sync engine (`docs/spec/services.md` § Synk) and the seam `docs/rfcs/arkaik-dev.md` (Option B.1) calls for — built once, serving both:

- **`lib/data/provider-registry.ts`** (new): `getProvider()` / `setProvider()`, defaulting to `localProvider`. All 6 named direct importers (`lib/hooks/useProject.ts`, `useNodes.ts`, `useEdges.ts`, `useJournal.ts`, `useProjects.ts`, `lib/utils/export.ts`) now read through `getProvider()` instead of importing `localProvider` directly — no behavior change. I also found and switched a 7th direct importer, `app/projects/page.tsx` (not named in the issue but the same category of direct import; leaving it out would have undermined the seam's point), for consistency.
- **`lib/data/local-provider.ts`**: `subscribeToMutations(cb: (e: { projectId: string }) => void): () => void` — a dependency-free pub/sub. Every mutation that changes stored data (`createNode`/`updateNode`/`deleteNode`/`deleteNodes`, `createEdge`/`deleteEdge`, `importProject`, `saveProject`) fires a notification once per affected project, always **after** its `db.transaction(...)` resolves successfully — never inside the transaction, never on a thrown/failed mutation. `deleteNodes` (batch) fires one notification per affected project, not one per node. `archiveProject` deliberately does **not** fire, matching its existing "no-emit" journal treatment (see the module doc in `local-provider.ts`) — this mirrors the issue's acceptance list, which also omits it.
- The `DataProvider` interface (`lib/data/data-provider.ts`) is **untouched** — notifications are a capability of the local-provider module, not a new interface method, so future providers stay unburdened.

## Tests

New: `tests/data/mutation-notifications.test.js` and `tests/data/provider-registry.test.js`, each with a `load-*.js` loader following the repo's existing transpile-on-the-fly pattern (`tests/data/load-migrate.js`, `load-emit-events.js`, etc.).

The mutation-notifications loader (`tests/data/load-local-provider.js`) transpiles the real `local-provider.ts` and its real dependencies (`migrate.ts`, `emit-events.ts`, `cycle.ts`), and swaps in a small hand-written in-memory fake for `lib/data/db.ts` — deliberately **no `fake-indexeddb` dependency**, matching this test suite's existing documented philosophy of staying IndexedDB-free. This lets the provider's actual mutation methods (transactions, journal dual-write, and now notifications) run for real in plain Node.

Covers, beyond the required minimum ("a node update fires exactly one notification with the right projectId"): every wired mutation method fires exactly once with the right `projectId`; `unsubscribe()` stops delivery; a thrown/failed mutation fires nothing; `archiveProject` fires nothing; and `deleteNodes` across two projects fires exactly 2 notifications (one per project), not one per node.

Updated `tests/data/import-roundtrip.test.js`'s stub to match `export.ts`'s new `provider-registry` import (it previously stubbed `local-provider` directly).

Wired into `package.json` as `npm run test:provider` and added one step to `.github/workflows/ci.yml`'s existing test list (no job-structure changes).

## Verification

- `npm run lint` — 0 errors (3 pre-existing, unrelated warnings)
- `npm run build` — succeeds
- `npm run generate` — no generated-artifact drift (mirrors the CI gate)
- Full existing `npm run test:*` battery (fixtures, schema, id-gen, serialize, refs, journal, journal-projections, emit, emit-events, screenshot-size, migrate, cli) — all green
- New `npm run test:provider` — all green

## Scope notes

- Did not touch `db/`, `app/api/`, or `.github/workflows/ci.yml`'s job structure (per instructions — another agent's parallel work).
- `DataProvider` interface unchanged.

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QpXVmp8QNHQF3s2cCvtead)_