### PR TITLE
M4: Publik API — create, fetch, delete, report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,3 +116,6 @@ jobs:
 
       - name: Re-run migrations (idempotency gate — must be a no-op, exit 0)
         run: npm run db:migrate
+
+      - name: Publik API integration tests
+        run: npm run test:publik

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 /tests/data/.test-build-emit-events/
 /tests/data/.test-build-local-provider/
 /tests/data/.test-build-provider-registry/
+/tests/services/.test-build-publik/
 /packages/cli/.test-build/
 
 # next.js

--- a/app/api/publik/[id]/report/route.ts
+++ b/app/api/publik/[id]/report/route.ts
@@ -1,0 +1,55 @@
+import {
+  REPORT_RATE_LIMIT,
+  checkRateLimit,
+  deriveClientIp,
+  hashIp,
+  reportSnapshot,
+  servicesConfigured,
+  servicesUnavailable,
+} from "@/lib/services/publik";
+
+/**
+ * POST /api/publik/{id}/report — increment `report_count` and flag for review
+ * over the threshold (docs/spec/services.md § Publik → Protocol, § Moderation).
+ * Rate-limited per IP like every other unauthenticated write. Returns `202`.
+ *
+ * Node runtime for the `pg` driver.
+ */
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type Context = { params: Promise<{ id: string }> };
+
+export async function POST(req: Request, { params }: Context): Promise<Response> {
+  if (!servicesConfigured()) return servicesUnavailable();
+
+  const { id } = await params;
+  try {
+    const ipHash = hashIp(deriveClientIp(req));
+    const rate = await checkRateLimit(ipHash, "report", REPORT_RATE_LIMIT);
+    if (rate.limited) {
+      return Response.json(
+        { error: "rate_limited", message: "Too many reports. Try again later." },
+        { status: 429, headers: { "retry-after": String(rate.retryAfter) } },
+      );
+    }
+
+    const outcome = await reportSnapshot(id);
+    if (!outcome.found) {
+      return Response.json({ error: "not_found", message: "Snapshot not found." }, { status: 404 });
+    }
+
+    // 202 Accepted: the report is recorded; review is an out-of-band process.
+    // `flagged` makes the threshold state queryable by the caller (§ Moderation).
+    return Response.json(
+      { status: "accepted", report_count: outcome.reportCount, flagged: outcome.flagged },
+      { status: 202 },
+    );
+  } catch (err) {
+    console.error("[publik] report failed:", err instanceof Error ? err.message : "unknown error");
+    return Response.json(
+      { error: "internal_error", message: "Failed to record report." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/publik/[id]/route.ts
+++ b/app/api/publik/[id]/route.ts
@@ -1,0 +1,78 @@
+import {
+  deleteSnapshot,
+  fetchSnapshotBundle,
+  servicesConfigured,
+  servicesUnavailable,
+} from "@/lib/services/publik";
+
+/**
+ * GET  /api/publik/{id} — return the stored bundle verbatim, or 404.
+ * DELETE /api/publik/{id} — delete iff the Bearer owner key matches (204/403).
+ *
+ * docs/spec/services.md § Publik → Protocol. Node runtime for the `pg` driver.
+ */
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type Context = { params: Promise<{ id: string }> };
+
+export async function GET(_req: Request, { params }: Context): Promise<Response> {
+  if (!servicesConfigured()) return servicesUnavailable();
+
+  const { id } = await params;
+  try {
+    const bundle = await fetchSnapshotBundle(id);
+    if (bundle === null) {
+      return Response.json({ error: "not_found", message: "Snapshot not found." }, { status: 404 });
+    }
+    // Verbatim stored bundle (§ "returns the stored bundle verbatim").
+    return Response.json(bundle, { status: 200 });
+  } catch (err) {
+    console.error("[publik] GET failed:", err instanceof Error ? err.message : "unknown error");
+    return Response.json(
+      { error: "internal_error", message: "Failed to fetch snapshot." },
+      { status: 500 },
+    );
+  }
+}
+
+/** Extract the token from an `Authorization: Bearer <token>` header, or null. */
+function bearerToken(req: Request): string | null {
+  const header = req.headers.get("authorization");
+  if (!header) return null;
+  const match = /^Bearer\s+(.+)$/i.exec(header.trim());
+  return match ? match[1].trim() : null;
+}
+
+export async function DELETE(req: Request, { params }: Context): Promise<Response> {
+  if (!servicesConfigured()) return servicesUnavailable();
+
+  const token = bearerToken(req);
+  if (!token) {
+    return Response.json(
+      { error: "unauthorized", message: "Missing Authorization: Bearer <owner_key>." },
+      { status: 401 },
+    );
+  }
+
+  const { id } = await params;
+  try {
+    const outcome = await deleteSnapshot(id, token);
+    if (outcome === "not_found") {
+      return Response.json({ error: "not_found", message: "Snapshot not found." }, { status: 404 });
+    }
+    if (outcome === "forbidden") {
+      return Response.json(
+        { error: "forbidden", message: "Owner key does not match." },
+        { status: 403 },
+      );
+    }
+    return new Response(null, { status: 204 });
+  } catch (err) {
+    console.error("[publik] DELETE failed:", err instanceof Error ? err.message : "unknown error");
+    return Response.json(
+      { error: "internal_error", message: "Failed to delete snapshot." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/publik/route.ts
+++ b/app/api/publik/route.ts
@@ -1,0 +1,91 @@
+import {
+  CREATE_RATE_LIMIT,
+  MAX_BUNDLE_BYTES,
+  checkRateLimit,
+  deriveClientIp,
+  hashIp,
+  servicesConfigured,
+  servicesUnavailable,
+  storeSnapshot,
+  stripJournal,
+  validateInboundBundle,
+} from "@/lib/services/publik";
+
+/**
+ * POST /api/publik — create an anonymous snapshot (docs/spec/services.md §
+ * Publik → Protocol). Validates through @arkaik/schema, strips the journal by
+ * default, rate-limits per IP in Postgres, and returns `201 { id, url, owner_key }`
+ * with the owner key delivered exactly once.
+ *
+ * Node runtime: the `pg` driver needs Node APIs, not the edge runtime.
+ */
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(req: Request): Promise<Response> {
+  if (!servicesConfigured()) return servicesUnavailable();
+
+  // 1. Size cap (§ "Size cap 5 MB → 413"). Read raw so we measure real bytes,
+  //    not a possibly-absent content-length header.
+  const raw = await req.text();
+  if (Buffer.byteLength(raw, "utf8") > MAX_BUNDLE_BYTES) {
+    return Response.json(
+      {
+        error: "payload_too_large",
+        message: `Bundle exceeds the ${MAX_BUNDLE_BYTES} byte limit.`,
+      },
+      { status: 413 },
+    );
+  }
+
+  try {
+    // 2. Per-IP creation throttle (§ "Rate limiting → 429 with retry-after").
+    //    Checked before parsing so invalid/abusive floods are throttled too.
+    const ipHash = hashIp(deriveClientIp(req));
+    const rate = await checkRateLimit(ipHash, "create", CREATE_RATE_LIMIT);
+    if (rate.limited) {
+      return Response.json(
+        { error: "rate_limited", message: "Too many snapshots created. Try again later." },
+        { status: 429, headers: { "retry-after": String(rate.retryAfter) } },
+      );
+    }
+
+    // 3. Parse the JSON body. Malformed JSON is a syntactic error → 400.
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return Response.json(
+        { error: "invalid_json", message: "Request body is not valid JSON." },
+        { status: 400 },
+      );
+    }
+
+    // 4. Validate through @arkaik/schema (§ "Validate → 422 with findings").
+    const validation = validateInboundBundle(parsed);
+    if (!validation.ok) {
+      return Response.json(
+        { error: "validation_failed", findings: validation.findings },
+        { status: 422 },
+      );
+    }
+
+    // 5. Journal strip, enforced server-side (§ "Journal stripped by default").
+    const includeJournal = new URL(req.url).searchParams.get("include_journal") === "true";
+    const bundle = parsed as Record<string, unknown>;
+    const toStore = includeJournal ? bundle : stripJournal(bundle);
+
+    // 6. Store (immutable) and return id + one-time owner key.
+    const { id, ownerKey } = await storeSnapshot(toStore);
+    const url = `${new URL(req.url).origin}/p/${id}`;
+
+    return Response.json({ id, url, owner_key: ownerKey }, { status: 201 });
+  } catch (err) {
+    // Never log the request body or owner key (§ Security & Privacy).
+    console.error("[publik] POST failed:", err instanceof Error ? err.message : "unknown error");
+    return Response.json(
+      { error: "internal_error", message: "Failed to create snapshot." },
+      { status: 500 },
+    );
+  }
+}

--- a/db/migrations/002_publik_rate_limits.sql
+++ b/db/migrations/002_publik_rate_limits.sql
@@ -1,0 +1,28 @@
+-- 002_publik_rate_limits.sql
+--
+-- Per-IP rate limiting for the Publik endpoints (docs/spec/services.md § Publik
+-- → Protocol "Rate limiting", § Security & Privacy). Enforced entirely in
+-- Postgres so the service surface needs no extra infra dependency (no Redis,
+-- no edge KV) — the same "runs on any Postgres" promise as 001, so this file
+-- doubles as an Inkognito self-hosting setup script.
+--
+-- Design: one append-only row per throttled request. The route handler counts
+-- rows for (ip_hash, action) inside a sliding 1-hour window and rejects once the
+-- count reaches the per-action limit (create ~10/h). Raw IPs are NEVER stored —
+-- only a keyed hash (HMAC-SHA256, see lib/services/publik.ts hashIp), so the
+-- table holds no personally identifying network address. Expired rows are pruned
+-- opportunistically on each check (no cron dependency), keeping the table bounded.
+--
+-- Every statement uses IF NOT EXISTS so the file is safe to re-run by hand,
+-- independent of the `npm run db:migrate` bookkeeping (matching 001).
+
+create table if not exists publik_rate_limits (
+  id         bigint generated always as identity primary key,
+  ip_hash    text        not null,   -- HMAC-SHA256 of the client IP; never the raw IP
+  action     text        not null,   -- throttled action, e.g. 'create' | 'report'
+  created_at timestamptz not null default now()
+);
+
+-- Covers the hot path: count/prune rows for one (ip_hash, action) within a window.
+create index if not exists publik_rate_limits_lookup_idx
+  on publik_rate_limits (ip_hash, action, created_at);

--- a/lib/services/publik.ts
+++ b/lib/services/publik.ts
@@ -1,0 +1,309 @@
+import "server-only";
+
+import { createHash, createHmac, randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
+
+import { parseBundle, validateBundle, type ValidationFinding } from "@arkaik/schema";
+
+import { query } from "@/lib/services/db";
+
+/**
+ * Server-side Publik logic (docs/spec/services.md § Publik). Kept out of the
+ * route handlers so the security-critical bits — owner-key hashing, journal
+ * strip, IP-hashed rate limiting, schema validation — live in one audited place
+ * and can be unit/integration tested by importing this module or the handlers
+ * that call it.
+ *
+ * Invariants enforced here (§ Security & Privacy):
+ *  - Owner keys are never persisted or logged; only their SHA-256 hash is stored.
+ *  - Journals are stripped server-side by default; opt-in is explicit.
+ *  - Raw client IPs are never stored; only a keyed HMAC-SHA256 hash is.
+ *  - Every SQL statement is parameterized via the shared `query()` helper.
+ */
+
+/** Import cap mirrored from the app (docs/spec/services.md § Publik → "Size cap 5 MB"). */
+export const MAX_BUNDLE_BYTES = 5 * 1024 * 1024;
+
+/** Per-IP creation throttle: ~10 creations per hour (§ Publik → "Rate limiting"). */
+export const CREATE_RATE_LIMIT = 10;
+
+/** Per-IP report throttle. More lenient than creation but still real (§ Moderation). */
+export const REPORT_RATE_LIMIT = 30;
+
+/** `report_count` at/above which a snapshot is flagged for review (§ Moderation). */
+export const REPORT_THRESHOLD = 5;
+
+// ---------------------------------------------------------------------------
+// Crypto helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Server-generated snapshot id: 16 random bytes (128-bit) as URL-safe base64
+ * → 22 chars, no padding. Unguessable and non-sequential, comfortably above
+ * the spec's "≥ 10 chars of ≥ 64-bit randomness" floor (§ Publik → "id").
+ */
+export function generateSnapshotId(): string {
+  return randomBytes(16).toString("base64url");
+}
+
+/** Owner key: a UUID v4, returned to the caller exactly once (§ Publik → "owner_key"). */
+export function generateOwnerKey(): string {
+  return randomUUID();
+}
+
+/** SHA-256 hex of an owner key — the only form ever stored (§ Security & Privacy). */
+export function hashOwnerKey(ownerKey: string): string {
+  return createHash("sha256").update(ownerKey).digest("hex");
+}
+
+/**
+ * Salt/key for the IP HMAC. A plain SHA-256 of an IPv4 is trivially reversible
+ * (the address space is tiny), so the hash is keyed. In production AUTH_SECRET
+ * is set and used; self-hosters can set RATE_LIMIT_SALT; the constant fallback
+ * still avoids persisting any raw address, which is the stored-data guarantee
+ * the spec requires.
+ */
+function ipHashKey(): string {
+  return process.env.RATE_LIMIT_SALT ?? process.env.AUTH_SECRET ?? "arkaik-publik-rate-limit-v1";
+}
+
+/** Keyed HMAC-SHA256 of a client IP — never the raw IP (§ Security & Privacy). */
+export function hashIp(ip: string): string {
+  return createHmac("sha256", ipHashKey()).update(ip).digest("hex");
+}
+
+/**
+ * Constant-time comparison of a presented owner key against a stored hash.
+ * Both operands are 32-byte SHA-256 digests, so lengths always match and
+ * `timingSafeEqual` never throws; the compare leaks no timing signal about how
+ * many bytes matched (§ Publik → DELETE "constant-time hash compare").
+ */
+export function ownerKeyMatches(presentedKey: string, storedHashHex: string): boolean {
+  const presented = Buffer.from(hashOwnerKey(presentedKey), "hex");
+  let stored: Buffer;
+  try {
+    stored = Buffer.from(storedHashHex, "hex");
+  } catch {
+    return false;
+  }
+  if (presented.length !== stored.length) return false;
+  return timingSafeEqual(presented, stored);
+}
+
+// ---------------------------------------------------------------------------
+// Request helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Client IP from the first `x-forwarded-for` hop (Vercel sets it), falling back
+ * to `x-real-ip`, then a shared "unknown" bucket. The first hop is the closest
+ * the platform can attest to the real client; later hops are proxy addresses.
+ */
+export function deriveClientIp(req: Request): string {
+  const xff = req.headers.get("x-forwarded-for");
+  if (xff) {
+    const first = xff.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  const real = req.headers.get("x-real-ip");
+  if (real && real.trim()) return real.trim();
+  return "unknown";
+}
+
+/** True when the services surface has no database configured. */
+export function servicesConfigured(): boolean {
+  return Boolean(process.env.DATABASE_URL);
+}
+
+/**
+ * 503 for when `DATABASE_URL` is unset: the local-first app still builds and
+ * serves, and the client gets a clear, non-crashing signal that hosted services
+ * are absent on this deployment (docs/spec/services.md § Backend — env vars).
+ */
+export function servicesUnavailable(): Response {
+  return Response.json(
+    {
+      error: "services_unavailable",
+      message: "arkaik services (Publik) are not configured on this deployment.",
+    },
+    { status: 503 },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Journal strip
+// ---------------------------------------------------------------------------
+
+/**
+ * Remove the `journal` array from a bundle, returning a shallow copy with every
+ * other key preserved verbatim. The privacy default of docs/spec/journal.md is
+ * enforced here, server-side — it MUST NOT depend on client behavior (§ Publik).
+ */
+export function stripJournal(bundle: Record<string, unknown>): Record<string, unknown> {
+  const { journal: _journal, ...rest } = bundle;
+  void _journal;
+  return rest;
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+export interface BundleValidation {
+  ok: boolean;
+  /** Error-severity findings (shape + semantic), structured for a 422 body. */
+  findings: ValidationFinding[];
+}
+
+/** Map a zod issue to the same finding shape `validateBundle` emits. */
+function zodIssueToFinding(issue: { path: PropertyKey[]; code: string; message: string }): ValidationFinding {
+  return {
+    path: issue.path.map((p) => String(p)).join("."),
+    rule: issue.code,
+    message: issue.message,
+    severity: "error",
+  };
+}
+
+/**
+ * Full inbound gate: `parseBundle` (shape, zod) then `validateBundle` (semantic
+ * graph rules). Errors from either become structured findings for a 422; zod
+ * shape errors short-circuit the semantic pass since it assumes a rough shape.
+ * Warnings never fail (§ Publik → "warnings pass").
+ */
+export function validateInboundBundle(input: unknown): BundleValidation {
+  const parsed = parseBundle(input);
+  if (!parsed.success) {
+    return { ok: false, findings: parsed.error.issues.map(zodIssueToFinding) };
+  }
+  const semantic = validateBundle(input);
+  if (!semantic.valid) {
+    return { ok: false, findings: semantic.errors };
+  }
+  return { ok: true, findings: [] };
+}
+
+// ---------------------------------------------------------------------------
+// Rate limiting (Postgres-backed, per-IP)
+// ---------------------------------------------------------------------------
+
+export type RateLimitResult = { limited: false } | { limited: true; retryAfter: number };
+
+/**
+ * Sliding-window per-IP throttle in Postgres (§ Publik → "Rate limiting").
+ * Prunes this key's expired rows first (opportunistic cleanup, no cron), counts
+ * rows in the window, and either records a fresh hit (allowed) or reports how
+ * many seconds until the oldest in-window hit expires (rejected).
+ */
+export async function checkRateLimit(
+  ipHash: string,
+  action: string,
+  limit: number,
+): Promise<RateLimitResult> {
+  // The 1-hour window is a fixed SQL literal — never interpolated from input —
+  // so the whole file keeps its "every value goes through $-params" property.
+  await query(
+    `delete from publik_rate_limits
+      where ip_hash = $1 and action = $2 and created_at <= now() - interval '1 hour'`,
+    [ipHash, action],
+  );
+
+  const { rows } = await query<{ hits: number; retry_after: number | null }>(
+    `select count(*)::int as hits,
+            ceil(extract(epoch from (min(created_at) + interval '1 hour' - now())))::int as retry_after
+       from publik_rate_limits
+      where ip_hash = $1 and action = $2 and created_at > now() - interval '1 hour'`,
+    [ipHash, action],
+  );
+
+  const hits = Number(rows[0]?.hits ?? 0);
+  if (hits >= limit) {
+    const retryAfter = Math.max(1, Number(rows[0]?.retry_after ?? 3600));
+    return { limited: true, retryAfter };
+  }
+
+  await query(`insert into publik_rate_limits (ip_hash, action) values ($1, $2)`, [ipHash, action]);
+  return { limited: false };
+}
+
+// ---------------------------------------------------------------------------
+// Storage
+// ---------------------------------------------------------------------------
+
+export interface StoredSnapshot {
+  id: string;
+  ownerKey: string;
+}
+
+/**
+ * Persist a validated, already-stripped bundle. Generates the id + owner key,
+ * stores only `sha256(owner_key)`, and returns the plaintext owner key to the
+ * caller for its one-and-only-time delivery. Snapshots are immutable — there is
+ * no update path (§ Publik → Storage).
+ */
+export async function storeSnapshot(bundle: Record<string, unknown>): Promise<StoredSnapshot> {
+  const id = generateSnapshotId();
+  const ownerKey = generateOwnerKey();
+  const ownerKeyHash = hashOwnerKey(ownerKey);
+
+  const project = (bundle.project ?? {}) as Record<string, unknown>;
+  const title = typeof project.title === "string" ? project.title : "Untitled";
+  const schemaVersion =
+    typeof bundle.schema_version === "number" ? bundle.schema_version : 1;
+  const sizeBytes = Buffer.byteLength(JSON.stringify(bundle), "utf8");
+
+  await query(
+    `insert into publik_snapshots
+       (id, owner_key_hash, bundle, schema_version, title, size_bytes)
+     values ($1, $2, $3, $4, $5, $6)`,
+    [id, ownerKeyHash, JSON.stringify(bundle), schemaVersion, title, sizeBytes],
+  );
+
+  return { id, ownerKey };
+}
+
+/** Fetch the stored bundle JSON for an id, or null if none exists. */
+export async function fetchSnapshotBundle(id: string): Promise<unknown | null> {
+  const { rows } = await query<{ bundle: unknown }>(
+    `select bundle from publik_snapshots where id = $1`,
+    [id],
+  );
+  return rows.length ? rows[0].bundle : null;
+}
+
+export type DeleteOutcome = "deleted" | "not_found" | "forbidden";
+
+/**
+ * Delete a snapshot iff the presented owner key hashes to the stored hash.
+ * Constant-time compare; missing row → not_found, mismatch → forbidden.
+ */
+export async function deleteSnapshot(id: string, presentedKey: string): Promise<DeleteOutcome> {
+  const { rows } = await query<{ owner_key_hash: string }>(
+    `select owner_key_hash from publik_snapshots where id = $1`,
+    [id],
+  );
+  if (!rows.length) return "not_found";
+  if (!ownerKeyMatches(presentedKey, rows[0].owner_key_hash)) return "forbidden";
+
+  await query(`delete from publik_snapshots where id = $1`, [id]);
+  return "deleted";
+}
+
+export interface ReportOutcome {
+  found: boolean;
+  reportCount: number;
+  flagged: boolean;
+}
+
+/** Increment `report_count`; flag for review at/above the threshold (§ Moderation). */
+export async function reportSnapshot(id: string): Promise<ReportOutcome> {
+  const { rows } = await query<{ report_count: number }>(
+    `update publik_snapshots
+        set report_count = report_count + 1
+      where id = $1
+      returning report_count`,
+    [id],
+  );
+  if (!rows.length) return { found: false, reportCount: 0, flagged: false };
+  const reportCount = Number(rows[0].report_count);
+  return { found: true, reportCount, flagged: reportCount >= REPORT_THRESHOLD };
+}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "test:screenshot-size": "node tests/schema/screenshot-size.test.js",
     "test:migrate": "node tests/data/migrate.test.js && node tests/data/import-roundtrip.test.js && node tests/data/seed-import.test.js",
     "test:provider": "node tests/data/provider-registry.test.js && node tests/data/mutation-notifications.test.js",
-    "test:cli": "npm run build -w arkaik && node tests/cli/run-cli-tests.js && node tests/cli/init.test.js && node tests/cli/log-release.test.js && node tests/cli/sync.test.js && node tests/cli/pack-open.test.js"
+    "test:cli": "npm run build -w arkaik && node tests/cli/run-cli-tests.js && node tests/cli/init.test.js && node tests/cli/log-release.test.js && node tests/cli/sync.test.js && node tests/cli/pack-open.test.js",
+    "test:publik": "node tests/services/publik-api.test.js"
   },
   "dependencies": {
     "@radix-ui/react-collapsible": "^1.1.12",

--- a/tests/services/load-publik-api.js
+++ b/tests/services/load-publik-api.js
@@ -1,0 +1,118 @@
+/**
+ * Loads the Publik route handlers (app/api/publik/**\/route.ts) plus their
+ * server-side deps (lib/services/publik.ts, lib/services/db.ts) into a running
+ * Node process without a bundler — the same transpile-on-the-fly approach as
+ * tests/data/load-*.js and tests/schema/load-schema.js.
+ *
+ * The transpiled output goes into a build dir *inside the repo* (tests/services/
+ * .test-build-publik) so bare requires like `require("pg")` and
+ * `require("server-only")` resolve against the workspace node_modules. The two
+ * non-relative app specifiers are rewritten to the built files:
+ *   - `@arkaik/schema`      → the CJS schema index (built via load-schema.js)
+ *   - `@/lib/services/db`   → ./db.js
+ *   - `@/lib/services/publik` → ./publik.js
+ *
+ * Returns the handler functions so a test can invoke them directly with real
+ * `Request` objects against a real DATABASE_URL (the CI "services" job / a local
+ * Postgres) — exactly how docs/spec/services.md § CI Additions frames the
+ * integration tests ("route handlers invoked against the migrated schema").
+ */
+
+const fs = require("fs");
+const path = require("path");
+const ts = require("typescript");
+const { loadSchema, BUILD_DIR: SCHEMA_BUILD_DIR } = require("../schema/load-schema");
+
+const ROOT = path.join(__dirname, "..", "..");
+const BUILD_DIR = path.join(__dirname, ".test-build-publik");
+
+const COMPILER_OPTIONS = {
+  module: ts.ModuleKind.CommonJS,
+  target: ts.ScriptTarget.ES2020,
+  esModuleInterop: true,
+};
+
+function transpile(srcAbsPath, fileName, rewrites) {
+  const source = fs.readFileSync(srcAbsPath, "utf8");
+  let { outputText } = ts.transpileModule(source, { fileName, compilerOptions: COMPILER_OPTIONS });
+  for (const [specifier, replacement] of rewrites) {
+    // Rewrite `require("<specifier>")` → `require(<replacement>)`.
+    const pattern = new RegExp(
+      `require\\((['"])${specifier.replace(/[.*+?^${}()|[\]\\/]/g, "\\$&")}\\1\\)`,
+      "g",
+    );
+    outputText = outputText.replace(pattern, `require(${JSON.stringify(replacement)})`);
+  }
+  return outputText;
+}
+
+function loadPublikApi() {
+  // Build @arkaik/schema so `require(...schema index)` resolves at runtime.
+  loadSchema();
+  const schemaIndex = path.join(SCHEMA_BUILD_DIR, "index.js");
+
+  fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+  fs.mkdirSync(BUILD_DIR, { recursive: true });
+  fs.writeFileSync(path.join(BUILD_DIR, "package.json"), JSON.stringify({ type: "commonjs" }));
+
+  const write = (name, text) => fs.writeFileSync(path.join(BUILD_DIR, name), text);
+
+  // `server-only` throws outside a React Server Component (its default export is
+  // a guard). The route handlers only ever run server-side in production; for the
+  // test harness we stub it to a no-op so the modules load in plain Node.
+  const serverOnlyStub = "./server-only-stub.js";
+  write("server-only-stub.js", "module.exports = {};\n");
+
+  // lib/services/db.ts — stub `server-only`; bare `pg` require resolves as-is.
+  write(
+    "db.js",
+    transpile(path.join(ROOT, "lib", "services", "db.ts"), "db.ts", [["server-only", serverOnlyStub]]),
+  );
+
+  // lib/services/publik.ts — rewrite the schema + db + server-only specifiers.
+  write(
+    "publik.js",
+    transpile(path.join(ROOT, "lib", "services", "publik.ts"), "publik.ts", [
+      ["@arkaik/schema", schemaIndex],
+      ["@/lib/services/db", "./db.js"],
+      ["server-only", serverOnlyStub],
+    ]),
+  );
+
+  // Route handlers — rewrite the publik specifier.
+  write(
+    "post.js",
+    transpile(path.join(ROOT, "app", "api", "publik", "route.ts"), "route.ts", [
+      ["@/lib/services/publik", "./publik.js"],
+    ]),
+  );
+  write(
+    "id.js",
+    transpile(path.join(ROOT, "app", "api", "publik", "[id]", "route.ts"), "route.ts", [
+      ["@/lib/services/publik", "./publik.js"],
+    ]),
+  );
+  write(
+    "report.js",
+    transpile(path.join(ROOT, "app", "api", "publik", "[id]", "report", "route.ts"), "route.ts", [
+      ["@/lib/services/publik", "./publik.js"],
+    ]),
+  );
+
+  for (const name of ["db.js", "publik.js", "post.js", "id.js", "report.js"]) {
+    delete require.cache[path.join(BUILD_DIR, name)];
+  }
+
+  const post = require(path.join(BUILD_DIR, "post.js"));
+  const idRoute = require(path.join(BUILD_DIR, "id.js"));
+  const report = require(path.join(BUILD_DIR, "report.js"));
+
+  return {
+    POST: post.POST,
+    GET: idRoute.GET,
+    DELETE: idRoute.DELETE,
+    REPORT: report.POST,
+  };
+}
+
+module.exports = { loadPublikApi, BUILD_DIR, SCHEMA_BUILD_DIR };

--- a/tests/services/publik-api.test.js
+++ b/tests/services/publik-api.test.js
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+
+/**
+ * Integration tests for the Publik API (docs/spec/services.md § Publik, § CI
+ * Additions). The route handlers are invoked directly with real `Request`
+ * objects against a real Postgres (the CI "services" job's Postgres 16 container,
+ * or a local instance) whose schema was applied by `npm run db:migrate`.
+ *
+ * Coverage (the acceptance list from issue #238):
+ *   - create → fetch → delete round-trip
+ *   - journal stripped by default
+ *   - journal kept with ?include_journal=true
+ *   - oversized body rejected (413)
+ *   - wrong owner key rejected (403)
+ *   - per-IP rate limit (429 + retry-after)
+ * Plus: 422 on invalid bundle, 404 on missing id, report → 202 + flag.
+ *
+ * Each test uses a distinct client IP (via x-forwarded-for) so the per-IP
+ * creation throttle never bleeds across cases; the rate-limit test pins one IP.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const { randomBytes } = require("node:crypto");
+const { loadPublikApi, BUILD_DIR, SCHEMA_BUILD_DIR } = require("./load-publik-api");
+
+const ROOT = path.join(__dirname, "..", "..");
+const ORIGIN = "https://publik.test";
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+let failures = 0;
+function check(name, cond, detail) {
+  if (cond) {
+    console.log(`PASS: ${name}`);
+  } else {
+    failures++;
+    console.log(`FAIL: ${name}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+function readFixture(rel) {
+  return JSON.parse(fs.readFileSync(path.join(ROOT, rel), "utf8"));
+}
+
+/** A fresh, non-routable client IP so each test gets its own rate-limit bucket. */
+function freshIp() {
+  const b = randomBytes(3);
+  return `10.${b[0]}.${b[1]}.${b[2]}`;
+}
+
+function postRequest(bundle, { ip, includeJournal } = {}) {
+  const qs = includeJournal ? "?include_journal=true" : "";
+  return new Request(`${ORIGIN}/api/publik${qs}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-forwarded-for": ip || freshIp(),
+    },
+    body: typeof bundle === "string" ? bundle : JSON.stringify(bundle),
+  });
+}
+
+function idRequest(id, { method = "GET", bearer } = {}) {
+  const headers = {};
+  if (bearer) headers["authorization"] = `Bearer ${bearer}`;
+  return new Request(`${ORIGIN}/api/publik/${id}`, { method, headers });
+}
+
+function ctx(id) {
+  return { params: Promise.resolve({ id }) };
+}
+
+async function main() {
+  if (!process.env.DATABASE_URL) {
+    console.error(
+      "\n[publik-api.test] DATABASE_URL is not set. These integration tests require a " +
+        "migrated Postgres (the CI services job sets it; locally, start Postgres and " +
+        "`npm run db:migrate` first). Refusing to pass silently.",
+    );
+    process.exit(1);
+  }
+
+  const { POST, GET, DELETE, REPORT } = loadPublikApi();
+  const validBundle = readFixture("tests/fixtures/valid-bundle.json");
+  const level2Bundle = readFixture("tests/fixtures/valid-level2.json");
+
+  // --- 1. create → fetch → delete round-trip -------------------------------
+  {
+    const res = await POST(postRequest(validBundle, { ip: freshIp() }));
+    const body = await res.json();
+    check("create returns 201", res.status === 201, `status ${res.status}`);
+    check("create response has url-safe id", typeof body.id === "string" && body.id.length >= 10, body.id);
+    check("create id is URL-safe (base64url charset)", /^[A-Za-z0-9_-]+$/.test(body.id || ""), body.id);
+    check("create response url is origin + /p/{id}", body.url === `${ORIGIN}/p/${body.id}`, body.url);
+    check("owner_key is a UUID v4", UUID_V4.test(body.owner_key || ""), body.owner_key);
+
+    const getRes = await GET(idRequest(body.id), ctx(body.id));
+    const fetched = await getRes.json();
+    check("fetch returns 200", getRes.status === 200, `status ${getRes.status}`);
+    check("fetch returns the stored bundle verbatim", fetched.project && fetched.project.id === "test-project", JSON.stringify(fetched.project));
+
+    const delRes = await DELETE(idRequest(body.id, { method: "DELETE", bearer: body.owner_key }), ctx(body.id));
+    check("delete with owner key returns 204", delRes.status === 204, `status ${delRes.status}`);
+
+    const getGone = await GET(idRequest(body.id), ctx(body.id));
+    check("fetch after delete returns 404", getGone.status === 404, `status ${getGone.status}`);
+  }
+
+  // --- 2. journal stripped by default --------------------------------------
+  {
+    check("fixture level2 actually carries a journal", Array.isArray(level2Bundle.journal) && level2Bundle.journal.length > 0);
+    const res = await POST(postRequest(level2Bundle, { ip: freshIp() }));
+    const body = await res.json();
+    check("create (with journal, default) returns 201", res.status === 201, `status ${res.status}`);
+    const fetched = await (await GET(idRequest(body.id), ctx(body.id))).json();
+    check("journal stripped by default", fetched.journal === undefined, JSON.stringify(fetched.journal));
+    check("non-journal data survives the strip", Array.isArray(fetched.nodes) && fetched.nodes.length === level2Bundle.nodes.length);
+  }
+
+  // --- 3. journal kept with ?include_journal=true --------------------------
+  {
+    const res = await POST(postRequest(level2Bundle, { ip: freshIp(), includeJournal: true }));
+    const body = await res.json();
+    check("create (include_journal) returns 201", res.status === 201, `status ${res.status}`);
+    const fetched = await (await GET(idRequest(body.id), ctx(body.id))).json();
+    check(
+      "journal preserved with include_journal=true",
+      Array.isArray(fetched.journal) && fetched.journal.length === level2Bundle.journal.length,
+      `len ${fetched.journal && fetched.journal.length}`,
+    );
+  }
+
+  // --- 4. oversized body rejected (413) ------------------------------------
+  {
+    const oversized = JSON.stringify({ blob: "x".repeat(5 * 1024 * 1024) });
+    const res = await POST(postRequest(oversized, { ip: freshIp() }));
+    check("oversized body returns 413", res.status === 413, `status ${res.status}`);
+  }
+
+  // --- 5. invalid bundle rejected (422 + findings) -------------------------
+  {
+    const res = await POST(postRequest({ project: { title: "" }, nodes: [], edges: [] }, { ip: freshIp() }));
+    const body = await res.json();
+    check("invalid bundle returns 422", res.status === 422, `status ${res.status}`);
+    check("422 body carries structured findings", Array.isArray(body.findings) && body.findings.length > 0, JSON.stringify(body.findings));
+  }
+
+  // --- 6. wrong owner key rejected (403) -----------------------------------
+  {
+    const res = await POST(postRequest(validBundle, { ip: freshIp() }));
+    const body = await res.json();
+    const wrong = await DELETE(idRequest(body.id, { method: "DELETE", bearer: "00000000-0000-4000-8000-000000000000" }), ctx(body.id));
+    check("delete with wrong owner key returns 403", wrong.status === 403, `status ${wrong.status}`);
+    // snapshot must still exist after a failed delete
+    const still = await GET(idRequest(body.id), ctx(body.id));
+    check("snapshot survives a failed delete", still.status === 200, `status ${still.status}`);
+    // missing Authorization → 401
+    const noAuth = await DELETE(idRequest(body.id, { method: "DELETE" }), ctx(body.id));
+    check("delete without Authorization returns 401", noAuth.status === 401, `status ${noAuth.status}`);
+    // cleanup with the real key
+    await DELETE(idRequest(body.id, { method: "DELETE", bearer: body.owner_key }), ctx(body.id));
+  }
+
+  // --- 7. missing id → 404 -------------------------------------------------
+  {
+    const res = await GET(idRequest("does-not-exist-xxxx"), ctx("does-not-exist-xxxx"));
+    check("fetch of unknown id returns 404", res.status === 404, `status ${res.status}`);
+  }
+
+  // --- 8. report → 202 + flag ----------------------------------------------
+  {
+    const created = await (await POST(postRequest(validBundle, { ip: freshIp() }))).json();
+    const reportRes = await REPORT(idRequest(created.id, { method: "POST" }), ctx(created.id));
+    const reportBody = await reportRes.json();
+    check("report returns 202", reportRes.status === 202, `status ${reportRes.status}`);
+    check("report increments report_count", reportBody.report_count === 1, JSON.stringify(reportBody));
+    check("report not flagged below threshold", reportBody.flagged === false, JSON.stringify(reportBody));
+    const missing = await REPORT(idRequest("nope-nope-nope"), ctx("nope-nope-nope"));
+    check("report on unknown id returns 404", missing.status === 404, `status ${missing.status}`);
+  }
+
+  // --- 9. per-IP rate limit (429 + retry-after) ----------------------------
+  {
+    const ip = freshIp();
+    let allowed = 0;
+    let limitedRes = null;
+    for (let i = 0; i < 11; i++) {
+      const res = await POST(postRequest(validBundle, { ip }));
+      if (res.status === 201) allowed++;
+      else if (res.status === 429) {
+        limitedRes = res;
+        break;
+      } else {
+        check(`rate-limit loop unexpected status at i=${i}`, false, `status ${res.status}`);
+      }
+    }
+    check("first 10 creations from one IP are allowed", allowed === 10, `allowed ${allowed}`);
+    check("11th creation is rate-limited (429)", limitedRes !== null && limitedRes.status === 429);
+    if (limitedRes) {
+      const retryAfter = limitedRes.headers.get("retry-after");
+      check("429 carries a numeric retry-after header", retryAfter !== null && Number(retryAfter) > 0, `retry-after ${retryAfter}`);
+    }
+  }
+
+  // Cleanup transpiled build dirs (mirrors the other loaders' teardown).
+  fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+  fs.rmSync(SCHEMA_BUILD_DIR, { recursive: true, force: true });
+
+  if (failures > 0) {
+    console.log(`\n${failures} publik-api test(s) failed.`);
+    process.exit(1);
+  }
+  console.log("\nAll publik-api integration tests passed.");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

First public server surface (`docs/spec/services.md` § Publik): anonymous snapshot sharing with owner-key deletion. Security posture is the priority — owner keys hashed, journal stripped server-side, everything validated through `@arkaik/schema` before storage. All security-critical logic lives in one audited module, `lib/services/publik.ts`; the route handlers are thin.

### Endpoints
- **`POST /api/publik`** — `parseBundle` + `validateBundle` (errors → `422` with structured findings; warnings pass), 5 MB cap → `413`, journal stripped server-side unless `?include_journal=true`, per-IP creation throttle (~10/h) in Postgres → `429` with `retry-after`. Returns `201 { id, url, owner_key }`: `id` is 128-bit URL-safe randomness (`base64url`, 22 chars), `owner_key` a UUID v4 returned exactly once, and only `sha256(owner_key)` is stored. `url` is built from the request origin + `/p/{id}`.
- **`GET /api/publik/{id}`** — returns the stored bundle verbatim (`application/json`), else `404`.
- **`DELETE /api/publik/{id}`** — `Authorization: Bearer <owner_key>`, constant-time (`timingSafeEqual`) hash compare → `204` / `403` (missing header → `401`, unknown id → `404`).
- **`POST /api/publik/{id}/report`** — increments `report_count`, `202`, `flagged` threshold state returned so it is queryable.

### Security & invariants
- Owner keys never logged (error paths log only `err.message`, never the body or key); snapshots immutable (no update path).
- Raw client IPs never stored — a keyed HMAC-SHA256 (`AUTH_SECRET` / `RATE_LIMIT_SALT` when set) is; IP derived from the first `x-forwarded-for` hop.
- Every statement parameterized via the shared `query()` helper from #237; the 1-hour rate window is a fixed SQL literal, never interpolated from input.
- Graceful absence: when `DATABASE_URL` is unset, every handler returns `503 { error: "services_unavailable" }` — the local-first app still builds and serves.
- New runtime is Node (`export const runtime = "nodejs"`) — `pg` needs Node, not edge.

### Storage / migration
New migration **`002_publik_rate_limits.sql`** (plain Postgres, `IF NOT EXISTS`, doubles as an Inkognito setup script) adds the per-IP rate-limit table with an `(ip_hash, action, created_at)` index; expired rows are pruned opportunistically on each check (no cron). Snapshots use the existing `publik_snapshots` table from #237.

### Tests / CI
Integration tests (`tests/services/publik-api.test.js`) invoke the route handlers directly with real `Request` objects against a migrated Postgres, using the repo's transpile-on-the-fly loader style (`tests/services/load-publik-api.js`). Wired as `npm run test:publik` and added to the CI **services** job after the migrate steps.

## Verification
- `npm run lint` — 0 errors (3 pre-existing warnings, unrelated).
- `npm run build` with **no** env vars — passes; all three routes register as dynamic (`ƒ`).
- `npm run generate` + drift gate — no drift (exit 0).
- Full existing `npm run test:*` battery — all green (incl. `test:cli` 43/43).
- Local Postgres 16: `npm run db:migrate` (applies + idempotent re-run) then `npm run test:publik` — **29/29 assertions pass**, covering create→fetch→delete round-trip, journal-strip default, strip opt-out, oversized `413`, invalid `422` + findings, wrong-key `403`, no-auth `401`, missing-id `404`, report `202` + flag, and rate-limit (10 allowed, 11th `429` + `retry-after`).
- `503` graceful-absence path verified manually with `DATABASE_URL` unset.

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QpXVmp8QNHQF3s2cCvtead)_