### PR TITLE
M4: Auth.js — GitHub OAuth, users/tier schema, sign-in UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,8 +13,19 @@
 # (Inkognito). Example: postgres://user:password@host:5432/arkaik
 DATABASE_URL=
 
-# --- Auth (Synk accounts) — reserved, not wired in M4 -------------------------
+# --- Auth (Synk accounts) -----------------------------------------------------
 # Auth.js (NextAuth v5) with GitHub OAuth (docs/spec/services.md § Synk → Auth).
-# AUTH_SECRET=
-# AUTH_GITHUB_ID=
-# AUTH_GITHUB_SECRET=
+# The sign-in UI stays hidden and every auth route degrades to absent until ALL
+# three are set. Auth.js infers AUTH_GITHUB_ID / AUTH_GITHUB_SECRET as the GitHub
+# provider's clientId/secret, and signs the session JWT with AUTH_SECRET.
+#
+# AUTH_SECRET: a random 32+ byte secret. Generate with `npx auth secret` or
+#   `openssl rand -base64 33`.
+# AUTH_GITHUB_ID / AUTH_GITHUB_SECRET: from a GitHub OAuth App
+#   (https://github.com/settings/developers). Set its Authorization callback URL
+#   to `<origin>/api/auth/callback/github` — e.g.
+#   https://arkaik.app/api/auth/callback/github in production, or
+#   http://localhost:3000/api/auth/callback/github for local dev.
+AUTH_SECRET=
+AUTH_GITHUB_ID=
+AUTH_GITHUB_SECRET=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,3 +116,6 @@ jobs:
 
       - name: Re-run migrations (idempotency gate — must be a no-op, exit 0)
         run: npm run db:migrate
+
+      - name: Synk auth-guard integration test (unauthenticated → 401)
+        run: npm run test:auth

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,12 @@
+import { handlers } from "@/auth";
+
+/**
+ * Auth.js catch-all route (docs/spec/services.md § Synk → Auth). Handles
+ * `/api/auth/signin`, `/api/auth/callback/github`, `/api/auth/session`, etc.
+ *
+ * Re-exporting `handlers` is inert at import: NextAuth's config is lazy
+ * (auth.ts), so this file adds no env reads and does not break the env-unset
+ * build. The GitHub OAuth callback URL a deployment must register is
+ * `<origin>/api/auth/callback/github`.
+ */
+export const { GET, POST } = handlers;

--- a/app/api/auth/status/route.ts
+++ b/app/api/auth/status/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+
+import { getSession, isAuthConfigured } from "@/lib/services/auth";
+
+/**
+ * Client-facing auth status (docs/spec/services.md § Synk → Auth: "session
+ * available to client components"). The app shell's sign-in button
+ * (components/auth/AuthButton) polls this once on mount to decide whether to
+ * render at all, and whom it is rendering for.
+ *
+ * It ships ONLY a boolean plus the signed-in user's public profile — never a
+ * secret. When auth is unconfigured this returns `{ configured: false }` and the
+ * button renders nothing, keeping every services surface hidden.
+ *
+ * `force-dynamic`: configured-ness and the session are runtime facts (env +
+ * cookie), so this response must never be statically cached at build time.
+ */
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  if (!isAuthConfigured()) {
+    return NextResponse.json({ configured: false, user: null });
+  }
+
+  const session = await getSession();
+  const user = session?.user
+    ? {
+        name: session.user.name ?? null,
+        email: session.user.email ?? null,
+        image: session.user.image ?? null,
+      }
+    : null;
+
+  return NextResponse.json({ configured: true, user });
+}

--- a/app/api/synk/ping/route.ts
+++ b/app/api/synk/ping/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+
+import { getSession } from "@/lib/services/auth";
+
+/**
+ * Minimal session-guarded route (docs/spec/services.md § Synk). This is NOT the
+ * Synk backup API — it is the smallest possible expression of the auth check the
+ * real Synk handlers (another issue) will copy: read the session, 401 if absent,
+ * otherwise act as the owner. It also backs the M4 acceptance test
+ * (tests/services/auth-guard.test.js): unauthenticated GET → 401.
+ *
+ * `getSession()` returns null both when no one is signed in AND when auth is
+ * unconfigured, so this correctly 401s in the env-unset build too.
+ *
+ * `force-dynamic`: the response depends on the request's session cookie and must
+ * never be statically cached.
+ */
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const session = await getSession();
+
+  if (!session?.user) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  return NextResponse.json({ ok: true, user: session.user });
+}

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/card";
 import { ArkaikLogo } from "@/components/branding/ArkaikLogo";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { AuthButton } from "@/components/auth/AuthButton";
 import { getProvider } from "@/lib/data/provider-registry";
 import type { Project, ProjectBundle } from "@/lib/data/types";
 import { archiveProject, importProjectFromFile } from "@/lib/utils/export";
@@ -155,7 +156,10 @@ export default function ProjectsPage() {
         <Link href="/" aria-label="Go to home" className="inline-flex items-center">
           <ArkaikLogo className="w-20 shrink-0" />
         </Link>
-        <ThemeToggle />
+        <div className="flex items-center gap-2">
+          <AuthButton />
+          <ThemeToggle />
+        </div>
       </header>
 
       <main className="mx-auto flex w-full max-w-4xl flex-1 flex-col gap-6 p-6">

--- a/auth.ts
+++ b/auth.ts
@@ -1,0 +1,43 @@
+import NextAuth from "next-auth";
+import GitHub from "next-auth/providers/github";
+import PostgresAdapter from "@auth/pg-adapter";
+
+import { getPool } from "@/lib/services/db";
+
+/**
+ * Auth.js (NextAuth v5) configuration for Synk accounts
+ * (docs/spec/services.md § Synk → Auth).
+ *
+ * GRACEFUL ABSENCE (§ Backend — env rules): this module MUST be importable, and
+ * `next build` MUST succeed, with every AUTH_* / DATABASE_URL variable unset —
+ * the local-first app has no server. That is why the config is passed as a
+ * *lazy* function: NextAuth only invokes it when a request actually reaches an
+ * auth route or when `auth()` is called, never at import. Nothing here reads an
+ * env var or opens a Postgres connection at module scope.
+ *
+ * The GitHub provider needs no arguments: Auth.js infers `AUTH_GITHUB_ID` /
+ * `AUTH_GITHUB_SECRET` as its clientId/secret, and `AUTH_SECRET` signs the JWT.
+ * Callers gate on `isAuthConfigured()` (lib/services/auth.ts) before ever
+ * invoking `auth()`, so `getPool()` — which throws when DATABASE_URL is unset —
+ * is only reached in a correctly configured deployment.
+ *
+ * Session strategy is JWT: stateless, serverless-friendly, and it means reading
+ * a session on the request path (the Synk API's auth check) never touches the
+ * database. The Postgres adapter still persists users/accounts on sign-in.
+ */
+export const { handlers, auth, signIn, signOut } = NextAuth(() => ({
+  adapter: PostgresAdapter(getPool()),
+  providers: [GitHub],
+  session: { strategy: "jwt" },
+  callbacks: {
+    // Surface the user id to the session so route handlers and client
+    // components can scope Synk data by owner. On the JWT strategy the id lives
+    // in `token.sub` (set by Auth.js on sign-in); copy it onto `session.user`.
+    session({ session, token }) {
+      if (token.sub && session.user) {
+        session.user.id = token.sub;
+      }
+      return session;
+    },
+  },
+}));

--- a/components/auth/AuthButton.tsx
+++ b/components/auth/AuthButton.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { GithubIcon, LogOutIcon, UserRoundIcon } from "lucide-react";
+import { signIn, signOut } from "next-auth/react";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+/**
+ * Sign-in / account entry point for the app shell (docs/spec/services.md
+ * § Synk → Auth). Native to the existing chrome — an icon-sized control that
+ * sits beside the theme toggle / in the sidebar footer.
+ *
+ * GRACEFUL ABSENCE: the component asks GET /api/auth/status once on mount and
+ * renders *nothing* until it knows auth is configured. When it is not (the
+ * default local-first deployment), this stays null forever — no sign-in affords,
+ * no services surface leaks, and local-first usage is untouched. The endpoint
+ * returns only a boolean and the public profile; no secret reaches the client.
+ *
+ * Signed-out state gates no local feature: this button is the *only* thing that
+ * changes between signed-in and signed-out.
+ */
+
+interface AuthUser {
+  name: string | null;
+  email: string | null;
+  image: string | null;
+}
+
+type AuthStatus =
+  | { state: "loading" }
+  | { state: "unconfigured" }
+  | { state: "signed-out" }
+  | { state: "signed-in"; user: AuthUser };
+
+function initials(user: AuthUser): string {
+  const source = user.name ?? user.email ?? "";
+  const trimmed = source.trim();
+  return trimmed ? trimmed[0]!.toUpperCase() : "";
+}
+
+export function AuthButton() {
+  const [status, setStatus] = useState<AuthStatus>({ state: "loading" });
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadStatus() {
+      try {
+        const res = await fetch("/api/auth/status", { cache: "no-store" });
+        if (!res.ok) throw new Error(`status ${res.status}`);
+        const data: { configured: boolean; user: AuthUser | null } = await res.json();
+        if (!active) return;
+        if (!data.configured) {
+          setStatus({ state: "unconfigured" });
+        } else if (data.user) {
+          setStatus({ state: "signed-in", user: data.user });
+        } else {
+          setStatus({ state: "signed-out" });
+        }
+      } catch {
+        // Treat any failure as "auth unavailable" — degrade to hidden, never
+        // block the local-first shell.
+        if (active) setStatus({ state: "unconfigured" });
+      }
+    }
+
+    void loadStatus();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  // Hidden while loading and whenever auth is not configured.
+  if (status.state === "loading" || status.state === "unconfigured") {
+    return null;
+  }
+
+  if (status.state === "signed-out") {
+    return (
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={() => void signIn("github")}
+        aria-label="Sign in with GitHub"
+      >
+        <GithubIcon />
+        <span>Sign in</span>
+      </Button>
+    );
+  }
+
+  const { user } = status;
+  const label = user.name ?? user.email ?? "Account";
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size="icon"
+          className="rounded-full"
+          aria-label={`Account menu for ${label}`}
+        >
+          {initials(user) ? (
+            <span className="text-xs font-semibold">{initials(user)}</span>
+          ) : (
+            <UserRoundIcon />
+          )}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-56">
+        <DropdownMenuLabel className="flex flex-col gap-0.5">
+          {user.name ? <span className="truncate text-sm">{user.name}</span> : null}
+          {user.email ? (
+            <span className="truncate text-xs font-normal text-muted-foreground">{user.email}</span>
+          ) : null}
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          className="cursor-pointer"
+          onClick={() => void signOut()}
+        >
+          <LogOutIcon />
+          <span>Sign out</span>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/db/migrations/003_auth_tables.sql
+++ b/db/migrations/003_auth_tables.sql
@@ -1,0 +1,68 @@
+-- 003_auth_tables.sql
+--
+-- Auth.js (NextAuth v5) Postgres adapter schema (docs/spec/services.md § Synk →
+-- Auth). These are the four tables @auth/pg-adapter reads and writes, transcribed
+-- by hand from the adapter's documented schema (https://authjs.dev/reference/
+-- adapter/pg) so the migration doubles as an Inkognito self-hosting setup script:
+-- plain Postgres that runs unmodified against Neon, RDS, Supabase's Postgres, or a
+-- local instance — no ORM, no framework.
+--
+-- The adapter issues queries with case-sensitive, camelCase identifiers
+-- ("userId", "emailVerified", "providerAccountId", "sessionToken"); those columns
+-- MUST stay quoted here so their case survives. SQL keywords are lowercased to
+-- match 001_publik_snapshots.sql.
+--
+-- Session strategy is JWT (see auth.ts), so `sessions` is not read on the request
+-- path; the adapter still owns it (and may persist rows for DB-backed flows), so
+-- it is created for schema completeness and forward compatibility.
+--
+-- Every statement uses IF NOT EXISTS so the file is safe to re-run by hand,
+-- independent of the `npm run db:migrate` bookkeeping.
+
+-- Verification tokens (email magic-links). Deferred as a launch provider, but the
+-- adapter contract includes it; created now so the schema is complete.
+create table if not exists verification_token (
+  identifier text        not null,
+  expires    timestamptz not null,
+  token      text        not null,
+  primary key (identifier, token)
+);
+
+-- Linked OAuth accounts (GitHub at launch). One row per provider identity linked
+-- to a user; token columns hold the provider's OAuth response.
+create table if not exists accounts (
+  id                  serial,
+  "userId"            integer      not null,
+  type                varchar(255) not null,
+  provider            varchar(255) not null,
+  "providerAccountId" varchar(255) not null,
+  refresh_token       text,
+  access_token        text,
+  expires_at          bigint,
+  id_token            text,
+  scope               text,
+  session_state       text,
+  token_type          text,
+  primary key (id)
+);
+
+-- Database sessions. Unused under the JWT session strategy but part of the
+-- adapter's owned surface (see header).
+create table if not exists sessions (
+  id             serial,
+  "userId"       integer      not null,
+  expires        timestamptz  not null,
+  "sessionToken" varchar(255) not null,
+  primary key (id)
+);
+
+-- Users. arkaik adds `tier` in the next migration (004_users_tier.sql); the base
+-- columns below are exactly what the adapter expects.
+create table if not exists users (
+  id              serial,
+  name            varchar(255),
+  email           varchar(255),
+  "emailVerified" timestamptz,
+  image           text,
+  primary key (id)
+);

--- a/db/migrations/004_users_tier.sql
+++ b/db/migrations/004_users_tier.sql
@@ -1,0 +1,11 @@
+-- 004_users_tier.sql
+--
+-- arkaik's one addition to the Auth.js adapter schema (docs/spec/services.md
+-- § Synk → Auth, § Tier Enforcement Points): the tier column that selects a row
+-- in lib/services/limits.ts's TIER_LIMITS table.
+--
+-- M4 has no path that sets this to anything but the default 'synk'. M5's billing
+-- work flips the column; it does not touch enforcement. Plain Postgres, and
+-- idempotent (`add column if not exists`) so the file is safe to re-run by hand.
+
+alter table users add column if not exists tier text not null default 'synk';

--- a/lib/services/auth.ts
+++ b/lib/services/auth.ts
@@ -1,0 +1,50 @@
+import "server-only";
+
+import type { Session } from "next-auth";
+
+import { auth } from "@/auth";
+
+/**
+ * Server-side auth helpers for the arkaik services surface
+ * (docs/spec/services.md § Synk → Auth).
+ *
+ * This is the seam the Synk API depends on: a single place that answers "is auth
+ * turned on?" and "who is the caller?" without any route handler having to know
+ * about NextAuth internals — and, critically, without breaking when auth is
+ * unconfigured.
+ */
+
+/**
+ * True only when every variable Auth.js needs to run is present. Reads env at
+ * call time (never at import), so the local-first app boots with all of them
+ * unset. These are all server-only vars — no NEXT_PUBLIC_ — so this MUST NOT be
+ * imported into client code; the client learns configured-ness as a bare boolean
+ * from GET /api/auth/status.
+ */
+export function isAuthConfigured(): boolean {
+  return Boolean(
+    process.env.AUTH_SECRET &&
+      process.env.AUTH_GITHUB_ID &&
+      process.env.AUTH_GITHUB_SECRET,
+  );
+}
+
+/**
+ * The current session, or null when there is none — and null, never a throw,
+ * when auth is unconfigured. Guarding on `isAuthConfigured()` first means we
+ * never invoke `auth()` (and therefore never construct the Postgres adapter /
+ * read DATABASE_URL) in the env-unset build. `auth()` itself is wrapped so that
+ * being called outside a request scope, or any decode error, degrades to "no
+ * session" rather than a 500 — the JWT strategy makes this a pure cookie decode,
+ * so there is no database dependency to mask.
+ */
+export async function getSession(): Promise<Session | null> {
+  if (!isAuthConfigured()) {
+    return null;
+  }
+  try {
+    return await auth();
+  } catch {
+    return null;
+  }
+}

--- a/lib/services/db.ts
+++ b/lib/services/db.ts
@@ -20,7 +20,14 @@ import { Pool, type QueryResult, type QueryResultRow } from "pg";
 
 let pool: Pool | undefined;
 
-function getPool(): Pool {
+/**
+ * The lazily-created singleton connection pool. Exported so the Auth.js Postgres
+ * adapter (auth.ts) can share the same pool instead of opening a second one.
+ * DATABASE_URL is still read here at call time, never at import — the adapter is
+ * only constructed inside NextAuth's lazy config, which runs on request, so the
+ * local-first app boots untouched with services env vars unset.
+ */
+export function getPool(): Pool {
   if (!pool) {
     const connectionString = process.env.DATABASE_URL;
     if (!connectionString) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "packages/*"
       ],
       "dependencies": {
+        "@auth/pg-adapter": "^1.11.2",
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -31,6 +32,7 @@
         "highlight.js": "^11.11.1",
         "lucide-react": "^0.577.0",
         "next": "16.2.0",
+        "next-auth": "^5.0.0-beta.31",
         "next-themes": "^0.4.6",
         "pg": "^8.13.1",
         "react": "19.2.4",
@@ -72,6 +74,47 @@
     "node_modules/@arkaik/schema": {
       "resolved": "packages/schema",
       "link": true
+    },
+    "node_modules/@auth/core": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.2.tgz",
+      "integrity": "sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w==",
+      "license": "ISC",
+      "dependencies": {
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^6.0.6",
+        "oauth4webapi": "^3.3.0",
+        "preact": "10.24.3",
+        "preact-render-to-string": "6.5.11"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^7.0.7"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@auth/pg-adapter": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@auth/pg-adapter/-/pg-adapter-1.11.2.tgz",
+      "integrity": "sha512-GPT3EkNtQiZ5fVycoTjQ9KeplnAhOCA2RVf0AXJffT1wrYpoN3zyg02W4F7oAOnB5NYsF09SPuRXZyjtiE6VSQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@auth/core": "0.41.2"
+      },
+      "peerDependencies": {
+        "pg": "^8"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -1741,6 +1784,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -6669,6 +6721,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8168,6 +8229,33 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "5.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.31.tgz",
+      "integrity": "sha512-1OBgCKPzo+S7UWWMp3xgvGvIJ0OpV7B3vR4ZDRqD9a4Ch+OT6dakLXG9ivhtmIWVa71nTSXattOHyCg8sNi8/Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@auth/core": "0.41.2"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "next": "^14.0.0-0 || ^15.0.0 || ^16.0.0",
+        "nodemailer": "^7.0.7",
+        "react": "^18.2.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/next-themes": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
@@ -8231,6 +8319,15 @@
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.6.tgz",
+      "integrity": "sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -8672,6 +8769,25 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.24.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
+      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "6.5.11",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
+      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "preact": ">=10"
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -25,9 +25,11 @@
     "test:screenshot-size": "node tests/schema/screenshot-size.test.js",
     "test:migrate": "node tests/data/migrate.test.js && node tests/data/import-roundtrip.test.js && node tests/data/seed-import.test.js",
     "test:provider": "node tests/data/provider-registry.test.js && node tests/data/mutation-notifications.test.js",
-    "test:cli": "npm run build -w arkaik && node tests/cli/run-cli-tests.js && node tests/cli/init.test.js && node tests/cli/log-release.test.js && node tests/cli/sync.test.js && node tests/cli/pack-open.test.js"
+    "test:cli": "npm run build -w arkaik && node tests/cli/run-cli-tests.js && node tests/cli/init.test.js && node tests/cli/log-release.test.js && node tests/cli/sync.test.js && node tests/cli/pack-open.test.js",
+    "test:auth": "node tests/services/auth-guard.test.js"
   },
   "dependencies": {
+    "@auth/pg-adapter": "^1.11.2",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -48,6 +50,7 @@
     "highlight.js": "^11.11.1",
     "lucide-react": "^0.577.0",
     "next": "16.2.0",
+    "next-auth": "^5.0.0-beta.31",
     "next-themes": "^0.4.6",
     "pg": "^8.13.1",
     "react": "19.2.4",

--- a/tests/services/auth-guard.test.js
+++ b/tests/services/auth-guard.test.js
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+
+/**
+ * Integration test for the Synk auth guard (docs/spec/services.md § Synk → Auth;
+ * issue #241 acceptance: "unauthenticated request to a session-guarded test
+ * route → 401").
+ *
+ * The route under test is app/api/synk/ping/route.ts — the smallest expression
+ * of the session check the real Synk handlers will copy. We transpile it with
+ * the TypeScript compiler (the same bundler-free approach as the other loaders
+ * in tests/) and stub its two imports:
+ *
+ *   - `next/server`          → a tiny NextResponse.json shim exposing `.status`
+ *                              and `.json()`, so we can read the response.
+ *   - `@/lib/services/auth`  → a controllable `getSession()`.
+ *
+ * Stubbing at the getSession boundary is deliberate: the 401 path is pure guard
+ * logic and needs no live OAuth round-trip, no database, and no next-auth (which
+ * is ESM-only and cannot be required under this CommonJS transpile). We assert
+ * both the unauthenticated 401 and the authenticated 200 — the exact contract
+ * the Synk API depends on.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const Module = require("module");
+const ts = require("typescript");
+
+const ROOT = path.join(__dirname, "..", "..");
+const SRC_FILE = path.join(ROOT, "app", "api", "synk", "ping", "route.ts");
+const BUILD_DIR = path.join(__dirname, ".test-build-auth-guard");
+
+let failures = 0;
+function check(name, cond, detail) {
+  if (cond) {
+    console.log(`PASS: ${name}`);
+  } else {
+    failures++;
+    console.log(`FAIL: ${name}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+/** Minimal stand-in for Next's NextResponse.json(). */
+class StubResponse {
+  constructor(body, init) {
+    this.status = (init && init.status) || 200;
+    this._body = body;
+  }
+  async json() {
+    return this._body;
+  }
+}
+
+// Controls what the stubbed getSession() returns for the current assertion.
+let currentSession = null;
+
+const STUBS = {
+  "next/server": {
+    NextResponse: {
+      json: (body, init) => new StubResponse(body, init),
+    },
+  },
+  "@/lib/services/auth": {
+    getSession: async () => currentSession,
+  },
+};
+
+function installStubs() {
+  const originalLoad = Module._load;
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (Object.prototype.hasOwnProperty.call(STUBS, request)) {
+      return STUBS[request];
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+  return () => {
+    Module._load = originalLoad;
+  };
+}
+
+function loadRoute() {
+  fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+  fs.mkdirSync(BUILD_DIR, { recursive: true });
+  fs.writeFileSync(path.join(BUILD_DIR, "package.json"), JSON.stringify({ type: "commonjs" }));
+
+  const source = fs.readFileSync(SRC_FILE, "utf8");
+  const { outputText } = ts.transpileModule(source, {
+    fileName: "route.ts",
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+      esModuleInterop: true,
+    },
+  });
+
+  const outFile = path.join(BUILD_DIR, "route.js");
+  fs.writeFileSync(outFile, outputText);
+  delete require.cache[outFile];
+  return require(outFile);
+}
+
+async function main() {
+  const restore = installStubs();
+  try {
+    const route = loadRoute();
+    check("route exports a GET handler", typeof route.GET === "function");
+
+    // --- Unauthenticated → 401 (the acceptance criterion) -------------------
+    currentSession = null;
+    const unauthed = await route.GET();
+    check("unauthenticated request returns 401", unauthed.status === 401, `got ${unauthed.status}`);
+    const unauthedBody = await unauthed.json();
+    check(
+      "401 body carries an unauthorized error",
+      unauthedBody && unauthedBody.error === "unauthorized",
+      JSON.stringify(unauthedBody),
+    );
+    check("401 response does not leak ok/user", !("ok" in unauthedBody), JSON.stringify(unauthedBody));
+
+    // --- Authenticated → 200 { ok, user } (the pattern Synk copies) ---------
+    currentSession = { user: { id: "user-123", name: "Ada", email: "ada@example.com" } };
+    const authed = await route.GET();
+    check("authenticated request returns 200", authed.status === 200, `got ${authed.status}`);
+    const authedBody = await authed.json();
+    check("200 body reports ok:true", authedBody && authedBody.ok === true, JSON.stringify(authedBody));
+    check(
+      "200 body echoes the session user (owner scoping)",
+      authedBody && authedBody.user && authedBody.user.id === "user-123",
+      JSON.stringify(authedBody),
+    );
+  } finally {
+    restore();
+    fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+  }
+
+  if (failures > 0) {
+    console.error(`\n${failures} check(s) failed.`);
+    process.exit(1);
+  }
+  console.log("\nAll auth-guard checks passed.");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -1,0 +1,14 @@
+import type { DefaultSession } from "next-auth";
+
+/**
+ * Module augmentation so `session.user.id` is typed across the app. The value is
+ * populated by the `session` callback in auth.ts (from the JWT `sub`). Route
+ * handlers and client components rely on it to scope Synk data by owner.
+ */
+declare module "next-auth" {
+  interface Session {
+    user: {
+      id: string;
+    } & DefaultSession["user"];
+  }
+}


### PR DESCRIPTION
## Summary

Wires **Auth.js (NextAuth v5)** for Synk accounts with **GitHub OAuth** as the launch provider and the **Postgres adapter**. The whole surface degrades to *absent* when auth env vars are unset — the local-first app builds, boots, and serves every existing surface untouched, with no sign-in affordance leaking.

- **Migrations (plain Postgres, self-hosting-ready):**
  - `db/migrations/003_auth_tables.sql` — the `@auth/pg-adapter` schema (`users`, `accounts`, `sessions`, `verification_token`), hand-transcribed from the adapter docs with camelCase columns preserved (`"userId"`, `"emailVerified"`, `"providerAccountId"`, `"sessionToken"`).
  - `db/migrations/004_users_tier.sql` — `alter table users add column tier text not null default 'synk'`.
- **`auth.ts`** — `NextAuth(() => ({...}))` **lazy** config so no env var is read and no Postgres pool is opened at module import (the graceful-absence requirement). JWT session strategy (serverless-friendly; the adapter still persists users/accounts). `app/api/auth/[...nextauth]/route.ts` re-exports `handlers`.
- **`lib/services/auth.ts`** — `isAuthConfigured()` + `getSession()` (returns `null`, never throws, when unconfigured or no session). This is the seam the real Synk API will trust.
- **`app/api/synk/ping/route.ts`** — minimal session-guarded route: `401` unauthenticated, `{ ok: true, user }` when authed. The pattern the Synk backup API will copy (nothing more built here).
- **Sign-in UI** — `components/auth/AuthButton.tsx` in the `/projects` app-shell header. It reads `GET /api/auth/status`, which ships only a **boolean + public profile, never a secret**; the button renders nothing until auth is configured. No local feature is account-gated.
- **`types/next-auth.d.ts`** — types `session.user.id` (populated from the JWT `sub`).

## Verification

- `npm run build` with **all env vars unset** — passes; new routes register as dynamic (`ƒ /api/auth/[...nextauth]`, `ƒ /api/auth/status`, `ƒ /api/synk/ping`), `/projects` stays static.
- `npm run lint` — 0 errors (only pre-existing warnings in untouched files).
- `npm run generate` drift check — clean.
- Full existing `test:*` battery + `test:cli` — all green (43 CLI checks pass).
- **New:** `npm run test:auth` (`tests/services/auth-guard.test.js`) — unauthenticated ping → **401**, authed → 200 `{ ok, user }`. Wired as a CI **services**-job step.
- **Against a live Postgres 16:** `npm run db:migrate` applies 003/004, re-run is a no-op (idempotency), schema columns verified, and a real `@auth/pg-adapter` round-trip passes (`createUser` → new row defaults `tier='synk'`, `linkAccount`/`getUserByAccount`/`getUser`/`deleteUser`).
- **Runtime (prod server, no env):** `/api/auth/status` → `{"configured":false,"user":null}` (200); `/api/synk/ping` → `{"error":"unauthorized"}` (401); `/projects` → 200.

## Deployment notes

- Env vars consumed (all server-only, none `NEXT_PUBLIC_`): **`AUTH_SECRET`**, **`AUTH_GITHUB_ID`**, **`AUTH_GITHUB_SECRET`** (plus the existing `DATABASE_URL`). All three AUTH vars must be set together to switch auth on.
- GitHub OAuth App **Authorization callback URL**: `<origin>/api/auth/callback/github` (e.g. `https://arkaik.app/api/auth/callback/github`, or `http://localhost:3000/api/auth/callback/github` for dev).

Scoped away from the parallel agent's work: no changes to `app/api/publik/**`, migration `002`, or rate-limit code.

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QpXVmp8QNHQF3s2cCvtead)_