### PR TITLE
M4: arkaik push — Publik from the CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:screenshot-size": "node tests/schema/screenshot-size.test.js",
     "test:migrate": "node tests/data/migrate.test.js && node tests/data/import-roundtrip.test.js && node tests/data/seed-import.test.js",
     "test:provider": "node tests/data/provider-registry.test.js && node tests/data/mutation-notifications.test.js",
-    "test:cli": "npm run build -w arkaik && node tests/cli/run-cli-tests.js && node tests/cli/init.test.js && node tests/cli/log-release.test.js && node tests/cli/sync.test.js && node tests/cli/pack-open.test.js",
+    "test:cli": "npm run build -w arkaik && node tests/cli/run-cli-tests.js && node tests/cli/init.test.js && node tests/cli/log-release.test.js && node tests/cli/sync.test.js && node tests/cli/pack-open.test.js && node tests/cli/push.test.js",
     "test:auth": "node tests/services/auth-guard.test.js",
     "test:publik": "node tests/services/publik-api.test.js"
   },

--- a/packages/cli/src/commands/push.ts
+++ b/packages/cli/src/commands/push.ts
@@ -1,0 +1,437 @@
+/**
+ * `arkaik push [--include-journal] [--api <base-url>] [path]`
+ * `arkaik push --delete <id> --key <owner_key> [--api <base-url>]`
+ *
+ * Completes the Kommit journey — repo bundle to shareable URL without
+ * touching the browser (docs/spec/toolchain.md § the CLI, Phase 4;
+ * docs/spec/services.md § Publik → Surfaces: "CLI `arkaik push`").
+ *
+ * Create flow:
+ *  1. validate — the exact same shape + semantic + snapshot<->journal
+ *     cross-check `arkaik open` gates on (`../lib/bundle-validate`'s
+ *     `validateBundleAt`). An INVALID bundle prints findings and exits
+ *     non-zero; nothing is packed or sent.
+ *  2. pack — reuse `arkaik pack`'s internals (`./pack`'s `runPack`) rather
+ *     than re-implementing bundle assembly. The journal is stripped by
+ *     default (`noJournal: true`, the Publik-safe posture,
+ *     docs/spec/journal.md:41): it is never even embedded, so a stripped
+ *     push never sends journal bytes over the wire regardless of what the
+ *     server does with them. `--include-journal` flips that off, embedding
+ *     the journal exactly like a bare `arkaik pack` would.
+ *  3. `POST {api}/api/publik[?include_journal=true]` with the packed,
+ *     canonical bundle as the body (docs/spec/services.md § Publik →
+ *     Protocol — the API this command talks to is implemented at
+ *     `app/api/publik/route.ts` / `lib/services/publik.ts`).
+ *  4. report the response: `201` prints the URL + owner key prominently
+ *     with a save-it warning (the key is returned exactly once and there is
+ *     no recovery path in M4); `422` prints the server's structured
+ *     findings; `429` prints the retry-after; `413`/`503` get clear,
+ *     specific messages; any other non-201 status is a generic failure.
+ *     Every non-201 outcome exits 1.
+ *
+ * Delete flow: `DELETE {api}/api/publik/{id}` with
+ * `Authorization: Bearer <owner_key>` — `204` is success, `403` is a clear
+ * "owner key does not match" error, anything else is reported and exits 1.
+ *
+ * No update verb: snapshots are immutable server-side (docs/spec/services.md
+ * § Publik → Storage — "there is no update endpoint"); re-running `push`
+ * mints a new id.
+ *
+ * The only network call in this module goes through the injected
+ * `HttpClient` seam (`../lib/providers`, the same seam `arkaik sync` uses)
+ * — never a bare `fetch` — so tests substitute a mock and this command's
+ * tests (and CI) never touch the real network. `runPush`/`runPushDelete` are
+ * exported standalone (not just the CLI entry) so tests can call them
+ * directly with a mock client.
+ */
+import { resolve } from "node:path";
+import type { ValidationFinding } from "@arkaik/schema";
+import { validateBundleAt, type BundleValidation } from "../lib/bundle-validate";
+import { formatFinding } from "./validate";
+import { runPack } from "./pack";
+import { DEFAULT_HTTP_CLIENT, type HttpClient } from "../lib/providers";
+
+const DEFAULT_BUNDLE_PATH = "docs/arkaik/bundle.json";
+
+/** Default Publik host — override with `--api <base-url>` for self-hosted deployments. */
+export const DEFAULT_API_BASE = "https://arkaik.app";
+
+const USAGE = `arkaik push [--include-journal] [--api <base-url>] [path]
+arkaik push --delete <id> --key <owner_key> [--api <base-url>]
+
+Publish a project bundle to Publik (anonymous, account-less snapshot
+sharing) or delete a previously published one. Push validates the bundle
+first — the same shape + semantic + snapshot<->journal checks as
+"arkaik validate"/"arkaik open" — and only on success packs it (reusing
+"arkaik pack" internals) and POSTs it to Publik.
+
+The journal is stripped before packing by default and never sent — the
+Publik-safe posture (docs/spec/journal.md). --include-journal embeds it
+(like a bare "arkaik pack") and forwards ?include_journal=true so the server
+knows to keep it.
+
+Snapshots are immutable: there is no update verb. Pushing again always mints
+a new id. The owner key printed on success is shown exactly once and cannot
+be recovered — save it if you may need to delete the snapshot later.
+
+Arguments:
+  path                Path to the bundle JSON file (default: ${DEFAULT_BUNDLE_PATH}).
+                       Ignored with --delete.
+
+Options:
+  --include-journal   Embed the journal in the pushed bundle and forward
+                       ?include_journal=true. Default: stripped, omitted
+                       entirely from the request body.
+  --api <base-url>    Publik API base URL (default: ${DEFAULT_API_BASE}).
+                       Point at a self-hosted deployment.
+  --delete <id>       Delete a snapshot by id instead of pushing. Requires
+                       --key.
+  --key <owner_key>   Owner key for --delete (from the original push's
+                       output).
+  -h, --help          Show this help.`;
+
+function fail(message: string): never {
+  console.error(message);
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Create (push)
+// ---------------------------------------------------------------------------
+
+export interface RunPushOptions {
+  /** Path to the bundle JSON file (default: docs/arkaik/bundle.json), resolved against `cwd`. */
+  path?: string;
+  /** Embed the journal (forwarding ?include_journal=true) instead of stripping it. */
+  includeJournal?: boolean;
+  /** Publik API base URL (default: https://arkaik.app). */
+  apiBase?: string;
+  /** Base directory `path` resolves against (default: process.cwd()). */
+  cwd?: string;
+  /** The HTTP seam the POST goes through (default: real fetch). Tests inject a mock. */
+  httpClient?: HttpClient;
+}
+
+/** Structured outcome of a `POST /api/publik` request, once one was actually sent. */
+export type PushOutcome = "created" | "rejected";
+
+export interface RunPushResult {
+  ok: boolean;
+  /** Set when `ok` is false — a fatal error (bad path/JSON, or a pack failure) before a request could be attempted. */
+  fatal?: string;
+  bundlePath: string;
+  /** Local validation outcome (same gate as `arkaik open`). */
+  valid: boolean;
+  errorLines: string[];
+  warningLines: string[];
+  /** True once a request was actually sent (only when `valid`). */
+  requestSent: boolean;
+  /** HTTP status of the POST response, when one was received. */
+  status?: number;
+  /** Set on 201: the new snapshot's id. */
+  id?: string;
+  /** Set on 201: the shareable URL. */
+  url?: string;
+  /** Set on 201: the one-time owner key — never logged or persisted by this command. */
+  ownerKey?: string;
+  /** Set on 422: the server's structured validation findings. */
+  serverFindings?: ValidationFinding[];
+  /** Set on 429: seconds until the caller may retry (from the `retry-after` header). */
+  retryAfter?: string | null;
+  /** Human-readable message for any non-201 outcome (network error, non-201 status, or a request that never got sent). */
+  errorMessage?: string;
+}
+
+function fatalResult(bundlePath: string, message: string): RunPushResult {
+  return {
+    ok: false,
+    fatal: message,
+    bundlePath,
+    valid: false,
+    errorLines: [],
+    warningLines: [],
+    requestSent: false,
+  };
+}
+
+/**
+ * Validate, pack (journal stripped unless `includeJournal`), and POST to
+ * Publik. Mirrors `runOpen`'s validate-gate shape: an invalid bundle returns
+ * `ok: true, valid: false` with findings and never reaches pack/network.
+ */
+export async function runPush(options: RunPushOptions = {}): Promise<RunPushResult> {
+  const cwd = options.cwd ?? process.cwd();
+  const filePath = resolve(cwd, options.path ?? DEFAULT_BUNDLE_PATH);
+  const includeJournal = options.includeJournal ?? false;
+  const apiBase = options.apiBase ?? DEFAULT_API_BASE;
+  const httpClient = options.httpClient ?? DEFAULT_HTTP_CLIENT;
+
+  let v: BundleValidation;
+  try {
+    v = validateBundleAt(filePath);
+  } catch (e) {
+    return fatalResult(filePath, (e as Error).message);
+  }
+
+  const warningLines = v.result.warnings.map(formatFinding);
+  const errorLines = [
+    ...v.sidecarFindings.map((f) => `ERROR [${f.rule}] line ${f.line}: ${f.message}`),
+    ...v.result.errors.map(formatFinding),
+  ];
+
+  if (!v.valid) {
+    return { ok: true, bundlePath: filePath, valid: false, errorLines, warningLines, requestSent: false };
+  }
+
+  // Reuse pack's internals verbatim — noJournal strips journal[] before
+  // serialization, so a stripped push never even has journal bytes to send.
+  const packed = runPack({ path: filePath, noJournal: !includeJournal, cwd });
+  if (!packed.ok) {
+    return fatalResult(filePath, packed.fatal ?? "pack failed");
+  }
+
+  const url = `${apiBase}/api/publik${includeJournal ? "?include_journal=true" : ""}`;
+
+  let res: Response;
+  try {
+    res = await httpClient(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: packed.output,
+    });
+  } catch (e) {
+    return {
+      ok: true,
+      bundlePath: filePath,
+      valid: true,
+      errorLines,
+      warningLines,
+      requestSent: false,
+      errorMessage: `Network error: ${(e as Error).message}`,
+    };
+  }
+
+  const status = res.status;
+
+  if (status === 201) {
+    const body = (await res.json()) as { id?: string; url?: string; owner_key?: string };
+    return {
+      ok: true,
+      bundlePath: filePath,
+      valid: true,
+      errorLines,
+      warningLines,
+      requestSent: true,
+      status,
+      id: body.id,
+      url: body.url,
+      ownerKey: body.owner_key,
+    };
+  }
+
+  // Every non-201 response body is `{ error, message }` (§ Protocol), plus
+  // `findings` on 422. Tolerate a non-JSON or empty body defensively.
+  let errBody: { error?: string; message?: string; findings?: ValidationFinding[] } = {};
+  try {
+    errBody = (await res.json()) as typeof errBody;
+  } catch {
+    // no body / not JSON — fall through with the generic message below.
+  }
+
+  return {
+    ok: true,
+    bundlePath: filePath,
+    valid: true,
+    errorLines,
+    warningLines,
+    requestSent: true,
+    status,
+    serverFindings: errBody.findings,
+    retryAfter: status === 429 ? res.headers.get("retry-after") : undefined,
+    errorMessage: errBody.message ?? `Request failed with status ${status}`,
+  };
+}
+
+function reportPush(result: RunPushResult): never {
+  if (result.warningLines.length > 0) {
+    console.error(`Warnings: ${result.warningLines.length}`);
+    result.warningLines.forEach((w) => console.error(`  ${w}`));
+  }
+
+  if (!result.valid) {
+    console.error(`Errors: ${result.errorLines.length}`);
+    result.errorLines.forEach((e) => console.error(`  ${e}`));
+    console.error("\nInvalid bundle — not packed, not pushed.");
+    process.exit(1);
+  }
+
+  if (!result.requestSent) {
+    console.error(`FATAL: ${result.errorMessage ?? "Push failed before a request could be sent."}`);
+    process.exit(1);
+  }
+
+  if (result.status === 201) {
+    console.log("\n  Published to Publik");
+    console.log("  ====================\n");
+    console.log(`  URL:        ${result.url}`);
+    console.log(`  Owner key:  ${result.ownerKey}`);
+    console.log("\n  Save this key now — it is shown only once and is required to delete this");
+    console.log("  snapshot later. There is no recovery path if it is lost.");
+    console.log(`\n  Delete with: arkaik push --delete ${result.id} --key <owner_key>\n`);
+    process.exit(0);
+  }
+
+  if (result.status === 422) {
+    console.error("Server rejected the bundle (422):");
+    (result.serverFindings ?? []).forEach((f) => console.error(`  ${formatFinding(f)}`));
+    process.exit(1);
+  }
+
+  if (result.status === 429) {
+    console.error(`Rate limited (429) — try again in ${result.retryAfter ?? "a while"} second(s).`);
+    process.exit(1);
+  }
+
+  if (result.status === 413) {
+    console.error(`Bundle too large (413): ${result.errorMessage ?? "exceeds the Publik size cap."}`);
+    process.exit(1);
+  }
+
+  if (result.status === 503) {
+    console.error(`Publik is unavailable (503): ${result.errorMessage ?? "services not configured on this deployment."}`);
+    process.exit(1);
+  }
+
+  console.error(`Push failed (${result.status}): ${result.errorMessage}`);
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Delete
+// ---------------------------------------------------------------------------
+
+export interface RunPushDeleteOptions {
+  id: string;
+  key: string;
+  /** Publik API base URL (default: https://arkaik.app). */
+  apiBase?: string;
+  /** The HTTP seam the DELETE goes through (default: real fetch). Tests inject a mock. */
+  httpClient?: HttpClient;
+}
+
+export interface RunPushDeleteResult {
+  /** False only for a network-level failure — the request never completed. */
+  ok: boolean;
+  fatal?: string;
+  status?: number;
+  deleted: boolean;
+  errorMessage?: string;
+}
+
+/** `DELETE {api}/api/publik/{id}` with `Authorization: Bearer <key>`. */
+export async function runPushDelete(options: RunPushDeleteOptions): Promise<RunPushDeleteResult> {
+  const apiBase = options.apiBase ?? DEFAULT_API_BASE;
+  const httpClient = options.httpClient ?? DEFAULT_HTTP_CLIENT;
+  const url = `${apiBase}/api/publik/${options.id}`;
+
+  let res: Response;
+  try {
+    res = await httpClient(url, {
+      method: "DELETE",
+      headers: { authorization: `Bearer ${options.key}` },
+    });
+  } catch (e) {
+    return { ok: false, fatal: `Network error: ${(e as Error).message}`, deleted: false };
+  }
+
+  if (res.status === 204) {
+    return { ok: true, status: 204, deleted: true };
+  }
+
+  let errBody: { error?: string; message?: string } = {};
+  try {
+    errBody = (await res.json()) as typeof errBody;
+  } catch {
+    // no body / not JSON
+  }
+
+  return {
+    ok: true,
+    status: res.status,
+    deleted: false,
+    errorMessage: errBody.message ?? `Delete failed with status ${res.status}`,
+  };
+}
+
+function reportDelete(id: string, result: RunPushDeleteResult): never {
+  if (!result.ok) fail(`FATAL: ${result.fatal}`);
+
+  if (result.deleted) {
+    console.log(`Deleted ${id}`);
+    process.exit(0);
+  }
+
+  console.error(`Delete failed (${result.status}): ${result.errorMessage}`);
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry
+// ---------------------------------------------------------------------------
+
+export function runPushCli(args: string[]): void {
+  let includeJournal = false;
+  let apiBase: string | undefined;
+  let deleteId: string | undefined;
+  let key: string | undefined;
+  const positionals: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "-h" || arg === "--help") {
+      console.log(USAGE);
+      process.exit(0);
+    } else if (arg === "--include-journal") {
+      includeJournal = true;
+    } else if (arg === "--api") {
+      const value = args[++i];
+      if (value === undefined) fail(`Missing value for --api\n\n${USAGE}`);
+      apiBase = value;
+    } else if (arg === "--delete") {
+      const value = args[++i];
+      if (value === undefined) fail(`Missing value for --delete\n\n${USAGE}`);
+      deleteId = value;
+    } else if (arg === "--key") {
+      const value = args[++i];
+      if (value === undefined) fail(`Missing value for --key\n\n${USAGE}`);
+      key = value;
+    } else if (arg.startsWith("-")) {
+      fail(`Unknown option: ${arg}\n\n${USAGE}`);
+    } else {
+      positionals.push(arg);
+    }
+  }
+
+  if (deleteId !== undefined) {
+    if (key === undefined) fail(`--delete requires --key <owner_key>\n\n${USAGE}`);
+    if (positionals.length > 0) {
+      fail(`Unexpected argument(s) with --delete: ${positionals.join(" ")}\n\n${USAGE}`);
+    }
+
+    runPushDelete({ id: deleteId, key, apiBase })
+      .then((result) => reportDelete(deleteId, result))
+      .catch((e: unknown) => fail(`FATAL: ${(e as Error).message}`));
+    return;
+  }
+
+  if (key !== undefined) fail(`--key is only valid with --delete\n\n${USAGE}`);
+
+  const filePath = positionals[0] ?? DEFAULT_BUNDLE_PATH;
+
+  runPush({ path: filePath, includeJournal, apiBase })
+    .then((result) => {
+      if (!result.ok) fail(`FATAL: ${result.fatal}`);
+      reportPush(result);
+    })
+    .catch((e: unknown) => fail(`FATAL: ${(e as Error).message}`));
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,9 +2,7 @@
  * `arkaik` CLI entry point.
  *
  * A tiny hand-rolled command dispatcher — deliberately dependency-free (no
- * commander/yargs). Each command owns its own flag parsing so later commands
- * (push — Phase 4) slot in by adding a `case` here and a handler module under
- * `./commands`.
+ * commander/yargs). Each command owns its own flag parsing.
  *
  * All schema behaviour is reused verbatim from `@arkaik/schema`; the commands
  * never re-implement validation or serialization.
@@ -16,6 +14,7 @@ import { runRelease } from "./commands/release";
 import { runSyncCli } from "./commands/sync";
 import { runPackCli } from "./commands/pack";
 import { runOpenCli } from "./commands/open";
+import { runPushCli } from "./commands/push";
 
 const USAGE = `arkaik — CLI for Arkaik project bundles
 
@@ -30,6 +29,8 @@ Commands:
   sync [options] [path]       Mirror external ref status (GitHub issues/PRs) into node refs.
   pack [options] [path]       Produce a single self-contained interchange bundle (embeds the journal).
   open [options] [path]       Validate, then hand off the packed bundle to arkaik.app import.
+  push [options] [path]       Validate, pack (journal stripped), and publish to Publik.
+                               --delete <id> --key <owner_key> removes a snapshot.
 
 Options:
   -h, --help        Show this help.
@@ -65,6 +66,9 @@ function main(argv: string[]): void {
       return;
     case "open":
       runOpenCli(rest);
+      return;
+    case "push":
+      runPushCli(rest);
       return;
     default:
       console.error(`Unknown command: ${command}\n`);

--- a/tests/cli/push.test.js
+++ b/tests/cli/push.test.js
@@ -1,0 +1,459 @@
+#!/usr/bin/env node
+
+/**
+ * Exercises `arkaik push` (issue #240, docs/spec/services.md § Publik →
+ * Surfaces: "CLI `arkaik push`").
+ *
+ * Two layers, mirroring tests/cli/sync.test.js:
+ *  - `runPush()`/`runPushDelete()` exercised in-process:
+ *    packages/cli/src/commands/push.ts is esbuild-bundled (same technique
+ *    build.js uses for the real CLI, just to a throwaway `.test-build/` dir)
+ *    into an importable ESM module, so a mock `httpClient` can be injected
+ *    straight into the exported functions — no subprocess, no real network,
+ *    ever.
+ *  - the built CLI binary (packages/cli/dist/index.js) spawned for the
+ *    argv-parsing / exit-code / --help contract, using only cases that fail
+ *    (validation, usage errors) before any network call would be attempted,
+ *    so a spawned run can never reach the real network.
+ *
+ * Covers (the issue's required scenarios plus the full response matrix):
+ *  - success (201): journal stripped by default and never sent, prints the
+ *    URL + owner key;
+ *  - --include-journal: journal embedded in the body, ?include_journal=true
+ *    forwarded;
+ *  - validation failure: an invalid bundle never reaches pack or the network;
+ *  - 429 rate limited: retry-after surfaced;
+ *  - 422 (server-side validation_failed): structured findings surfaced;
+ *  - 413 / 503: clear messages;
+ *  - a thrown network error is reported, not crashed;
+ *  - delete: 204 success (Authorization: Bearer <key> sent), 403 wrong key,
+ *    a network-level failure;
+ *  - --api overrides the default https://arkaik.app base for both push and
+ *    delete;
+ *  - CLI-level: --help, --delete without --key, --key without --delete,
+ *    unexpected positional with --delete, unknown flag, missing bundle file.
+ */
+
+const { build } = require("esbuild");
+const { spawnSync } = require("child_process");
+const {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+  copyFileSync,
+} = require("fs");
+const { tmpdir } = require("os");
+const path = require("path");
+const { pathToFileURL } = require("url");
+
+const ROOT = path.join(__dirname, "..", "..");
+const CLI = path.join(ROOT, "packages", "cli", "dist", "index.js");
+const FIXTURES = path.join(ROOT, "tests", "fixtures");
+const PUSH_ENTRY = path.join(ROOT, "packages", "cli", "src", "commands", "push.ts");
+const TEST_BUILD_DIR = path.join(ROOT, "packages", "cli", ".test-build");
+const PUSH_BUNDLE = path.join(TEST_BUILD_DIR, "push.mjs");
+
+if (!existsSync(CLI)) {
+  console.error(`CLI not built at ${CLI}. Run \`npm run build -w arkaik\` first.`);
+  process.exit(1);
+}
+
+function runCli(args) {
+  return spawnSync(process.execPath, [CLI, ...args], { encoding: "utf8" });
+}
+
+let failures = 0;
+let passes = 0;
+function check(name, cond, detail) {
+  if (cond) {
+    passes++;
+    console.log(`PASS: ${name}`);
+  } else {
+    failures++;
+    console.log(`FAIL: ${name}`);
+    if (detail) console.log(detail);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: a minimal valid bundle + sidecar journal.
+// ---------------------------------------------------------------------------
+function makeBundle() {
+  return {
+    schema_version: 1,
+    project: {
+      id: "demo",
+      title: "Demo",
+      created_at: "2026-01-01T00:00:00.000Z",
+      updated_at: "2026-01-01T00:00:00.000Z",
+    },
+    nodes: [
+      {
+        id: "V-home",
+        project_id: "demo",
+        species: "view",
+        title: "Home",
+        status: "live",
+        platforms: ["web"],
+      },
+    ],
+    edges: [],
+  };
+}
+
+const JOURNAL_LINES = [
+  {
+    id: "01J9ZK4E4N0000000000000001",
+    ts: "2026-01-01T00:00:00.000Z",
+    actor: "claude-code",
+    type: "node.created",
+    node_id: "V-home",
+    species: "view",
+    title: "Home",
+  },
+];
+const JOURNAL = JOURNAL_LINES.map((e) => JSON.stringify(e)).join("\n") + "\n";
+
+const createdDirs = [];
+
+/** Fresh temp dir with bundle.json + journal.jsonl sidecar. */
+function fixture() {
+  const dir = mkdtempSync(path.join(tmpdir(), "arkaik-push-"));
+  createdDirs.push(dir);
+  const bundlePath = path.join(dir, "bundle.json");
+  const journalPath = path.join(dir, "journal.jsonl");
+  writeFileSync(bundlePath, JSON.stringify(makeBundle(), null, 2) + "\n");
+  writeFileSync(journalPath, JOURNAL);
+  return { dir, bundlePath, journalPath };
+}
+
+/** Fresh temp dir with a copy of the shared dangling-edge (invalid) fixture, no sidecar. */
+function invalidFixture() {
+  const dir = mkdtempSync(path.join(tmpdir(), "arkaik-push-invalid-"));
+  createdDirs.push(dir);
+  const bundlePath = path.join(dir, "bundle.json");
+  copyFileSync(path.join(FIXTURES, "dangling-edge.json"), bundlePath);
+  return { dir, bundlePath };
+}
+
+function jsonResponse(status, body, headers = {}) {
+  const lower = {};
+  for (const [k, v] of Object.entries(headers)) lower[k.toLowerCase()] = v;
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    headers: { get: (name) => lower[name.toLowerCase()] ?? null },
+  };
+}
+
+/** Mock httpClient: routes by a caller-supplied responder, records every call it saw. */
+function makeMockHttpClient(responder) {
+  const calls = [];
+  const client = async (url, init) => {
+    calls.push({ url, init });
+    return responder(url, init, calls.length);
+  };
+  client.calls = calls;
+  return client;
+}
+
+async function main() {
+  mkdirSync(TEST_BUILD_DIR, { recursive: true });
+  await build({
+    entryPoints: [PUSH_ENTRY],
+    outfile: PUSH_BUNDLE,
+    bundle: true,
+    platform: "node",
+    target: "node18",
+    format: "esm",
+    legalComments: "none",
+  });
+  const { runPush, runPushDelete, DEFAULT_API_BASE } = await import(pathToFileURL(PUSH_BUNDLE).href);
+
+  check("DEFAULT_API_BASE is https://arkaik.app", DEFAULT_API_BASE === "https://arkaik.app", DEFAULT_API_BASE);
+
+  // -------------------------------------------------------------------------
+  // Success (201): journal stripped by default, never sent.
+  // -------------------------------------------------------------------------
+  {
+    const { bundlePath } = fixture();
+    const httpClient = makeMockHttpClient((url) => {
+      check("POST url has no include_journal query by default", url === `${DEFAULT_API_BASE}/api/publik`, url);
+      return jsonResponse(201, {
+        id: "abc123",
+        url: `${DEFAULT_API_BASE}/p/abc123`,
+        owner_key: "11111111-1111-4111-8111-111111111111",
+      });
+    });
+
+    const result = await runPush({ path: bundlePath, httpClient });
+
+    check("runPush ok", result.ok === true, JSON.stringify(result));
+    check("push validates first (valid: true)", result.valid === true);
+    check("request was sent", result.requestSent === true);
+    check("status 201", result.status === 201, result.status);
+    check("returns the created id", result.id === "abc123", result.id);
+    check("returns the shareable url", result.url === `${DEFAULT_API_BASE}/p/abc123`, result.url);
+    check(
+      "returns the one-time owner key",
+      result.ownerKey === "11111111-1111-4111-8111-111111111111",
+      result.ownerKey,
+    );
+
+    check("exactly one HTTP call made", httpClient.calls.length === 1, httpClient.calls.length);
+    const call = httpClient.calls[0];
+    check("method is POST", call.init.method === "POST");
+    check(
+      "content-type header set",
+      call.init.headers["content-type"] === "application/json",
+      JSON.stringify(call.init.headers),
+    );
+    const sentBundle = JSON.parse(call.init.body);
+    check("sent body has no journal key at all (stripped, not just empty)", sentBundle.journal === undefined, JSON.stringify(Object.keys(sentBundle)));
+    check("sent body carries the project", sentBundle.project && sentBundle.project.id === "demo", JSON.stringify(sentBundle.project));
+  }
+
+  // -------------------------------------------------------------------------
+  // --include-journal: embeds the sidecar journal, forwards the query param.
+  // -------------------------------------------------------------------------
+  {
+    const { bundlePath } = fixture();
+    const httpClient = makeMockHttpClient((url) => {
+      check(
+        "POST url forwards ?include_journal=true",
+        url === `${DEFAULT_API_BASE}/api/publik?include_journal=true`,
+        url,
+      );
+      return jsonResponse(201, { id: "xyz", url: `${DEFAULT_API_BASE}/p/xyz`, owner_key: "22222222-2222-4222-8222-222222222222" });
+    });
+
+    const result = await runPush({ path: bundlePath, includeJournal: true, httpClient });
+
+    check("include-journal push ok", result.ok === true && result.status === 201, JSON.stringify(result));
+    const sentBundle = JSON.parse(httpClient.calls[0].init.body);
+    check(
+      "sent body embeds the sidecar journal",
+      Array.isArray(sentBundle.journal) && sentBundle.journal.length === 1,
+      JSON.stringify(sentBundle.journal),
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Validation failure: never reaches pack or the network.
+  // -------------------------------------------------------------------------
+  {
+    const { bundlePath } = invalidFixture();
+    const httpClient = makeMockHttpClient(() => {
+      throw new Error("must not be called");
+    });
+
+    const result = await runPush({ path: bundlePath, httpClient });
+
+    check("runPush ok (validation ran, just failed)", result.ok === true, JSON.stringify(result));
+    check("valid is false", result.valid === false);
+    check("no request was sent", result.requestSent === false);
+    check("error lines report the dangling edge", result.errorLines.length > 0, JSON.stringify(result.errorLines));
+    check("no HTTP call was attempted", httpClient.calls.length === 0, httpClient.calls.length);
+  }
+
+  // -------------------------------------------------------------------------
+  // 429 rate limited: retry-after surfaced.
+  // -------------------------------------------------------------------------
+  {
+    const { bundlePath } = fixture();
+    const httpClient = makeMockHttpClient(() =>
+      jsonResponse(429, { error: "rate_limited", message: "Too many snapshots created. Try again later." }, { "retry-after": "37" }),
+    );
+
+    const result = await runPush({ path: bundlePath, httpClient });
+
+    check("429 result ok (request completed)", result.ok === true);
+    check("status 429", result.status === 429);
+    check("retryAfter surfaced from header", result.retryAfter === "37", result.retryAfter);
+    check("errorMessage surfaced from body", /Too many snapshots/.test(result.errorMessage || ""), result.errorMessage);
+  }
+
+  // -------------------------------------------------------------------------
+  // 422: server-side validation_failed findings surfaced.
+  // -------------------------------------------------------------------------
+  {
+    const { bundlePath } = fixture();
+    const findings = [{ path: "nodes[0].title", rule: "required", message: "Title is required.", severity: "error" }];
+    const httpClient = makeMockHttpClient(() => jsonResponse(422, { error: "validation_failed", findings }));
+
+    const result = await runPush({ path: bundlePath, httpClient });
+
+    check("status 422", result.status === 422);
+    check("serverFindings surfaced", Array.isArray(result.serverFindings) && result.serverFindings.length === 1, JSON.stringify(result.serverFindings));
+  }
+
+  // -------------------------------------------------------------------------
+  // 413 payload too large.
+  // -------------------------------------------------------------------------
+  {
+    const { bundlePath } = fixture();
+    const httpClient = makeMockHttpClient(() =>
+      jsonResponse(413, { error: "payload_too_large", message: "Bundle exceeds the 5242880 byte limit." }),
+    );
+
+    const result = await runPush({ path: bundlePath, httpClient });
+
+    check("status 413", result.status === 413);
+    check("413 message surfaced", /exceeds the/.test(result.errorMessage || ""), result.errorMessage);
+  }
+
+  // -------------------------------------------------------------------------
+  // 503 services unavailable.
+  // -------------------------------------------------------------------------
+  {
+    const { bundlePath } = fixture();
+    const httpClient = makeMockHttpClient(() =>
+      jsonResponse(503, { error: "services_unavailable", message: "arkaik services (Publik) are not configured on this deployment." }),
+    );
+
+    const result = await runPush({ path: bundlePath, httpClient });
+
+    check("status 503", result.status === 503);
+    check("503 message surfaced", /not configured/.test(result.errorMessage || ""), result.errorMessage);
+  }
+
+  // -------------------------------------------------------------------------
+  // A thrown network error is reported, not crashed.
+  // -------------------------------------------------------------------------
+  {
+    const { bundlePath } = fixture();
+    const httpClient = async () => {
+      throw new Error("getaddrinfo ENOTFOUND arkaik.app");
+    };
+
+    const result = await runPush({ path: bundlePath, httpClient });
+
+    check("network error result ok (no crash)", result.ok === true, JSON.stringify(result));
+    check("request not marked sent", result.requestSent === false);
+    check("network error message surfaced", /Network error/.test(result.errorMessage || ""), result.errorMessage);
+  }
+
+  // -------------------------------------------------------------------------
+  // --api overrides the default base for push.
+  // -------------------------------------------------------------------------
+  {
+    const { bundlePath } = fixture();
+    const customBase = "http://localhost:4000";
+    const httpClient = makeMockHttpClient((url) => {
+      check("POST goes to the custom --api base", url === `${customBase}/api/publik`, url);
+      return jsonResponse(201, { id: "id1", url: `${customBase}/p/id1`, owner_key: "33333333-3333-4333-8333-333333333333" });
+    });
+
+    const result = await runPush({ path: bundlePath, apiBase: customBase, httpClient });
+    check("custom --api push ok", result.status === 201);
+    check("returned url uses the custom base", result.url === `${customBase}/p/id1`, result.url);
+  }
+
+  // -------------------------------------------------------------------------
+  // Delete: 204 success, Authorization: Bearer <key> sent.
+  // -------------------------------------------------------------------------
+  {
+    const httpClient = makeMockHttpClient((url, init) => {
+      check("DELETE url targets the snapshot id", url === `${DEFAULT_API_BASE}/api/publik/abc123`, url);
+      check("DELETE method", init.method === "DELETE");
+      check(
+        "Authorization: Bearer <key> sent",
+        init.headers.authorization === "Bearer the-owner-key",
+        JSON.stringify(init.headers),
+      );
+      return jsonResponse(204, null);
+    });
+
+    const result = await runPushDelete({ id: "abc123", key: "the-owner-key", httpClient });
+
+    check("delete ok", result.ok === true, JSON.stringify(result));
+    check("delete deleted:true", result.deleted === true);
+    check("delete status 204", result.status === 204);
+  }
+
+  // -------------------------------------------------------------------------
+  // Delete: wrong key -> 403, clear error, not deleted.
+  // -------------------------------------------------------------------------
+  {
+    const httpClient = makeMockHttpClient(() => jsonResponse(403, { error: "forbidden", message: "Owner key does not match." }));
+
+    const result = await runPushDelete({ id: "abc123", key: "wrong-key", httpClient });
+
+    check("wrong-key delete ok (request completed)", result.ok === true);
+    check("wrong-key delete not deleted", result.deleted === false);
+    check("wrong-key delete status 403", result.status === 403);
+    check("wrong-key delete message surfaced", /does not match/.test(result.errorMessage || ""), result.errorMessage);
+  }
+
+  // -------------------------------------------------------------------------
+  // Delete: a thrown network error is reported as a fatal, not a crash.
+  // -------------------------------------------------------------------------
+  {
+    const httpClient = async () => {
+      throw new Error("connect ECONNREFUSED");
+    };
+    const result = await runPushDelete({ id: "abc123", key: "k", httpClient });
+    check("delete network error is not ok", result.ok === false);
+    check("delete network error fatal surfaced", /Network error/.test(result.fatal || ""), result.fatal);
+  }
+
+  // -------------------------------------------------------------------------
+  // --api overrides the default base for delete.
+  // -------------------------------------------------------------------------
+  {
+    const customBase = "http://localhost:4000";
+    const httpClient = makeMockHttpClient((url) => {
+      check("DELETE goes to the custom --api base", url === `${customBase}/api/publik/abc123`, url);
+      return jsonResponse(204, null);
+    });
+    const result = await runPushDelete({ id: "abc123", key: "k", apiBase: customBase, httpClient });
+    check("custom --api delete ok", result.deleted === true);
+  }
+
+  // -------------------------------------------------------------------------
+  // CLI-level: argv parsing / exit codes, spawned — every case here fails
+  // before any network call would be attempted, so a real (unmocked)
+  // subprocess run can never reach the network.
+  // -------------------------------------------------------------------------
+  {
+    const help = runCli(["push", "--help"]);
+    check("push --help exits 0", help.status === 0 && /arkaik push/.test(help.stdout), help.stdout);
+    check("help documents --delete", /--delete/.test(help.stdout));
+    check("help documents --include-journal", /--include-journal/.test(help.stdout));
+    check("help documents --api", /--api/.test(help.stdout));
+
+    const noKey = runCli(["push", "--delete", "abc123"]);
+    check("--delete without --key exits 1", noKey.status === 1, `${noKey.stdout}\n${noKey.stderr}`);
+    check("--delete without --key reports the reason", /requires --key/.test(noKey.stderr || noKey.stdout), noKey.stderr);
+
+    const keyWithoutDelete = runCli(["push", "--key", "somekey"]);
+    check("--key without --delete exits 1", keyWithoutDelete.status === 1);
+
+    const extraPositional = runCli(["push", "--delete", "abc123", "--key", "k", "extra-arg"]);
+    check("unexpected positional with --delete exits 1", extraPositional.status === 1);
+
+    const badFlag = runCli(["push", "--nope"]);
+    check("unknown flag exits 1", badFlag.status === 1);
+
+    const missingFile = runCli(["push", path.join(tmpdir(), "arkaik-push-does-not-exist", "bundle.json")]);
+    check("missing bundle file exits 1 (fatal, before any network)", missingFile.status === 1, `${missingFile.stdout}\n${missingFile.stderr}`);
+
+    const missingApiValue = runCli(["push", "--api"]);
+    check("--api with no value exits 1", missingApiValue.status === 1);
+  }
+
+  for (const dir of createdDirs) rmSync(dir, { recursive: true, force: true });
+  rmSync(TEST_BUILD_DIR, { recursive: true, force: true });
+
+  console.log(`\n${passes} passed, ${failures} failed.`);
+  process.exit(failures > 0 ? 1 : 0);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds `arkaik push [--include-journal] [--api <base-url>] [path]`: validates the bundle (the same shape + semantic + snapshot↔journal cross-check `arkaik open` gates on), packs it reusing `pack.ts`'s internals (journal stripped by default — never even embedded, let alone sent), `POST`s it to `{api}/api/publik`, and on `201` prints the shareable URL + one-time owner key with a prominent "save this key" warning.
- Adds `arkaik push --delete <id> --key <owner_key> [--api <base-url>]`: issues the `DELETE` with `Authorization: Bearer <key>`; `204` → success, `403` → clear error, exit 1.
- `--include-journal` embeds the journal (like a bare `arkaik pack`) and forwards `?include_journal=true`.
- `--api <base-url>` overrides the default `https://arkaik.app` for self-hosted deployments.
- Full response handling per `docs/spec/services.md` § Publik → Protocol and the merged `app/api/publik/route.ts` / `lib/services/publik.ts` contracts: `422` prints structured findings, `429` prints retry-after, `413`/`503` get clear messages, any other non-201 exits 1.
- No update verb — snapshots are immutable; re-pushing mints a new id.
- New file `packages/cli/src/commands/push.ts` + a `case "push"` in `packages/cli/src/index.ts` (the slot the entry-point comment reserved for it).

## Implementation notes

- Follows `sync.ts`'s injectable `HttpClient` seam (reused directly from `../lib/providers`, not reinvented) — the only network call in the module goes through it, so tests never touch the real network.
- Reuses `../lib/bundle-validate`'s `validateBundleAt` (same gate as `arkaik open`) and `./pack`'s `runPack` (same packing internals as `arkaik pack`) rather than re-implementing either.
- Diff stays inside `packages/cli/**`, its tests, and one line of `package.json` (`test:cli` extended to chain the new test file, matching how every prior CLI command's test file was wired in). No changes to `app/**`, `lib/services/**`, `db/**`, or migrations.

## Test plan

- [x] `packages/cli/src/commands/push.ts` — new command implementation
- [x] `tests/cli/push.test.js` — new test file (esbuild-bundles `push.ts` for in-process `runPush`/`runPushDelete` calls with a mock `HttpClient`, plus a spawned-binary layer for argv/exit-code/`--help` contract). Covers the four required scenarios (success, validation failure, 429, delete with wrong key) plus the full response matrix: 201, `--include-journal` forwarding, 422, 413, 503, a thrown network error, `--api` override for both push and delete, and CLI-level usage errors.
- [x] `npm run lint` — clean (pre-existing unrelated warnings only, 0 errors)
- [x] `npm run build` — passes
- [x] `npm run generate` — no drift
- [x] Full `npm run test:*` battery, all green: `test:fixtures`, `test:schema`, `test:id-gen`, `test:serialize`, `test:refs`, `test:journal`, `test:journal-projections`, `test:emit`, `test:emit-events`, `test:screenshot-size`, `test:migrate`, `test:provider`, `test:cli` (244 assertions, 0 failures), `test:auth`, `test:publik` (ran against a real local Postgres 16 + migrations)
- [x] Real end-to-end smoke test against the actual built app (`next start` + local Postgres, migrated): `arkaik push` against the live `/api/publik` — confirmed the server strips the journal by default, `--include-journal` round-trips it intact, delete with the wrong key returns 403, delete with the correct key returns 204 and the snapshot is subsequently 404

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QpXVmp8QNHQF3s2cCvtead)_