### PR TITLE
M4: Synk API — backups, content-hash dedupe, retention, tier limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,3 +121,5 @@ jobs:
         run: npm run test:publik
       - name: Synk auth-guard integration test (unauthenticated → 401)
         run: npm run test:auth
+      - name: Synk API integration tests (authz isolation, dedupe, limits, retention)
+        run: npm run test:synk

--- a/app/api/synk/backups/[backupId]/route.ts
+++ b/app/api/synk/backups/[backupId]/route.ts
@@ -1,0 +1,46 @@
+import { getSession } from "@/lib/services/auth";
+import { getBackupBundle, servicesConfigured, servicesUnavailable } from "@/lib/services/synk";
+
+/**
+ * GET /api/synk/backups/{backupId} — return the stored bundle JSON for a backup
+ * so the client can restore it (docs/spec/services.md § Synk → Backup protocol).
+ *
+ * Session-guarded and user-scoped: the lookup is filtered by the session's user
+ * id, so a backup id owned by another user is indistinguishable from a missing
+ * one — 404 either way (§ "Authorization is by ownership"; § Security & Privacy
+ * → "The client never receives another user's rows"). Node runtime for `pg`.
+ */
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type Context = { params: Promise<{ backupId: string }> };
+
+export async function GET(_req: Request, { params }: Context): Promise<Response> {
+  if (!servicesConfigured()) return servicesUnavailable();
+
+  const session = await getSession();
+  if (!session?.user) {
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }
+  const userId = Number(session.user.id);
+  if (!Number.isInteger(userId)) {
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const { backupId } = await params;
+
+  try {
+    const bundle = await getBackupBundle(userId, backupId);
+    if (bundle === null) {
+      return Response.json({ error: "not_found", message: "Backup not found." }, { status: 404 });
+    }
+    // Verbatim stored bundle (journal included — it is the user's private data).
+    return Response.json(bundle, { status: 200 });
+  } catch (err) {
+    console.error("[synk] GET backup failed:", err instanceof Error ? err.message : "unknown error");
+    return Response.json(
+      { error: "internal_error", message: "Failed to fetch backup." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/synk/projects/[projectId]/backups/route.ts
+++ b/app/api/synk/projects/[projectId]/backups/route.ts
@@ -1,0 +1,42 @@
+import { getSession } from "@/lib/services/auth";
+import { listBackups, servicesConfigured, servicesUnavailable } from "@/lib/services/synk";
+
+/**
+ * GET /api/synk/projects/{projectId}/backups — list the retained backup
+ * versions of one project (id, created_at, size, content hash), newest first
+ * (docs/spec/services.md § Synk → Backup protocol).
+ *
+ * Session-guarded and user-scoped: the query filters on the session's user id,
+ * so requesting another user's project id yields an empty list, never their
+ * rows (§ "Authorization is by ownership"). Node runtime for the `pg` driver.
+ */
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type Context = { params: Promise<{ projectId: string }> };
+
+export async function GET(_req: Request, { params }: Context): Promise<Response> {
+  if (!servicesConfigured()) return servicesUnavailable();
+
+  const session = await getSession();
+  if (!session?.user) {
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }
+  const userId = Number(session.user.id);
+  if (!Number.isInteger(userId)) {
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const { projectId } = await params;
+
+  try {
+    const backups = await listBackups(userId, projectId);
+    return Response.json({ backups }, { status: 200 });
+  } catch (err) {
+    console.error("[synk] GET backups failed:", err instanceof Error ? err.message : "unknown error");
+    return Response.json(
+      { error: "internal_error", message: "Failed to list backups." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/synk/projects/[projectId]/route.ts
+++ b/app/api/synk/projects/[projectId]/route.ts
@@ -1,0 +1,104 @@
+import { getSession } from "@/lib/services/auth";
+import {
+  BUNDLE_SHA256_HEADER,
+  deleteProject,
+  putBackup,
+  servicesConfigured,
+  servicesUnavailable,
+} from "@/lib/services/synk";
+
+/**
+ * PUT    /api/synk/projects/{projectId} — store a backup version of the bundle,
+ *        or dedupe it (docs/spec/services.md § Synk → Backup protocol).
+ * DELETE /api/synk/projects/{projectId} — remove the project and all its backups.
+ *
+ * Both are session-guarded and user-scoped: every persisted row carries the
+ * caller's user id and every query filters on it (§ "Authorization is by
+ * ownership"). Node runtime for the `pg` driver; force-dynamic because the
+ * response depends on the session cookie.
+ */
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type Context = { params: Promise<{ projectId: string }> };
+
+export async function PUT(req: Request, { params }: Context): Promise<Response> {
+  if (!servicesConfigured()) return servicesUnavailable();
+
+  const session = await getSession();
+  if (!session?.user) {
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }
+  const userId = Number(session.user.id);
+  if (!Number.isInteger(userId)) {
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const { projectId } = await params;
+
+  // Parse the JSON body. Malformed JSON is a syntactic error → 400.
+  let input: unknown;
+  try {
+    input = await req.json();
+  } catch {
+    return Response.json(
+      { error: "invalid_json", message: "Request body is not valid JSON." },
+      { status: 400 },
+    );
+  }
+
+  // Advisory canonical hash the client MAY send to skip re-work (§ dedupe).
+  const clientHash = req.headers.get(BUNDLE_SHA256_HEADER);
+
+  try {
+    const result = await putBackup({ userId, projectId, input, clientHash });
+    switch (result.status) {
+      case "invalid":
+        return Response.json({ error: "validation_failed", findings: result.findings }, { status: 422 });
+      case "limit":
+        return Response.json(
+          { error: "limit_exceeded", limit: result.limit, actual: result.actual, tier: result.tier },
+          { status: 403 },
+        );
+      case "deduped":
+        return Response.json({ deduped: true }, { status: 200 });
+      case "stored":
+        return Response.json({ id: result.backupId, deduped: false }, { status: 201 });
+    }
+  } catch (err) {
+    console.error("[synk] PUT backup failed:", err instanceof Error ? err.message : "unknown error");
+    return Response.json(
+      { error: "internal_error", message: "Failed to store backup." },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE(_req: Request, { params }: Context): Promise<Response> {
+  if (!servicesConfigured()) return servicesUnavailable();
+
+  const session = await getSession();
+  if (!session?.user) {
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }
+  const userId = Number(session.user.id);
+  if (!Number.isInteger(userId)) {
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const { projectId } = await params;
+
+  try {
+    const deleted = await deleteProject(userId, projectId);
+    if (!deleted) {
+      return Response.json({ error: "not_found", message: "Project not found." }, { status: 404 });
+    }
+    return new Response(null, { status: 204 });
+  } catch (err) {
+    console.error("[synk] DELETE project failed:", err instanceof Error ? err.message : "unknown error");
+    return Response.json(
+      { error: "internal_error", message: "Failed to delete project." },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/synk/projects/route.ts
+++ b/app/api/synk/projects/route.ts
@@ -1,0 +1,38 @@
+import { getSession } from "@/lib/services/auth";
+import { listProjects, servicesConfigured, servicesUnavailable } from "@/lib/services/synk";
+
+/**
+ * GET /api/synk/projects — list the caller's backed-up projects, each with its
+ * latest backup metadata (docs/spec/services.md § Synk → Backup protocol).
+ *
+ * Session-guarded and user-scoped: the listing is filtered by the session's
+ * user id, so a caller can only ever see their own projects (§ "Authorization is
+ * by ownership"). Node runtime for the `pg` driver; force-dynamic because the
+ * response depends on the request's session cookie.
+ */
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(): Promise<Response> {
+  if (!servicesConfigured()) return servicesUnavailable();
+
+  const session = await getSession();
+  if (!session?.user) {
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }
+  const userId = Number(session.user.id);
+  if (!Number.isInteger(userId)) {
+    return Response.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const projects = await listProjects(userId);
+    return Response.json({ projects }, { status: 200 });
+  } catch (err) {
+    console.error("[synk] GET projects failed:", err instanceof Error ? err.message : "unknown error");
+    return Response.json(
+      { error: "internal_error", message: "Failed to list projects." },
+      { status: 500 },
+    );
+  }
+}

--- a/db/migrations/005_synk_tables.sql
+++ b/db/migrations/005_synk_tables.sql
@@ -1,0 +1,61 @@
+-- 005_synk_tables.sql
+--
+-- Synk: authenticated, one-way interval backups of local projects
+-- (docs/spec/services.md § Synk → Backup protocol, § Tier Enforcement Points,
+-- § Security & Privacy). Plain Postgres SQL: like the earlier migrations this
+-- file doubles as an Inkognito self-hosting setup script, so it must run
+-- unmodified against any Postgres (Neon, RDS, Supabase's Postgres, or a local
+-- instance).
+--
+-- Every statement uses IF NOT EXISTS so the file is safe to re-run by hand,
+-- independent of the `npm run db:migrate` bookkeeping (the CI services job runs
+-- the runner twice as an idempotency gate).
+--
+-- Ownership model (§ Synk → "Authorization is by ownership"): every row carries
+-- `user_id`; every query in lib/services/synk.ts filters on the session's user.
+-- App-layer authorization replaces the RLS concept from the superseded Supabase
+-- framing — same guarantee, enforced in one place. `user_id` foreign-keys the
+-- Auth.js `users` table (003_auth_tables.sql), whose ids are SERIAL/INTEGER, so
+-- the columns are `integer`. Account deletion cascades to all Synk rows
+-- (§ Security & Privacy → "Account deletion … cascades to all backups").
+
+-- One row per backed-up project, scoped to its owner. `id` is the client's own
+-- project id (from the bundle / URL path); it is NOT globally unique because two
+-- users can independently back up projects that share an id (e.g. the same seed
+-- project), so the primary key is the composite (user_id, id).
+create table if not exists synk_projects (
+  id         text        not null,
+  user_id    integer     not null references users(id) on delete cascade,
+  title      text        not null,   -- denormalized from project.title for listings
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (user_id, id)
+);
+
+-- One row per retained backup version. `bundle` holds the verbatim,
+-- schema-validated ProjectBundle JSON WITH its journal embedded — unlike Publik
+-- there is no strip; a backup is the user's private data and must round-trip
+-- history intact (§ Synk → "Journal included"). `sha256` is the server-computed
+-- hash of the canonical serialization (serializeBundle) — the truth used for
+-- content-hash dedupe; the client's `x-bundle-sha256` header is only a
+-- skip-early advisory. `entity_count` = nodes.length + edges.length, stored so
+-- listings need not re-parse the bundle.
+create table if not exists synk_backups (
+  id           text        primary key,
+  project_id   text        not null,
+  user_id      integer     not null references users(id) on delete cascade,
+  bundle       jsonb       not null,
+  sha256       text        not null,
+  size_bytes   int         not null,
+  entity_count int         not null,
+  created_at   timestamptz not null default now(),
+  -- Deleting a project (DELETE /api/synk/projects/{id}) removes all its backups.
+  foreign key (user_id, project_id)
+    references synk_projects (user_id, id) on delete cascade
+);
+
+-- Retention pruning, dedupe (latest hash), and per-project backup listings all
+-- read backups for one (user_id, project_id) newest-first; this index serves
+-- every one of them.
+create index if not exists synk_backups_project_created_idx
+  on synk_backups (user_id, project_id, created_at desc);

--- a/lib/services/limits.ts
+++ b/lib/services/limits.ts
@@ -1,0 +1,43 @@
+import "server-only";
+
+/**
+ * Tier limits — the server-side source of truth for Synk enforcement
+ * (docs/spec/services.md § Tier Enforcement Points).
+ *
+ * M4 builds the sockets Basik/Klub will plug into and nothing else. Enforcement
+ * lives in exactly two places, both in lib/services/synk.ts: the PUT backup
+ * handler (projects + entities) and the retention prune step (retention_days).
+ * `users.tier` selects the row; M4 has no path that sets it to anything but
+ * 'synk', but the lookup is real (getLimitsForTier) so M5's billing work only
+ * flips the column — it never touches enforcement.
+ */
+
+/**
+ * The tier → limits table, transcribed verbatim from the spec. `Infinity` for
+ * klub means "no cap": in synk.ts the entity/project comparisons are `actual >
+ * limit`, which is always false against Infinity, and retention pruning is
+ * skipped entirely when `retention_days` is not finite (so klub keeps every
+ * backup forever). Infinity never reaches a JSON response body — the only place
+ * a limit is serialized is the 403 rejection, which klub can never trigger.
+ */
+export const TIER_LIMITS = {
+  synk: { projects: 1, entities: 250, retention_days: 7 },
+  basik: { projects: 3, entities: 1000, retention_days: 30 },
+  klub: { projects: Infinity, entities: Infinity, retention_days: Infinity },
+} as const;
+
+export type Tier = keyof typeof TIER_LIMITS;
+export type TierLimits = (typeof TIER_LIMITS)[Tier];
+
+/**
+ * Resolve the limits row for a tier string read from `users.tier`. Unknown or
+ * missing tiers fall back to the most restrictive row (synk) — the safe default
+ * for a backup service: an unrecognized tier must never grant more than the
+ * free floor.
+ */
+export function getLimitsForTier(tier: string | null | undefined): TierLimits {
+  if (tier && Object.prototype.hasOwnProperty.call(TIER_LIMITS, tier)) {
+    return TIER_LIMITS[tier as Tier];
+  }
+  return TIER_LIMITS.synk;
+}

--- a/lib/services/synk.ts
+++ b/lib/services/synk.ts
@@ -1,0 +1,399 @@
+import "server-only";
+
+import { createHash, randomBytes } from "node:crypto";
+
+import {
+  parseBundle,
+  serializeBundle,
+  validateBundle,
+  type ProjectBundle,
+  type ValidationFinding,
+} from "@arkaik/schema";
+
+import { query } from "@/lib/services/db";
+import { getLimitsForTier } from "@/lib/services/limits";
+
+/**
+ * Server-side Synk logic (docs/spec/services.md § Synk). Kept out of the route
+ * handlers so the security-critical bits — user-scoped authorization, content-
+ * hash dedupe, tier-limit enforcement, and retention pruning — live in one
+ * audited place and can be integration-tested by importing this module or the
+ * handlers that call it (mirrors lib/services/publik.ts).
+ *
+ * Hard boundaries inherited from the spec, enforced here:
+ *  - One-way, browser-authoritative. The server stores what the client sends,
+ *    verbatim; it never re-projects, merges, or writes server state back down.
+ *  - Journal INCLUDED. Unlike Publik there is no strip — a backup is the user's
+ *    private data and must round-trip history intact (§ Synk → "Journal
+ *    included").
+ *  - Authorization is by ownership. Every row carries `user_id`; every query in
+ *    this module filters on the caller's user id (§ "Authorization is by
+ *    ownership"). No query is reachable that returns another user's rows.
+ *  - Every SQL statement is parameterized via the shared `query()` helper.
+ *
+ * ── Dedupe contract (§ "Content-hash dedupe") ──────────────────────────────
+ * The client serializes with the canonical `serializeBundle()` and MAY send the
+ * resulting sha256 in the `x-bundle-sha256` request header. That header is
+ * ADVISORY — a skip-early optimization only: when it equals the latest stored
+ * hash, the server short-circuits to `deduped` without re-validating. Otherwise
+ * the server recomputes the hash from its OWN canonicalization of the received
+ * body (`sha256(serializeBundle(bundle))`) and treats that server-computed hash
+ * as the single source of truth for both the dedupe comparison and the value
+ * persisted on the backup row. A lying or stale client header can only cause the
+ * client to skip storing its own change — never a wrong hash on disk.
+ */
+
+/** Header the client uses to advertise the canonical hash (skip-early only). */
+export const BUNDLE_SHA256_HEADER = "x-bundle-sha256";
+
+// ---------------------------------------------------------------------------
+// Availability (mirrors lib/services/publik.ts § graceful absence)
+// ---------------------------------------------------------------------------
+
+/** True when the services surface has a database configured. */
+export function servicesConfigured(): boolean {
+  return Boolean(process.env.DATABASE_URL);
+}
+
+/**
+ * 503 for when `DATABASE_URL` is unset: the local-first app still builds and
+ * serves, and the client gets a clear, non-crashing signal that hosted services
+ * are absent on this deployment (docs/spec/services.md § Backend — env vars).
+ */
+export function servicesUnavailable(): Response {
+  return Response.json(
+    {
+      error: "services_unavailable",
+      message: "arkaik services (Synk) are not configured on this deployment.",
+    },
+    { status: 503 },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Crypto / small helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Server-generated backup id: 16 random bytes (128-bit) as URL-safe base64 →
+ * 22 chars, no padding. Globally unique (its own primary key), unguessable, and
+ * non-sequential (mirrors publik.ts's snapshot id).
+ */
+export function generateBackupId(): string {
+  return randomBytes(16).toString("base64url");
+}
+
+/** SHA-256 hex of a string — used for the canonical-serialization content hash. */
+export function sha256Hex(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}
+
+/** Entity count for tier enforcement: nodes.length + edges.length (§ Limits). */
+export function countEntities(bundle: Record<string, unknown>): number {
+  const nodes = Array.isArray(bundle.nodes) ? bundle.nodes.length : 0;
+  const edges = Array.isArray(bundle.edges) ? bundle.edges.length : 0;
+  return nodes + edges;
+}
+
+// ---------------------------------------------------------------------------
+// Validation (mirrors lib/services/publik.ts's inbound gate)
+// ---------------------------------------------------------------------------
+
+export interface BundleValidation {
+  ok: boolean;
+  findings: ValidationFinding[];
+}
+
+function zodIssueToFinding(issue: { path: PropertyKey[]; code: string; message: string }): ValidationFinding {
+  return {
+    path: issue.path.map((p) => String(p)).join("."),
+    rule: issue.code,
+    message: issue.message,
+    severity: "error",
+  };
+}
+
+/**
+ * Full inbound gate: `parseBundle` (shape, zod) then `validateBundle` (semantic
+ * graph rules). Errors from either become structured findings for a 422; zod
+ * shape errors short-circuit the semantic pass. Warnings never fail — the server
+ * accepts conformance Levels 0–2 like every consumer.
+ */
+export function validateInboundBundle(input: unknown): BundleValidation {
+  const parsed = parseBundle(input);
+  if (!parsed.success) {
+    return { ok: false, findings: parsed.error.issues.map(zodIssueToFinding) };
+  }
+  const semantic = validateBundle(input);
+  if (!semantic.valid) {
+    return { ok: false, findings: semantic.errors };
+  }
+  return { ok: true, findings: [] };
+}
+
+// ---------------------------------------------------------------------------
+// Tier lookup
+// ---------------------------------------------------------------------------
+
+/**
+ * The caller's tier from `users.tier`. M4 has no path that sets it to anything
+ * but the 'synk' default, but the lookup is real so M5 billing only flips the
+ * column. A missing row (should not happen for a valid session) resolves to the
+ * safe 'synk' floor via getLimitsForTier.
+ */
+export async function getUserTier(userId: number): Promise<string> {
+  const { rows } = await query<{ tier: string }>(`select tier from users where id = $1`, [userId]);
+  return rows[0]?.tier ?? "synk";
+}
+
+// ---------------------------------------------------------------------------
+// Reads (every statement user-scoped)
+// ---------------------------------------------------------------------------
+
+export interface ProjectListing {
+  project_id: string;
+  title: string;
+  updated_at: string;
+  latest_backup_id: string | null;
+  latest_sha256: string | null;
+  latest_size_bytes: number | null;
+  latest_entity_count: number | null;
+  latest_created_at: string | null;
+}
+
+/** List the caller's backed-up projects with each project's latest backup metadata. */
+export async function listProjects(userId: number): Promise<ProjectListing[]> {
+  const { rows } = await query<ProjectListing>(
+    `select p.id                as project_id,
+            p.title             as title,
+            p.updated_at        as updated_at,
+            b.id                as latest_backup_id,
+            b.sha256            as latest_sha256,
+            b.size_bytes        as latest_size_bytes,
+            b.entity_count      as latest_entity_count,
+            b.created_at        as latest_created_at
+       from synk_projects p
+       left join lateral (
+         select id, sha256, size_bytes, entity_count, created_at
+           from synk_backups
+          where user_id = p.user_id and project_id = p.id
+          order by created_at desc
+          limit 1
+       ) b on true
+      where p.user_id = $1
+      order by p.updated_at desc`,
+    [userId],
+  );
+  return rows;
+}
+
+export interface BackupListing {
+  id: string;
+  created_at: string;
+  size_bytes: number;
+  entity_count: number;
+  sha256: string;
+}
+
+/**
+ * List the retained backup versions of one project (id, created_at, size,
+ * content hash), newest first. User-scoped: a project id belonging to another
+ * user yields an empty list, never their rows.
+ */
+export async function listBackups(userId: number, projectId: string): Promise<BackupListing[]> {
+  const { rows } = await query<BackupListing>(
+    `select id, created_at, size_bytes, entity_count, sha256
+       from synk_backups
+      where user_id = $1 and project_id = $2
+      order by created_at desc`,
+    [userId, projectId],
+  );
+  return rows;
+}
+
+/** True when the caller owns a project row with this id. */
+export async function projectExists(userId: number, projectId: string): Promise<boolean> {
+  const { rowCount } = await query(`select 1 from synk_projects where user_id = $1 and id = $2`, [
+    userId,
+    projectId,
+  ]);
+  return (rowCount ?? 0) > 0;
+}
+
+/**
+ * The stored bundle JSON for a backup id, or null when no such backup exists FOR
+ * THIS USER. The `user_id = $2` filter is the authorization boundary: a backup
+ * id owned by another user is indistinguishable from a missing one.
+ */
+export async function getBackupBundle(userId: number, backupId: string): Promise<unknown | null> {
+  const { rows } = await query<{ bundle: unknown }>(
+    `select bundle from synk_backups where id = $1 and user_id = $2`,
+    [backupId, userId],
+  );
+  return rows.length ? rows[0].bundle : null;
+}
+
+/**
+ * Delete a project and (via the composite cascade FK) all its backups. Returns
+ * true when a row was removed, false when the caller owns no such project.
+ */
+export async function deleteProject(userId: number, projectId: string): Promise<boolean> {
+  const { rowCount } = await query(`delete from synk_projects where user_id = $1 and id = $2`, [
+    userId,
+    projectId,
+  ]);
+  return (rowCount ?? 0) > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Retention
+// ---------------------------------------------------------------------------
+
+/**
+ * Prune backups older than `retentionDays` for one project in a single
+ * statement — except the newest backup per project, which is NEVER pruned
+ * regardless of age (§ Retention). Runs on every successful write (no cron), and
+ * is exported so it can be exercised directly in tests.
+ *
+ * The `id <> (newest)` subquery is what keeps the newest-even-when-stale row:
+ * if every backup is older than the window, the delete still spares the most
+ * recent one. Klub's `retention_days` is Infinity → not finite → we prune
+ * nothing (keep every backup forever), which also keeps `make_interval` from
+ * ever seeing a non-integer.
+ */
+export async function pruneRetention(
+  userId: number,
+  projectId: string,
+  retentionDays: number,
+): Promise<number> {
+  if (!Number.isFinite(retentionDays)) return 0;
+  const { rowCount } = await query(
+    `delete from synk_backups
+      where user_id = $1
+        and project_id = $2
+        and created_at < now() - make_interval(days => $3::int)
+        and id <> (
+          select id
+            from synk_backups
+           where user_id = $1 and project_id = $2
+           order by created_at desc
+           limit 1
+        )`,
+    [userId, projectId, retentionDays],
+  );
+  return rowCount ?? 0;
+}
+
+// ---------------------------------------------------------------------------
+// Write (PUT backup) — validation, dedupe, limits, store, prune
+// ---------------------------------------------------------------------------
+
+export type PutBackupResult =
+  | { status: "invalid"; findings: ValidationFinding[] }
+  | { status: "limit"; limit: number; actual: number; tier: string }
+  | { status: "deduped" }
+  | { status: "stored"; backupId: string };
+
+/** Latest stored content hash for a project, or null when it has no backups. */
+async function latestHash(userId: number, projectId: string): Promise<string | null> {
+  const { rows } = await query<{ sha256: string }>(
+    `select sha256 from synk_backups
+      where user_id = $1 and project_id = $2
+      order by created_at desc
+      limit 1`,
+    [userId, projectId],
+  );
+  return rows.length ? rows[0].sha256 : null;
+}
+
+/**
+ * Store a backup version for `projectId` owned by `userId`, or report why not.
+ * Order (§ Backup protocol): advisory skip → validate → dedupe → limits → store
+ * → prune.
+ *
+ *  1. If the client's advisory `clientHash` equals the latest stored hash, the
+ *     content is unchanged — short-circuit to `deduped` without re-validating.
+ *  2. Validate through @arkaik/schema; invalid → `invalid` (→ 422).
+ *  3. Recompute the server-truth hash from the canonical serialization and
+ *     compare to the latest stored hash; equal → `deduped` (→ 200). A no-op
+ *     re-backup is deduped BEFORE limits, so an unchanged bundle never 403s.
+ *  4. Enforce tier limits on the content actually being stored — entities
+ *     (nodes + edges) and, for a project new to this user, the project count.
+ *     Violation → `limit` (→ 403 with { limit, actual, tier }).
+ *  5. Upsert the project row, insert the backup (with the server-truth hash),
+ *     then prune retention. → `stored` (→ 201).
+ */
+export async function putBackup(args: {
+  userId: number;
+  projectId: string;
+  input: unknown;
+  clientHash?: string | null;
+}): Promise<PutBackupResult> {
+  const { userId, projectId, input, clientHash } = args;
+
+  const priorHash = await latestHash(userId, projectId);
+
+  // 1. Advisory skip-early: trust the client's claim of "nothing changed" only
+  //    to AVOID work, never to write. The prior bundle was validated when stored.
+  if (clientHash && priorHash && clientHash === priorHash) {
+    return { status: "deduped" };
+  }
+
+  // 2. Validate.
+  const validation = validateInboundBundle(input);
+  if (!validation.ok) {
+    return { status: "invalid", findings: validation.findings };
+  }
+  const bundle = input as Record<string, unknown>;
+
+  // 3. Server-truth hash + dedupe.
+  const canonical = serializeBundle(bundle as unknown as ProjectBundle);
+  const serverHash = sha256Hex(canonical);
+  if (priorHash && serverHash === priorHash) {
+    return { status: "deduped" };
+  }
+
+  // 4. Tier limits on what is about to be stored.
+  const tier = await getUserTier(userId);
+  const limits = getLimitsForTier(tier);
+
+  const entities = countEntities(bundle);
+  if (entities > limits.entities) {
+    return { status: "limit", limit: limits.entities, actual: entities, tier };
+  }
+
+  const isNewProject = !(await projectExists(userId, projectId));
+  if (isNewProject) {
+    const { rows } = await query<{ n: number }>(
+      `select count(*)::int as n from synk_projects where user_id = $1`,
+      [userId],
+    );
+    const wouldBe = Number(rows[0]?.n ?? 0) + 1;
+    if (wouldBe > limits.projects) {
+      return { status: "limit", limit: limits.projects, actual: wouldBe, tier };
+    }
+  }
+
+  // 5. Store: upsert project (denormalized title), insert backup, prune.
+  const project = (bundle.project ?? {}) as Record<string, unknown>;
+  const title = typeof project.title === "string" && project.title.trim() ? project.title : "Untitled";
+  const sizeBytes = Buffer.byteLength(canonical, "utf8");
+  const backupId = generateBackupId();
+
+  await query(
+    `insert into synk_projects (user_id, id, title)
+     values ($1, $2, $3)
+     on conflict (user_id, id) do update set title = excluded.title, updated_at = now()`,
+    [userId, projectId, title],
+  );
+
+  await query(
+    `insert into synk_backups (id, user_id, project_id, bundle, sha256, size_bytes, entity_count)
+     values ($1, $2, $3, $4, $5, $6, $7)`,
+    [backupId, userId, projectId, JSON.stringify(bundle), serverHash, sizeBytes, entities],
+  );
+
+  await pruneRetention(userId, projectId, limits.retention_days);
+
+  return { status: "stored", backupId };
+}

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "test:provider": "node tests/data/provider-registry.test.js && node tests/data/mutation-notifications.test.js",
     "test:cli": "npm run build -w arkaik && node tests/cli/run-cli-tests.js && node tests/cli/init.test.js && node tests/cli/log-release.test.js && node tests/cli/sync.test.js && node tests/cli/pack-open.test.js",
     "test:auth": "node tests/services/auth-guard.test.js",
-    "test:publik": "node tests/services/publik-api.test.js"
+    "test:publik": "node tests/services/publik-api.test.js",
+    "test:synk": "node tests/services/synk-api.test.js"
   },
   "dependencies": {
     "@auth/pg-adapter": "^1.11.2",

--- a/tests/services/load-synk-api.js
+++ b/tests/services/load-synk-api.js
@@ -1,0 +1,161 @@
+/**
+ * Loads the Synk route handlers (app/api/synk/**\/route.ts) plus their
+ * server-side deps (lib/services/synk.ts, lib/services/limits.ts,
+ * lib/services/db.ts) into a running Node process without a bundler — the same
+ * transpile-on-the-fly approach as tests/services/load-publik-api.js.
+ *
+ * The transpiled output goes into a build dir *inside the repo* (tests/services/
+ * .test-build-synk) so bare requires like `require("pg")` and
+ * `require("server-only")` resolve against the workspace node_modules. The
+ * non-relative app specifiers are rewritten to the built files:
+ *   - `@arkaik/schema`         → the CJS schema index (built via load-schema.js)
+ *   - `@/lib/services/db`      → ./db.js
+ *   - `@/lib/services/limits`  → ./limits.js
+ *   - `@/lib/services/synk`    → ./synk.js
+ *   - `@/lib/services/auth`    → ./auth-stub.js (a controllable getSession)
+ *
+ * Stubbing at the getSession boundary (exactly as tests/services/
+ * auth-guard.test.js does) is deliberate: the handlers' auth check is pure guard
+ * logic and needs no live OAuth round-trip or next-auth (ESM-only, un-requireable
+ * under this CommonJS transpile). The test controls the "current session" via
+ * `setSession()`; the DATABASE_URL path is the real Postgres.
+ *
+ * Returns the handler functions, a `setSession` control, and the transpiled synk
+ * service module (so retention pruning can be exercised directly).
+ */
+
+const fs = require("fs");
+const path = require("path");
+const ts = require("typescript");
+const { loadSchema, BUILD_DIR: SCHEMA_BUILD_DIR } = require("../schema/load-schema");
+
+const ROOT = path.join(__dirname, "..", "..");
+const BUILD_DIR = path.join(__dirname, ".test-build-synk");
+
+const COMPILER_OPTIONS = {
+  module: ts.ModuleKind.CommonJS,
+  target: ts.ScriptTarget.ES2020,
+  esModuleInterop: true,
+};
+
+function transpile(srcAbsPath, fileName, rewrites) {
+  const source = fs.readFileSync(srcAbsPath, "utf8");
+  let { outputText } = ts.transpileModule(source, { fileName, compilerOptions: COMPILER_OPTIONS });
+  for (const [specifier, replacement] of rewrites) {
+    const pattern = new RegExp(
+      `require\\((['"])${specifier.replace(/[.*+?^${}()|[\]\\/]/g, "\\$&")}\\1\\)`,
+      "g",
+    );
+    outputText = outputText.replace(pattern, `require(${JSON.stringify(replacement)})`);
+  }
+  return outputText;
+}
+
+function loadSynkApi() {
+  // Build @arkaik/schema so `require(...schema index)` resolves at runtime.
+  loadSchema();
+  const schemaIndex = path.join(SCHEMA_BUILD_DIR, "index.js");
+
+  fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+  fs.mkdirSync(BUILD_DIR, { recursive: true });
+  fs.writeFileSync(path.join(BUILD_DIR, "package.json"), JSON.stringify({ type: "commonjs" }));
+
+  const write = (name, text) => fs.writeFileSync(path.join(BUILD_DIR, name), text);
+
+  // `server-only` throws outside a React Server Component; stub it to a no-op so
+  // the modules load in plain Node (same as load-publik-api.js).
+  const serverOnlyStub = "./server-only-stub.js";
+  write("server-only-stub.js", "module.exports = {};\n");
+
+  // Controllable session stub for `@/lib/services/auth`. The test drives it via
+  // the returned setSession(); default is unauthenticated (null).
+  write(
+    "auth-stub.js",
+    "let current = null;\n" +
+      "module.exports = {\n" +
+      "  getSession: async () => current,\n" +
+      "  __setSession: (s) => { current = s; },\n" +
+      "};\n",
+  );
+
+  // lib/services/db.ts — stub `server-only`; bare `pg` require resolves as-is.
+  write(
+    "db.js",
+    transpile(path.join(ROOT, "lib", "services", "db.ts"), "db.ts", [["server-only", serverOnlyStub]]),
+  );
+
+  // lib/services/limits.ts — stub `server-only`.
+  write(
+    "limits.js",
+    transpile(path.join(ROOT, "lib", "services", "limits.ts"), "limits.ts", [
+      ["server-only", serverOnlyStub],
+    ]),
+  );
+
+  // lib/services/synk.ts — rewrite schema + db + limits + server-only specifiers.
+  write(
+    "synk.js",
+    transpile(path.join(ROOT, "lib", "services", "synk.ts"), "synk.ts", [
+      ["@arkaik/schema", schemaIndex],
+      ["@/lib/services/db", "./db.js"],
+      ["@/lib/services/limits", "./limits.js"],
+      ["server-only", serverOnlyStub],
+    ]),
+  );
+
+  // Route handlers — rewrite the auth + synk specifiers.
+  const routeRewrites = [
+    ["@/lib/services/auth", "./auth-stub.js"],
+    ["@/lib/services/synk", "./synk.js"],
+  ];
+  write(
+    "projects.js",
+    transpile(path.join(ROOT, "app", "api", "synk", "projects", "route.ts"), "route.ts", routeRewrites),
+  );
+  write(
+    "project.js",
+    transpile(
+      path.join(ROOT, "app", "api", "synk", "projects", "[projectId]", "route.ts"),
+      "route.ts",
+      routeRewrites,
+    ),
+  );
+  write(
+    "backups.js",
+    transpile(
+      path.join(ROOT, "app", "api", "synk", "projects", "[projectId]", "backups", "route.ts"),
+      "route.ts",
+      routeRewrites,
+    ),
+  );
+  write(
+    "backup.js",
+    transpile(
+      path.join(ROOT, "app", "api", "synk", "backups", "[backupId]", "route.ts"),
+      "route.ts",
+      routeRewrites,
+    ),
+  );
+
+  const names = ["db.js", "limits.js", "synk.js", "auth-stub.js", "projects.js", "project.js", "backups.js", "backup.js"];
+  for (const name of names) delete require.cache[path.join(BUILD_DIR, name)];
+
+  const authStub = require(path.join(BUILD_DIR, "auth-stub.js"));
+  const synk = require(path.join(BUILD_DIR, "synk.js"));
+  const projectsRoute = require(path.join(BUILD_DIR, "projects.js"));
+  const projectRoute = require(path.join(BUILD_DIR, "project.js"));
+  const backupsRoute = require(path.join(BUILD_DIR, "backups.js"));
+  const backupRoute = require(path.join(BUILD_DIR, "backup.js"));
+
+  return {
+    LIST_PROJECTS: projectsRoute.GET,
+    PUT_BACKUP: projectRoute.PUT,
+    DELETE_PROJECT: projectRoute.DELETE,
+    LIST_BACKUPS: backupsRoute.GET,
+    GET_BACKUP: backupRoute.GET,
+    setSession: authStub.__setSession,
+    synk,
+  };
+}
+
+module.exports = { loadSynkApi, BUILD_DIR, SCHEMA_BUILD_DIR };

--- a/tests/services/synk-api.test.js
+++ b/tests/services/synk-api.test.js
@@ -1,0 +1,372 @@
+#!/usr/bin/env node
+
+/**
+ * Integration tests for the Synk API (docs/spec/services.md § Synk, § CI
+ * Additions). The route handlers are invoked directly with real `Request`
+ * objects against a real Postgres (the CI "services" job's Postgres 16 container,
+ * or a local instance) whose schema was applied by `npm run db:migrate`. The
+ * `getSession()` seam is stubbed at the module boundary (as
+ * tests/services/auth-guard.test.js does) so `setSession()` picks the acting
+ * user without a live OAuth round-trip.
+ *
+ * Coverage (the acceptance list from issue #242):
+ *   - authz isolation: user B cannot read user A's projects/backups
+ *   - content-hash dedupe (server-truth hash AND the advisory client header)
+ *   - tier-limit rejection: entities and projects → 403 { limit, actual, tier }
+ *   - retention prune keeps the newest backup even when it is itself stale
+ *   - plus: store round-trip, DELETE cascade, unauthenticated → 401
+ *
+ * Two users are seeded directly in SQL so the isolation test has genuinely
+ * distinct owners. All test rows use the `synktest-%@example.com` email pattern
+ * and are cleaned up (cascading to synk rows) at start and end, so local re-runs
+ * are idempotent.
+ */
+
+const { Client } = require("pg");
+const { loadSynkApi, BUILD_DIR, SCHEMA_BUILD_DIR } = require("./load-synk-api");
+const fs = require("fs");
+
+const ORIGIN = "https://synk.test";
+
+let failures = 0;
+function check(name, cond, detail) {
+  if (cond) {
+    console.log(`PASS: ${name}`);
+  } else {
+    failures++;
+    console.log(`FAIL: ${name}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+/** A valid ProjectBundle with `nodeCount` view nodes (each a distinct entity). */
+function makeBundle(projectId, nodeCount = 1, extra = {}) {
+  const nodes = [];
+  for (let i = 0; i < nodeCount; i++) {
+    nodes.push({
+      id: `V-n${i}`,
+      project_id: projectId,
+      species: "view",
+      title: `Node ${i}`,
+      status: "idea",
+      platforms: ["web"],
+    });
+  }
+  return {
+    project: {
+      id: projectId,
+      title: `Project ${projectId}`,
+      version: "1.0.0",
+      created_at: "2026-01-01T00:00:00.000Z",
+      updated_at: "2026-01-01T00:00:00.000Z",
+    },
+    nodes,
+    edges: [],
+    ...extra,
+  };
+}
+
+function putReq(bundle, { header } = {}) {
+  const headers = { "content-type": "application/json" };
+  if (header) headers["x-bundle-sha256"] = header;
+  return new Request(`${ORIGIN}/api/synk/projects/x`, {
+    method: "PUT",
+    headers,
+    body: JSON.stringify(bundle),
+  });
+}
+
+function bareReq(method) {
+  return new Request(`${ORIGIN}/api/synk`, { method });
+}
+
+const projectCtx = (projectId) => ({ params: Promise.resolve({ projectId }) });
+const backupCtx = (backupId) => ({ params: Promise.resolve({ backupId }) });
+
+async function seedUser(client, label) {
+  const email = `synktest-${label}-${Date.now()}-${Math.random().toString(36).slice(2)}@example.com`;
+  const { rows } = await client.query(
+    `insert into users (name, email) values ($1, $2) returning id`,
+    [`synktest ${label}`, email],
+  );
+  return rows[0].id;
+}
+
+async function main() {
+  if (!process.env.DATABASE_URL) {
+    console.error(
+      "\n[synk-api.test] DATABASE_URL is not set. These integration tests require a " +
+        "migrated Postgres (the CI services job sets it; locally, start Postgres and " +
+        "`npm run db:migrate` first). Refusing to pass silently.",
+    );
+    process.exit(1);
+  }
+
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+
+  // Idempotent local re-runs: purge any prior test users (cascades to synk rows).
+  await client.query(`delete from users where email like 'synktest-%@example.com'`);
+
+  const { LIST_PROJECTS, PUT_BACKUP, DELETE_PROJECT, LIST_BACKUPS, GET_BACKUP, setSession, synk } =
+    loadSynkApi();
+
+  const asUser = (id) => setSession(id == null ? null : { user: { id: String(id) } });
+
+  try {
+    // --- 0. store round-trip + list + fetch --------------------------------
+    {
+      const uid = await seedUser(client, "roundtrip");
+      asUser(uid);
+      const res = await PUT_BACKUP(putReq(makeBundle("p-round", 2)), projectCtx("p-round"));
+      const body = await res.json();
+      check("store returns 201", res.status === 201, `status ${res.status}`);
+      check("store body reports deduped:false + backup id", body.deduped === false && typeof body.id === "string", JSON.stringify(body));
+
+      const listRes = await LIST_PROJECTS();
+      const listBody = await listRes.json();
+      check("list projects returns 200", listRes.status === 200, `status ${listRes.status}`);
+      check(
+        "list projects shows the backed-up project with latest metadata",
+        Array.isArray(listBody.projects) &&
+          listBody.projects.length === 1 &&
+          listBody.projects[0].project_id === "p-round" &&
+          listBody.projects[0].latest_entity_count === 2,
+        JSON.stringify(listBody.projects),
+      );
+
+      const backupsRes = await LIST_BACKUPS(bareReq("GET"), projectCtx("p-round"));
+      const backupsBody = await backupsRes.json();
+      check(
+        "list backups returns one version with hash + size + entity_count",
+        backupsRes.status === 200 &&
+          backupsBody.backups.length === 1 &&
+          typeof backupsBody.backups[0].sha256 === "string" &&
+          backupsBody.backups[0].entity_count === 2,
+        JSON.stringify(backupsBody),
+      );
+
+      const getRes = await GET_BACKUP(bareReq("GET"), backupCtx(body.id));
+      const fetched = await getRes.json();
+      check("get backup returns the stored bundle verbatim", getRes.status === 200 && fetched.project.id === "p-round", JSON.stringify(fetched.project));
+      check("backup keeps its journal-capable bundle (nodes intact)", Array.isArray(fetched.nodes) && fetched.nodes.length === 2);
+    }
+
+    // --- 1. content-hash dedupe --------------------------------------------
+    {
+      const uid = await seedUser(client, "dedupe");
+      asUser(uid);
+      const bundle = makeBundle("p-dupe", 3);
+
+      const first = await PUT_BACKUP(putReq(bundle), projectCtx("p-dupe"));
+      check("dedupe: first store is 201", first.status === 201, `status ${first.status}`);
+
+      // Server recomputes the hash from its own canonicalization → dedupe.
+      const second = await PUT_BACKUP(putReq(bundle), projectCtx("p-dupe"));
+      const secondBody = await second.json();
+      check("dedupe: identical re-backup returns 200", second.status === 200, `status ${second.status}`);
+      check("dedupe: 200 body reports deduped:true", secondBody.deduped === true, JSON.stringify(secondBody));
+
+      // Advisory client header equal to the stored hash → early skip, also 200.
+      const { rows } = await client.query(
+        `select sha256 from synk_backups where user_id = $1 and project_id = $2 order by created_at desc limit 1`,
+        [uid, "p-dupe"],
+      );
+      const storedHash = rows[0].sha256;
+      const third = await PUT_BACKUP(putReq(bundle, { header: storedHash }), projectCtx("p-dupe"));
+      const thirdBody = await third.json();
+      check("dedupe: matching x-bundle-sha256 header returns 200 deduped", third.status === 200 && thirdBody.deduped === true, JSON.stringify(thirdBody));
+
+      const { rows: countRows } = await client.query(
+        `select count(*)::int as n from synk_backups where user_id = $1 and project_id = $2`,
+        [uid, "p-dupe"],
+      );
+      check("dedupe: no extra backup rows were stored", countRows[0].n === 1, `rows ${countRows[0].n}`);
+
+      // A genuine change stores a new version.
+      const changed = await PUT_BACKUP(putReq(makeBundle("p-dupe", 4)), projectCtx("p-dupe"));
+      check("dedupe: a changed bundle stores a new version (201)", changed.status === 201, `status ${changed.status}`);
+      const { rows: after } = await client.query(
+        `select count(*)::int as n from synk_backups where user_id = $1 and project_id = $2`,
+        [uid, "p-dupe"],
+      );
+      check("dedupe: changed bundle added exactly one version", after[0].n === 2, `rows ${after[0].n}`);
+    }
+
+    // --- 2. tier-limit rejection: entities ---------------------------------
+    {
+      const uid = await seedUser(client, "entlimit");
+      asUser(uid);
+      // 251 nodes → 251 entities, over the synk cap of 250.
+      const res = await PUT_BACKUP(putReq(makeBundle("p-ent", 251)), projectCtx("p-ent"));
+      const body = await res.json();
+      check("entities over limit returns 403", res.status === 403, `status ${res.status}`);
+      check(
+        "403 body carries { limit, actual, tier }",
+        body.limit === 250 && body.actual === 251 && body.tier === "synk",
+        JSON.stringify(body),
+      );
+      const { rows } = await client.query(`select count(*)::int as n from synk_backups where user_id = $1`, [uid]);
+      check("rejected over-limit backup stored nothing", rows[0].n === 0, `rows ${rows[0].n}`);
+    }
+
+    // --- 3. tier-limit rejection: projects ---------------------------------
+    {
+      const uid = await seedUser(client, "projlimit");
+      asUser(uid);
+      const first = await PUT_BACKUP(putReq(makeBundle("p-a", 1)), projectCtx("p-a"));
+      check("projects limit: first project stores (201)", first.status === 201, `status ${first.status}`);
+      // Second DISTINCT project would make 2 > synk cap of 1.
+      const second = await PUT_BACKUP(putReq(makeBundle("p-b", 1)), projectCtx("p-b"));
+      const body = await second.json();
+      check("second distinct project returns 403", second.status === 403, `status ${second.status}`);
+      check(
+        "projects 403 body carries { limit:1, actual:2, tier:synk }",
+        body.limit === 1 && body.actual === 2 && body.tier === "synk",
+        JSON.stringify(body),
+      );
+      // Re-backing the EXISTING project is not a new project → allowed.
+      const reBackup = await PUT_BACKUP(putReq(makeBundle("p-a", 2)), projectCtx("p-a"));
+      check("re-backing an existing project is allowed (201)", reBackup.status === 201, `status ${reBackup.status}`);
+    }
+
+    // --- 4. authz isolation: user B cannot read user A's rows --------------
+    {
+      const userA = await seedUser(client, "isoA");
+      const userB = await seedUser(client, "isoB");
+
+      // Both back up a project with the SAME client-chosen id.
+      asUser(userA);
+      const aRes = await PUT_BACKUP(putReq(makeBundle("shared", 2)), projectCtx("shared"));
+      const aBody = await aRes.json();
+      check("isolation: user A stores backup", aRes.status === 201, `status ${aRes.status}`);
+      const aBackupId = aBody.id;
+
+      asUser(userB);
+      const bRes = await PUT_BACKUP(putReq(makeBundle("shared", 3)), projectCtx("shared"));
+      const bBody = await bRes.json();
+      check("isolation: user B stores backup under same project id", bRes.status === 201, `status ${bRes.status}`);
+      const bBackupId = bBody.id;
+
+      // User B lists backups for "shared": only their own row.
+      const bList = await LIST_BACKUPS(bareReq("GET"), projectCtx("shared"));
+      const bListBody = await bList.json();
+      check(
+        "isolation: user B sees only their own backup for the shared project id",
+        bListBody.backups.length === 1 && bListBody.backups[0].id === bBackupId,
+        JSON.stringify(bListBody.backups),
+      );
+
+      // User B cannot fetch user A's backup by id → 404.
+      const bGetA = await GET_BACKUP(bareReq("GET"), backupCtx(aBackupId));
+      check("isolation: user B GET of user A's backup id is 404", bGetA.status === 404, `status ${bGetA.status}`);
+
+      // User A can still fetch their own.
+      asUser(userA);
+      const aGetA = await GET_BACKUP(bareReq("GET"), backupCtx(aBackupId));
+      check("isolation: user A can fetch their own backup", aGetA.status === 200, `status ${aGetA.status}`);
+
+      // User A's project list does not leak user B's rows.
+      const aProjects = await (await LIST_PROJECTS()).json();
+      check(
+        "isolation: user A's project list is scoped to user A",
+        aProjects.projects.length === 1 && aProjects.projects[0].latest_backup_id === aBackupId,
+        JSON.stringify(aProjects.projects),
+      );
+
+      // User B deleting "shared" removes only B's rows; A's survive.
+      asUser(userB);
+      const bDel = await DELETE_PROJECT(bareReq("DELETE"), projectCtx("shared"));
+      check("isolation: user B deletes their project (204)", bDel.status === 204, `status ${bDel.status}`);
+      asUser(userA);
+      const aStill = await GET_BACKUP(bareReq("GET"), backupCtx(aBackupId));
+      check("isolation: user A's backup survives user B's delete", aStill.status === 200, `status ${aStill.status}`);
+
+      // Delete cascade: after A deletes their project, its backups are gone.
+      const aDel = await DELETE_PROJECT(bareReq("DELETE"), projectCtx("shared"));
+      check("delete: user A deletes their project (204)", aDel.status === 204, `status ${aDel.status}`);
+      const { rows: gone } = await client.query(`select count(*)::int as n from synk_backups where id = $1`, [aBackupId]);
+      check("delete cascade removes the project's backups", gone[0].n === 0, `rows ${gone[0].n}`);
+      const aGone = await GET_BACKUP(bareReq("GET"), backupCtx(aBackupId));
+      check("delete: fetching a deleted backup is 404", aGone.status === 404, `status ${aGone.status}`);
+    }
+
+    // --- 5. retention prune keeps the newest even when stale ---------------
+    {
+      const uid = await seedUser(client, "retain");
+      // Seed the project + three backups directly, ALL older than the 7-day
+      // window (10, 9, 8 days ago). No fresh backup is written, so the newest
+      // retained row (8 days ago) is itself stale.
+      await client.query(`insert into synk_projects (user_id, id, title) values ($1, $2, $3)`, [uid, "p-old", "Old"]);
+      const seedBackup = async (id, daysAgo) =>
+        client.query(
+          `insert into synk_backups (id, user_id, project_id, bundle, sha256, size_bytes, entity_count, created_at)
+           values ($1, $2, $3, '{}'::jsonb, $4, 2, 1, now() - make_interval(days => $5::int))`,
+          [id, uid, "p-old", `hash-${daysAgo}`, daysAgo],
+        );
+      await seedBackup("b-10", 10);
+      await seedBackup("b-9", 9);
+      await seedBackup("b-8", 8); // newest (least days ago), still > 7 days → stale
+
+      const pruned = await synk.pruneRetention(uid, "p-old", 7);
+      check("retention: prune removed the two older stale backups", pruned === 2, `pruned ${pruned}`);
+
+      const { rows } = await client.query(
+        `select id from synk_backups where user_id = $1 and project_id = $2 order by created_at desc`,
+        [uid, "p-old"],
+      );
+      check(
+        "retention: the newest backup survives even though it is itself stale",
+        rows.length === 1 && rows[0].id === "b-8",
+        JSON.stringify(rows),
+      );
+
+      // And pruning runs on write: seed two more stale rows, then a real PUT
+      // (fresh, distinct content) prunes every now-stale row but its own.
+      await seedBackup("b-6", 6);
+      await seedBackup("b-5", 5);
+      asUser(uid);
+      const wRes = await PUT_BACKUP(putReq(makeBundle("p-old", 2)), projectCtx("p-old"));
+      check("retention-on-write: fresh backup stores (201)", wRes.status === 201, `status ${wRes.status}`);
+      const { rows: afterWrite } = await client.query(
+        `select id from synk_backups where user_id = $1 and project_id = $2`,
+        [uid, "p-old"],
+      );
+      // Only the just-written fresh backup remains: b-8 (8d), b-6 (6d), b-5 (5d)
+      // were all < now()-7d? b-6 and b-5 are inside the window, so they survive
+      // too. Assert the fresh one is present and the >7d ones (b-8) are gone.
+      const ids = afterWrite.map((r) => r.id);
+      check("retention-on-write: the stale >7d backup (b-8) was pruned", !ids.includes("b-8"), JSON.stringify(ids));
+      check("retention-on-write: in-window backups (b-6, b-5) survive", ids.includes("b-6") && ids.includes("b-5"), JSON.stringify(ids));
+    }
+
+    // --- 6. unauthenticated → 401 ------------------------------------------
+    {
+      asUser(null);
+      const listRes = await LIST_PROJECTS();
+      check("unauthenticated list projects is 401", listRes.status === 401, `status ${listRes.status}`);
+      const putRes = await PUT_BACKUP(putReq(makeBundle("nope", 1)), projectCtx("nope"));
+      check("unauthenticated PUT is 401", putRes.status === 401, `status ${putRes.status}`);
+      const getRes = await GET_BACKUP(bareReq("GET"), backupCtx("whatever"));
+      check("unauthenticated GET backup is 401", getRes.status === 401, `status ${getRes.status}`);
+      const delRes = await DELETE_PROJECT(bareReq("DELETE"), projectCtx("nope"));
+      check("unauthenticated DELETE is 401", delRes.status === 401, `status ${delRes.status}`);
+    }
+  } finally {
+    // Clean up all test rows (cascades to synk_projects + synk_backups).
+    await client.query(`delete from users where email like 'synktest-%@example.com'`);
+    await client.end();
+    fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+    fs.rmSync(SCHEMA_BUILD_DIR, { recursive: true, force: true });
+  }
+
+  if (failures > 0) {
+    console.log(`\n${failures} synk-api test(s) failed.`);
+    process.exit(1);
+  }
+  console.log("\nAll synk-api integration tests passed.");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Implements the Synk backup service (docs/spec/services.md § Synk). One-way, browser-authoritative, no server re-projection; the journal is **included** (private data, unlike Publik).

- **Migration `005_synk_tables.sql`** — `synk_projects` + `synk_backups`, user-scoped and `on delete cascade` from `users(id)` (SERIAL/INTEGER). `synk_projects` uses a composite PK `(user_id, id)` because client project ids are not globally unique (two users can back up projects that share an id); `synk_backups` cascades from its project via a composite FK too. Plain, idempotent Postgres.
- **`lib/services/limits.ts`** — `TIER_LIMITS` (synk/basik/klub) transcribed verbatim from the spec + `getLimitsForTier()` with a safe `synk` floor. `users.tier` selects the row; M4 only ever yields `synk` but the lookup is real.
- **`lib/services/synk.ts`** — validation gate, user-scoped reads, dedupe, tier-limit enforcement, retention pruning, all in one audited module (mirrors `publik.ts`).
- **Route handlers** — `PUT`/`DELETE /api/synk/projects/{projectId}`, `GET /api/synk/projects`, `GET /api/synk/projects/{projectId}/backups`, `GET /api/synk/backups/{backupId}`. Node runtime, web-standard `Response.json`. 503 when `DATABASE_URL` is unset; 401 via the #241 `getSession()` helper; **every query filtered by the session `user_id`**.

### Behavior notes

- **Dedupe**: the client MAY send `x-bundle-sha256` (documented in the `synk.ts` doc comment). It is **advisory** — a skip-early optimization only. The server recomputes the hash from its own canonicalization (`sha256(serializeBundle(bundle))`) and treats that server-computed hash as the truth for both the dedupe comparison and the value stored on the backup row. Match → `200 { deduped: true }`; otherwise a new version → `201 { id, deduped: false }`.
- **PUT order**: advisory skip → `@arkaik/schema` validate (422) → dedupe (200) → tier limits (403 `{ limit, actual, tier }`) → store → prune. A no-op re-backup is deduped before limits, so an unchanged bundle never 403s.
- **Limits**: entity count = `nodes.length + edges.length`; project limit counts distinct projects and only rejects a *new* project that would exceed the cap.
- **Retention**: single `DELETE` on every successful write removing backups older than `retention_days`, except the newest per project (never pruned, even when itself stale). Klub's `Infinity` retention skips pruning entirely.

## Verification

- `npm run lint` — clean (only pre-existing warnings in untouched `components/`).
- `npm run build` with **no** services env vars — succeeds; all four Synk routes register as dynamic (graceful absence holds).
- `npm run generate` + drift gate — no drift.
- Local Postgres 16: `npm run db:migrate` applies 001–005 and is a no-op on re-run (idempotency gate). `npm run test:synk` — **41/41 checks pass** (authz isolation, dedupe via server hash + client header, entity & project limit rejection, retention keeps-newest-when-stale + on-write pruning, DELETE cascade, 401 unauthenticated).
- Full existing battery green: `test:auth`, `test:publik`, `test:schema`, `test:serialize`, `test:refs`, `test:journal`, `test:journal-projections`, `test:emit`, `test:emit-events`, `test:screenshot-size`, `test:id-gen`, `test:migrate`, `test:provider`, `test:fixtures`, `test:cli`, `validate:seeds`.

## Scope

No changes to `app/p/**`, `packages/cli/**`, Publish UI, or `lib/services/publik.ts`. `package.json` / `ci.yml` touched only to add the `test:synk` script line and one services CI step.

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QpXVmp8QNHQF3s2cCvtead)_