### PR TITLE
M4: Publik surfaces — /p/{id} preview page and in-app Publish action

### DIFF
--- a/app/p/[id]/not-found.tsx
+++ b/app/p/[id]/not-found.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+import { ArkaikLogo } from "@/components/branding/ArkaikLogo";
+import { ThemeToggle } from "@/components/theme-toggle";
+
+/**
+ * 404 state for `/p/{id}` when the snapshot id does not exist (docs/spec/services.md
+ * § Publik → Surfaces: "404 state for missing ids"). Triggered by `notFound()`
+ * in `app/p/[id]/page.tsx` — a missing/removed id and a malformed one both land
+ * here, since Publik reads are by unguessable id only (no listing endpoint to
+ * distinguish "never existed" from "removed").
+ */
+export default function PublikSnapshotNotFound() {
+  return (
+    <div className="flex min-h-svh flex-col bg-background font-sans">
+      <header className="flex items-center justify-between border-b px-6 py-3">
+        <Link href="/" aria-label="Go to arkaik home" className="inline-flex items-center">
+          <ArkaikLogo className="w-20 shrink-0" />
+        </Link>
+        <ThemeToggle />
+      </header>
+      <main className="mx-auto flex w-full max-w-md flex-1 flex-col items-center justify-center gap-3 p-6 text-center">
+        <h1 className="text-lg font-semibold">Snapshot not found</h1>
+        <p className="text-sm text-muted-foreground">
+          This link doesn&apos;t point to a snapshot we have — it may have been removed, or the URL may be
+          incorrect. Publik snapshots carry no retention guarantee.
+        </p>
+        <Link href="/" className="text-sm underline underline-offset-4">
+          Back to arkaik
+        </Link>
+      </main>
+    </div>
+  );
+}

--- a/app/p/[id]/page.tsx
+++ b/app/p/[id]/page.tsx
@@ -1,0 +1,201 @@
+import type { Metadata } from "next";
+import { cache } from "react";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { CalendarIcon, GitBranchIcon, ImageOffIcon, InfoIcon, WorkflowIcon } from "lucide-react";
+
+import { ArkaikLogo } from "@/components/branding/ArkaikLogo";
+import { ThemeToggle } from "@/components/theme-toggle";
+import { Badge } from "@/components/ui/badge";
+import { ImportSnapshotButton } from "@/components/publik/ImportSnapshotButton";
+import { fetchSnapshotSummary, servicesConfigured, type SnapshotSummary } from "@/lib/services/publik";
+import { summarizeBundle, type ConformanceLevel } from "@/lib/utils/publik-preview";
+
+/**
+ * `/p/{id}` — the human-facing half of Publik (docs/spec/services.md § Publik
+ * → Surfaces). A *preview* page, not a server-rendered graph: full read-only
+ * rendering needs the provider-injection seam and is out of M4 scope. This
+ * page shows just enough to decide whether to import — title, description,
+ * node/edge counts, a format-level badge, the created date, the no-retention
+ * disclaimer, and the "Import into arkaik" action.
+ *
+ * Node runtime + force-dynamic: reads Postgres directly through
+ * lib/services/publik.ts (same process, no HTTP self-call) and must never be
+ * statically prerendered — the snapshot is a runtime fact.
+ */
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface PublikSnapshotPageProps {
+  params: Promise<{ id: string }>;
+}
+
+type SnapshotLookup =
+  | { status: "unconfigured" }
+  | { status: "not-found" }
+  | { status: "error" }
+  | { status: "found"; summary: SnapshotSummary };
+
+/**
+ * `cache()` dedupes the Postgres lookup within a single request — both
+ * `generateMetadata` and the page component need it, and React's per-request
+ * cache means it only actually runs once.
+ */
+const lookupSnapshot = cache(async (id: string): Promise<SnapshotLookup> => {
+  if (!servicesConfigured()) return { status: "unconfigured" };
+  try {
+    const summary = await fetchSnapshotSummary(id);
+    return summary ? { status: "found", summary } : { status: "not-found" };
+  } catch (err) {
+    console.error("[p/[id]] Failed to fetch snapshot:", err instanceof Error ? err.message : "unknown error");
+    return { status: "error" };
+  }
+});
+
+const LEVEL_LABELS: Record<ConformanceLevel, string> = {
+  0: "Level 0 · Static snapshot",
+  1: "Level 1 · Versioned snapshot",
+  2: "Level 2 · Snapshot + journal",
+};
+
+export async function generateMetadata({ params }: PublikSnapshotPageProps): Promise<Metadata> {
+  const { id } = await params;
+  const lookup = await lookupSnapshot(id);
+
+  if (lookup.status !== "found") {
+    return { title: "Shared project | arkaik" };
+  }
+
+  const { title, description } = summarizeBundle(lookup.summary.bundle);
+  return {
+    title: `${title} | arkaik`,
+    description: description ?? `A shared arkaik product graph: ${title}.`,
+    // Unlisted by design (docs/spec/services.md § Security & Privacy: "reads
+    // are by unguessable id only") — keep snapshots out of search indexes.
+    robots: { index: false, follow: false },
+  };
+}
+
+function formatCreatedDate(iso: string): string {
+  try {
+    return new Intl.DateTimeFormat("en-US", { dateStyle: "medium" }).format(new Date(iso));
+  } catch {
+    return iso;
+  }
+}
+
+function PageChrome({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-svh flex-col bg-background font-sans">
+      <header className="flex items-center justify-between border-b px-6 py-3">
+        <Link href="/" aria-label="Go to arkaik home" className="inline-flex items-center">
+          <ArkaikLogo className="w-20 shrink-0" />
+        </Link>
+        <ThemeToggle />
+      </header>
+      {children}
+    </div>
+  );
+}
+
+function MessageShell({ title, description }: { title: string; description: string }) {
+  return (
+    <PageChrome>
+      <main className="mx-auto flex w-full max-w-md flex-1 flex-col items-center justify-center gap-3 p-6 text-center">
+        <h1 className="text-lg font-semibold">{title}</h1>
+        <p className="text-sm text-muted-foreground">{description}</p>
+        <Link href="/" className="text-sm underline underline-offset-4">
+          Back to arkaik
+        </Link>
+      </main>
+    </PageChrome>
+  );
+}
+
+export default async function PublikSnapshotPage({ params }: PublikSnapshotPageProps) {
+  const { id } = await params;
+  const lookup = await lookupSnapshot(id);
+
+  if (lookup.status === "unconfigured") {
+    return (
+      <MessageShell
+        title="Sharing is not available"
+        description="This arkaik deployment does not have hosted sharing (Publik) configured. Ask the site operator to set DATABASE_URL to enable shared snapshots."
+      />
+    );
+  }
+
+  if (lookup.status === "error") {
+    return (
+      <MessageShell
+        title="Something went wrong"
+        description="This snapshot could not be loaded right now. Please try again shortly."
+      />
+    );
+  }
+
+  if (lookup.status === "not-found") {
+    notFound();
+  }
+
+  const { summary } = lookup;
+  const { title, description, nodeCount, edgeCount, conformanceLevel, previewAsset } = summarizeBundle(
+    summary.bundle,
+  );
+
+  return (
+    <PageChrome>
+      <main className="mx-auto flex w-full max-w-2xl flex-1 flex-col gap-6 p-6">
+        <div className="overflow-hidden rounded-xl border bg-card">
+          {previewAsset.kind === "image" ? (
+            // eslint-disable-next-line @next/next/no-img-element -- arbitrary data:/absolute-URL source, not a static/optimizable asset
+            <img src={previewAsset.src} alt={`${title} preview`} className="h-56 w-full object-cover" />
+          ) : previewAsset.kind === "placeholder" ? (
+            <div className="flex h-56 w-full flex-col items-center justify-center gap-2 bg-muted text-muted-foreground">
+              <ImageOffIcon className="size-8" />
+              <p className="text-xs">Preview image not available in this view</p>
+            </div>
+          ) : null}
+
+          <div className="flex flex-col gap-4 p-6">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div className="space-y-1">
+                <h1 className="text-2xl font-semibold">{title}</h1>
+                {description && <p className="text-sm text-muted-foreground">{description}</p>}
+              </div>
+              <Badge variant="secondary" className="shrink-0">
+                {LEVEL_LABELS[conformanceLevel]}
+              </Badge>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
+              <span className="inline-flex items-center gap-1.5">
+                <WorkflowIcon className="size-4" />
+                {nodeCount} node{nodeCount === 1 ? "" : "s"}
+              </span>
+              <span className="inline-flex items-center gap-1.5">
+                <GitBranchIcon className="size-4" />
+                {edgeCount} edge{edgeCount === 1 ? "" : "s"}
+              </span>
+              <span className="inline-flex items-center gap-1.5">
+                <CalendarIcon className="size-4" />
+                Published {formatCreatedDate(summary.createdAt)}
+              </span>
+            </div>
+
+            <div className="flex items-start gap-2 rounded-md border bg-muted/40 p-3 text-xs text-muted-foreground">
+              <InfoIcon className="mt-0.5 size-3.5 shrink-0" />
+              <p>
+                Anyone with this link can view and import a copy of this project. It carries no edit history —
+                the journal is never published — and arkaik makes no retention guarantee; this snapshot may be
+                removed at any time.
+              </p>
+            </div>
+
+            <ImportSnapshotButton snapshotId={id} suggestedFileName={`${title}.json`} />
+          </div>
+        </div>
+      </main>
+    </PageChrome>
+  );
+}

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -20,6 +20,8 @@ import type { Project, ProjectBundle } from "@/lib/data/types";
 import { archiveProject, importProjectFromFile } from "@/lib/utils/export";
 import { DeleteConfirmDialog } from "@/components/graph/DeleteConfirmDialog";
 import { CreateProjectForm } from "@/components/panels/CreateProjectForm";
+import { PublishDialog } from "@/components/publik/PublishDialog";
+import { Share2Icon } from "lucide-react";
 import {
   Select,
   SelectContent,
@@ -44,6 +46,7 @@ export default function ProjectsPage() {
   const [error, setError] = useState<string | null>(null);
   const [createOpen, setCreateOpen] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<ProjectBundle | null>(null);
+  const [publishTarget, setPublishTarget] = useState<ProjectBundle | null>(null);
   const [importing, setImporting] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -236,6 +239,10 @@ export default function ProjectsPage() {
                   <Button size="sm" onClick={() => router.push(`/project/${bundle.project.id}`)}>
                     Open
                   </Button>
+                  <Button size="sm" variant="outline" onClick={() => setPublishTarget(bundle)}>
+                    <Share2Icon />
+                    Publish
+                  </Button>
                   <Button size="sm" variant="outline" onClick={() => setDeleteTarget(bundle)}>
                     Delete
                   </Button>
@@ -256,6 +263,15 @@ export default function ProjectsPage() {
         title="Delete project"
         description={`Archive \"${deleteTarget?.project.title ?? "this project"}\" and remove it from your list?`}
         onConfirm={handleArchiveProject}
+      />
+
+      <PublishDialog
+        open={Boolean(publishTarget)}
+        onOpenChange={(open) => {
+          if (!open) setPublishTarget(null);
+        }}
+        projectId={publishTarget?.project.id ?? ""}
+        projectTitle={publishTarget?.project.title ?? "this project"}
       />
     </div>
   );

--- a/components/layout/ProjectSidebar.tsx
+++ b/components/layout/ProjectSidebar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import {
   BookOpenIcon,
@@ -10,8 +11,10 @@ import {
   MonitorIcon,
   ServerIcon,
   Settings2Icon,
+  Share2Icon,
 } from "lucide-react";
 import { ProjectSwitcher } from "@/components/layout/ProjectSwitcher";
+import { PublishDialog } from "@/components/publik/PublishDialog";
 import {
   Sidebar,
   SidebarContent,
@@ -54,6 +57,7 @@ export function ProjectSidebar({
   const canvasHref = `/project/${projectId}/canvas`;
   const libraryHref = `/project/${projectId}/library`;
   const changelogHref = `/project/${projectId}/changelog`;
+  const [publishOpen, setPublishOpen] = useState(false);
 
   return (
     <Sidebar collapsible="icon">
@@ -120,6 +124,16 @@ export function ProjectSidebar({
       <SidebarFooter>
         <SidebarMenu>
           <SidebarMenuItem>
+            <SidebarMenuButton
+              tooltip="Publish to Publik"
+              onClick={() => setPublishOpen(true)}
+              className="cursor-pointer"
+            >
+              <Share2Icon />
+              <span>Publish</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+          <SidebarMenuItem>
             <SidebarMenuButton disabled tooltip="Settings coming soon">
               <Settings2Icon />
               <span>Settings</span>
@@ -129,6 +143,13 @@ export function ProjectSidebar({
       </SidebarFooter>
 
       <SidebarRail />
+
+      <PublishDialog
+        open={publishOpen}
+        onOpenChange={setPublishOpen}
+        projectId={projectId}
+        projectTitle={currentProjectTitle ?? "Untitled project"}
+      />
     </Sidebar>
   );
 }

--- a/components/publik/ImportSnapshotButton.tsx
+++ b/components/publik/ImportSnapshotButton.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { DownloadIcon, Loader2Icon } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { importProjectFromFile } from "@/lib/utils/export";
+
+interface ImportSnapshotButtonProps {
+  snapshotId: string;
+  /** Used only as the synthetic `File` name handed to the import funnel. */
+  suggestedFileName: string;
+}
+
+/**
+ * The "Import into arkaik" action on `/p/{id}` (docs/spec/services.md § Publik
+ * → Surfaces). Fetches the snapshot JSON client-side, then funnels it through
+ * the same `importProjectFromFile` path the manual JSON import uses
+ * (`app/projects/page.tsx`) — validation, timestamp repair, and ID-collision
+ * rewriting come for free — before redirecting to the imported project's canvas.
+ */
+export function ImportSnapshotButton({ snapshotId, suggestedFileName }: ImportSnapshotButtonProps) {
+  const router = useRouter();
+  const [importing, setImporting] = useState(false);
+
+  async function handleImport() {
+    setImporting(true);
+    try {
+      const res = await fetch(`/api/publik/${encodeURIComponent(snapshotId)}`, { cache: "no-store" });
+      if (!res.ok) {
+        if (res.status === 404) {
+          toast.error("This snapshot is no longer available.");
+        } else {
+          toast.error(`Unable to load snapshot (HTTP ${res.status}).`);
+        }
+        return;
+      }
+
+      const text = await res.text();
+      const file = new File([text], suggestedFileName, { type: "application/json" });
+      const project = await importProjectFromFile(file);
+      toast.success(`Imported "${project.title}" into arkaik.`);
+      router.push(`/project/${project.id}/canvas`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown import error";
+      toast.error(`Import failed: ${message}`);
+    } finally {
+      setImporting(false);
+    }
+  }
+
+  return (
+    <Button size="lg" className="cursor-pointer" onClick={() => void handleImport()} disabled={importing}>
+      {importing ? <Loader2Icon className="size-4 animate-spin" /> : <DownloadIcon className="size-4" />}
+      {importing ? "Importing..." : "Import into arkaik"}
+    </Button>
+  );
+}

--- a/components/publik/PublishDialog.tsx
+++ b/components/publik/PublishDialog.tsx
@@ -1,0 +1,261 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { CheckIcon, CopyIcon, TriangleAlertIcon } from "lucide-react";
+import { toast } from "sonner";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { exportProject } from "@/lib/utils/export";
+
+interface PublishDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projectId: string;
+  projectTitle: string;
+}
+
+interface PublishResult {
+  url: string;
+  ownerKey: string;
+}
+
+type CopiedField = "url" | "key" | null;
+
+/** Structured 422 finding shape (lib/services/publik.ts `ValidationFinding`). */
+interface PublikFinding {
+  path?: string;
+  message: string;
+}
+
+function formatRetryAfter(seconds: number): string {
+  if (seconds >= 60) {
+    const minutes = Math.ceil(seconds / 60);
+    return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+  }
+  return `${seconds} second${seconds === 1 ? "" : "s"}`;
+}
+
+function findingLabel(finding: PublikFinding): string {
+  return finding.path ? `${finding.path}: ${finding.message}` : finding.message;
+}
+
+const MAX_SHOWN_FINDINGS = 5;
+
+/**
+ * Publish confirmation + result dialog (docs/spec/services.md § Publik →
+ * Surfaces: "In-app Publish action"). Two stages:
+ *  - confirm: states what becomes public (journal excluded, no retention
+ *    guarantee) and triggers the publish.
+ *  - success: shows the URL + owner key exactly once, with copy buttons and a
+ *    save-your-key warning — the server never returns the key again.
+ *
+ * The bundle is built client-side via the same `exportProject` the canvas
+ * "Export JSON" action uses (`localProvider.exportProject` through
+ * `getProvider()`), then POSTed as-is — no `?include_journal=true` — so the
+ * server's default journal strip (docs/spec/services.md § Publik → Protocol)
+ * is the only place history gets removed.
+ */
+export function PublishDialog({ open, onOpenChange, projectId, projectTitle }: PublishDialogProps) {
+  const [publishing, setPublishing] = useState(false);
+  const [result, setResult] = useState<PublishResult | null>(null);
+  const [findings, setFindings] = useState<string[] | null>(null);
+  const [copiedField, setCopiedField] = useState<CopiedField>(null);
+
+  // Fresh state every time the dialog is (re)opened.
+  useEffect(() => {
+    if (!open) return;
+    setPublishing(false);
+    setResult(null);
+    setFindings(null);
+    setCopiedField(null);
+  }, [open]);
+
+  async function handlePublish() {
+    setPublishing(true);
+    setFindings(null);
+    try {
+      const bundle = await exportProject(projectId);
+      const res = await fetch("/api/publik", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(bundle),
+      });
+
+      if (res.status === 201) {
+        const body = (await res.json()) as { url: string; owner_key: string };
+        setResult({ url: body.url, ownerKey: body.owner_key });
+        return;
+      }
+
+      if (res.status === 503) {
+        toast.error("Publik sharing is not available on this deployment.");
+        return;
+      }
+
+      if (res.status === 422) {
+        const body = (await res.json().catch(() => null)) as { findings?: PublikFinding[] } | null;
+        const messages = body?.findings?.map(findingLabel) ?? [];
+        setFindings(messages.length > 0 ? messages : ["This project failed validation and cannot be published."]);
+        return;
+      }
+
+      if (res.status === 429) {
+        const retryAfter = Number(res.headers.get("retry-after"));
+        toast.error(
+          Number.isFinite(retryAfter) && retryAfter > 0
+            ? `Too many snapshots published from this network. Try again in about ${formatRetryAfter(retryAfter)}.`
+            : "Too many snapshots published from this network. Try again later.",
+        );
+        return;
+      }
+
+      if (res.status === 413) {
+        toast.error("This project is too large to publish (over 5 MB).");
+        return;
+      }
+
+      const body = (await res.json().catch(() => null)) as { message?: string } | null;
+      toast.error(body?.message ?? `Publish failed (HTTP ${res.status}).`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      toast.error(`Publish failed: ${message}`);
+    } finally {
+      setPublishing(false);
+    }
+  }
+
+  async function copyValue(field: Exclude<CopiedField, null>, value: string) {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopiedField(field);
+      window.setTimeout(() => {
+        setCopiedField((current) => (current === field ? null : current));
+      }, 1500);
+    } catch {
+      toast.error("Unable to copy to clipboard.");
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        {result ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>Published</DialogTitle>
+              <DialogDescription>
+                Your project is live at the URL below. Save the owner key now — it is shown only once and is
+                required to delete this snapshot later.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-3">
+              <div className="space-y-1">
+                <p className="text-xs font-medium text-muted-foreground">Share URL</p>
+                <div className="flex items-center gap-2">
+                  <Input
+                    readOnly
+                    value={result.url}
+                    className="font-mono text-xs"
+                    onFocus={(event) => event.currentTarget.select()}
+                    aria-label="Share URL"
+                  />
+                  <Button
+                    type="button"
+                    size="icon"
+                    variant="outline"
+                    className="shrink-0 cursor-pointer"
+                    onClick={() => void copyValue("url", result.url)}
+                    aria-label="Copy share URL"
+                  >
+                    {copiedField === "url" ? <CheckIcon className="size-4" /> : <CopyIcon className="size-4" />}
+                  </Button>
+                </div>
+              </div>
+
+              <div className="space-y-1">
+                <p className="text-xs font-medium text-muted-foreground">Owner key</p>
+                <div className="flex items-center gap-2">
+                  <Input
+                    readOnly
+                    value={result.ownerKey}
+                    className="font-mono text-xs"
+                    onFocus={(event) => event.currentTarget.select()}
+                    aria-label="Owner key"
+                  />
+                  <Button
+                    type="button"
+                    size="icon"
+                    variant="outline"
+                    className="shrink-0 cursor-pointer"
+                    onClick={() => void copyValue("key", result.ownerKey)}
+                    aria-label="Copy owner key"
+                  >
+                    {copiedField === "key" ? <CheckIcon className="size-4" /> : <CopyIcon className="size-4" />}
+                  </Button>
+                </div>
+                <p className="flex items-start gap-1.5 pt-1 text-xs text-amber-700 dark:text-amber-500">
+                  <TriangleAlertIcon className="mt-0.5 size-3.5 shrink-0" />
+                  Save this key somewhere safe. It will not be shown again, and there is no way to delete this
+                  snapshot without it.
+                </p>
+              </div>
+            </div>
+
+            <DialogFooter>
+              <Button variant="outline" asChild>
+                <a href={result.url} target="_blank" rel="noreferrer">
+                  Open link
+                </a>
+              </Button>
+              <Button onClick={() => onOpenChange(false)}>Done</Button>
+            </DialogFooter>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle>Publish &quot;{projectTitle}&quot; to Publik</DialogTitle>
+              <DialogDescription>
+                Anyone with the link can view and import a copy. Your project&apos;s title, description, nodes, and
+                edges become public — the journal (change history) is never included. There is no listing; only
+                people with the URL can find it, and arkaik makes no retention guarantee.
+              </DialogDescription>
+            </DialogHeader>
+
+            {findings && (
+              <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+                <p className="font-medium">This project can&apos;t be published yet:</p>
+                <ul className="mt-1 list-disc space-y-0.5 pl-4">
+                  {findings.slice(0, MAX_SHOWN_FINDINGS).map((finding, index) => (
+                    <li key={index}>{finding}</li>
+                  ))}
+                </ul>
+                {findings.length > MAX_SHOWN_FINDINGS && (
+                  <p className="mt-1">and {findings.length - MAX_SHOWN_FINDINGS} more.</p>
+                )}
+              </div>
+            )}
+
+            <DialogFooter>
+              <Button variant="outline" onClick={() => onOpenChange(false)} disabled={publishing}>
+                Cancel
+              </Button>
+              <Button onClick={() => void handlePublish()} disabled={publishing} className="cursor-pointer">
+                {publishing ? "Publishing..." : "Publish"}
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex w-fit shrink-0 items-center gap-1 whitespace-nowrap rounded-md border px-2 py-0.5 text-xs font-medium",
+  {
+    variants: {
+      variant: {
+        default: "border-transparent bg-primary text-primary-foreground",
+        secondary: "border-transparent bg-secondary text-secondary-foreground",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+function Badge({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"span"> & VariantProps<typeof badgeVariants>) {
+  return (
+    <span data-slot="badge" className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/lib/services/publik.ts
+++ b/lib/services/publik.ts
@@ -270,6 +270,29 @@ export async function fetchSnapshotBundle(id: string): Promise<unknown | null> {
   return rows.length ? rows[0].bundle : null;
 }
 
+export interface SnapshotSummary {
+  /** The stored bundle JSON, verbatim (post journal-strip unless opted in). */
+  bundle: unknown;
+  /** ISO 8601 timestamp of when the snapshot was created. */
+  createdAt: string;
+}
+
+/**
+ * Fetch a snapshot's bundle plus its creation timestamp, for the `/p/{id}`
+ * preview page (docs/spec/services.md § Publik → Surfaces: "created date").
+ * Kept separate from {@link fetchSnapshotBundle} — which backs `GET
+ * /api/publik/{id}` and must keep returning the bundle alone — so that
+ * endpoint's response shape never changes.
+ */
+export async function fetchSnapshotSummary(id: string): Promise<SnapshotSummary | null> {
+  const { rows } = await query<{ bundle: unknown; created_at: Date }>(
+    `select bundle, created_at from publik_snapshots where id = $1`,
+    [id],
+  );
+  if (!rows.length) return null;
+  return { bundle: rows[0].bundle, createdAt: rows[0].created_at.toISOString() };
+}
+
 export type DeleteOutcome = "deleted" | "not_found" | "forbidden";
 
 /**

--- a/lib/utils/publik-preview.ts
+++ b/lib/utils/publik-preview.ts
@@ -1,0 +1,99 @@
+/**
+ * Pure, framework-agnostic helpers for rendering a Publik snapshot preview
+ * (`app/p/[id]/page.tsx`, docs/spec/services.md § Publik → Surfaces).
+ *
+ * The stored `bundle` is `unknown` from the page's point of view — it was
+ * validated at publish time by `lib/services/publik.ts`, but this module
+ * treats it defensively so a malformed or unexpected shape degrades the
+ * preview instead of crashing the route.
+ */
+
+export type ConformanceLevel = 0 | 1 | 2;
+
+export type PreviewAssetResolution =
+  | { kind: "image"; src: string }
+  | { kind: "placeholder" }
+  | { kind: "none" };
+
+export interface PublikBundleSummary {
+  title: string;
+  description?: string;
+  nodeCount: number;
+  edgeCount: number;
+  /** docs/spec/bundle-format.md § Conformance Levels, derived from what's stored. */
+  conformanceLevel: ConformanceLevel;
+  /** A representative screenshot for the preview card, if one can be resolved. */
+  previewAsset: PreviewAssetResolution;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Classify a single asset value per docs/spec/bundle-format.md § Asset Values.
+ * Only `data:` URIs and absolute URLs (any URI scheme) carry bytes the hosted
+ * preview can render directly; a schemeless relative path is a Kommit-mode
+ * reference the server has no bundle directory to resolve against, so it
+ * degrades to a placeholder rather than failing.
+ */
+function resolveAssetValue(value: unknown): PreviewAssetResolution {
+  if (typeof value !== "string" || value.length === 0) return { kind: "none" };
+  if (value.startsWith("data:")) return { kind: "image", src: value };
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(value)) return { kind: "image", src: value };
+  return { kind: "placeholder" };
+}
+
+/** Scan nodes (in stored order) for the first resolvable or placeholder-worthy screenshot. */
+function findRepresentativeAsset(nodes: unknown): PreviewAssetResolution {
+  if (!Array.isArray(nodes)) return { kind: "none" };
+
+  for (const node of nodes) {
+    if (!isRecord(node)) continue;
+    const metadata = node.metadata;
+    if (!isRecord(metadata)) continue;
+    const screenshots = metadata.platformScreenshots;
+    if (!isRecord(screenshots)) continue;
+
+    for (const value of Object.values(screenshots)) {
+      const resolved = resolveAssetValue(value);
+      if (resolved.kind !== "none") return resolved;
+    }
+  }
+
+  return { kind: "none" };
+}
+
+/**
+ * Derive the conformance level a stored bundle exhibits (docs/spec/bundle-format.md
+ * § Conformance Levels). Publik strips the journal by default, so most published
+ * snapshots read as Level 0/1; Level 2 only appears when a publisher opted in
+ * with `?include_journal=true`.
+ */
+function deriveConformanceLevel(root: Record<string, unknown>): ConformanceLevel {
+  if (Array.isArray(root.journal) && root.journal.length > 0) return 2;
+  if (typeof root.schema_version === "number") return 1;
+  return 0;
+}
+
+/** Summarize a stored bundle for the `/p/{id}` preview card. Never throws. */
+export function summarizeBundle(bundle: unknown): PublikBundleSummary {
+  const root = isRecord(bundle) ? bundle : {};
+  const project = isRecord(root.project) ? root.project : {};
+  const nodes = Array.isArray(root.nodes) ? root.nodes : [];
+  const edges = Array.isArray(root.edges) ? root.edges : [];
+
+  const title = typeof project.title === "string" && project.title.trim().length > 0
+    ? project.title
+    : "Untitled project";
+  const description = typeof project.description === "string" ? project.description : undefined;
+
+  return {
+    title,
+    description,
+    nodeCount: nodes.length,
+    edgeCount: edges.length,
+    conformanceLevel: deriveConformanceLevel(root),
+    previewAsset: findRepresentativeAsset(root.nodes),
+  };
+}


### PR DESCRIPTION
## Summary

Implements the human-facing half of Publik (docs/spec/services.md § Publik → Surfaces), consuming the already-merged `lib/services/publik.ts` / `app/api/publik/**` API surface:

- **`app/p/[id]/page.tsx`** (dynamic route): server-fetches the snapshot directly through `lib/services/publik.ts` (same process, no HTTP self-call) and renders a *preview* — title, description, node/edge counts, a Level 0/1/2 format badge derived from `schema_version`/`journal` presence, created date, the no-retention disclaimer, and an **Import into arkaik** button. Degrades to a "sharing not available" state when `DATABASE_URL` is unset (never crashes), and to Next's `notFound()` for missing ids (`app/p/[id]/not-found.tsx`).
- **Asset degradation**: a representative screenshot is picked from the bundle's nodes; relative-path forms (unresolvable server-side, per docs/spec/bundle-format.md § Asset Values) degrade to a placeholder, while `data:` URIs and absolute URLs render directly.
- **`components/publik/ImportSnapshotButton.tsx`**: fetches the snapshot JSON client-side and funnels it through the existing `importProjectFromFile` path (`lib/utils/export.ts`) — validation, timestamp repair, and ID-collision rewriting come for free — then redirects to the imported project's canvas.
- **`components/publik/PublishDialog.tsx`**: confirmation dialog stating what becomes public (journal excluded, no retention guarantee) → POSTs the client-exported bundle (`getProvider().exportProject`, no `?include_journal=true`) to `/api/publik`. Success shows the URL + owner key **once** with copy buttons and a save-your-key warning. 422 (validation findings), 429 (rate limit + retry-after), 413 (too large), and 503 (services unavailable) are all surfaced readably via toasts / inline findings. Wired into both the project shell (`ProjectSidebar` footer) and the project list (`app/projects/page.tsx`).
- **`lib/services/publik.ts`**: one small, additive, non-invasive read helper — `fetchSnapshotSummary` (bundle + `created_at`) — for the preview page. No existing exports touched.
- **`components/ui/badge.tsx`**: new shadcn-style `Badge` primitive for the conformance-level pill (none existed in the repo yet).

## Verification

- `npm run lint` — 0 errors (pre-existing unrelated warnings only)
- `npm run build` with **no env vars** — succeeds; `/p/[id]` correctly registers as dynamic (`ƒ`)
- `npm run generate` — no drift
- Full existing `npm run test:*` battery — all green (`fixtures`, `schema`, `id-gen`, `serialize`, `refs`, `journal`, `journal-projections`, `emit`, `emit-events`, `screenshot-size`, `migrate`, `provider`, `auth`, `publik`)
- **End-to-end against a local Postgres** (`initdb` + `db:migrate` + `next dev`):
  - `POST /api/publik` → `201` → `GET /p/{id}` renders title, description, correct node/edge counts (147/277 for the Pebbles seed), created date, disclaimer, Import button
  - Level 0 badge for a stripped snapshot; Level 2 badge confirmed via `?include_journal=true`
  - `/p/does-not-exist` → `404` with the custom not-found page
  - Asset degradation confirmed for all three forms: relative path → placeholder, `data:` URI → inline `<img>`, `https://` URL → inline `<img>`
  - `DATABASE_URL` unset → "sharing not available" shell, `200`, no crash

## Deviations / notes

- Added the Publish entry point to **both** the project shell (`ProjectSidebar` footer, replacing the disabled-only footer with a working "Publish" item alongside "Settings coming soon") and the project list card actions, since the issue allowed either and both were low-cost given the dialog is self-contained (takes just `projectId`/`projectTitle`).
- `fetchSnapshotSummary` was the only touch to `lib/services/publik.ts` — purely additive, per the issue's read-only-consumer guidance.
- Did not touch `packages/cli/**`, `app/api/synk/**`, `lib/services/limits.ts`, `db/migrations/**`, or any existing exports of `lib/services/publik.ts`.

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QpXVmp8QNHQF3s2cCvtead)_