### PR TITLE
M4: Synk client — SyncManager, backup status UI, restore, Lokal→Synk onboarding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,3 +123,5 @@ jobs:
         run: npm run test:auth
       - name: Synk API integration tests (authz isolation, dedupe, limits, retention)
         run: npm run test:synk
+      - name: Synk client SyncManager tests (debounce, hash, status transitions)
+        run: npm run test:sync

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import "highlight.js/styles/github.css";
 import "./globals.css";
 import { ThemeProvider } from "@/components/theme-provider";
 import { AppToaster } from "@/components/ui/toaster";
+import { SyncProvider } from "@/components/sync/SyncProvider";
 
 export const metadata: Metadata = {
   title: "arkaik",
@@ -72,6 +73,7 @@ export default function RootLayout({
         >
           {children}
           <AppToaster />
+          <SyncProvider />
         </ThemeProvider>
       </body>
     </html>

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -21,7 +21,10 @@ import { archiveProject, importProjectFromFile } from "@/lib/utils/export";
 import { DeleteConfirmDialog } from "@/components/graph/DeleteConfirmDialog";
 import { CreateProjectForm } from "@/components/panels/CreateProjectForm";
 import { PublishDialog } from "@/components/publik/PublishDialog";
-import { Share2Icon } from "lucide-react";
+import { ProjectSyncControl } from "@/components/sync/ProjectSyncControl";
+import { RestoreDialog } from "@/components/sync/RestoreDialog";
+import { SynkOnboardingBanner } from "@/components/sync/SynkOnboardingBanner";
+import { HistoryIcon, Share2Icon } from "lucide-react";
 import {
   Select,
   SelectContent,
@@ -29,6 +32,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useAuthStatus } from "@/lib/hooks/useAuthStatus";
 import pebbles from "@/seed/pebbles.json";
 import arkaikSelfMap from "@/seed/arkaik-self-map.json";
 
@@ -41,12 +45,14 @@ const EXAMPLE_SEEDS: Record<ExampleSeed, { fileName: string; data: unknown }> = 
 
 export default function ProjectsPage() {
   const router = useRouter();
+  const auth = useAuthStatus();
   const [projects, setProjects] = useState<ProjectBundle[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [createOpen, setCreateOpen] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<ProjectBundle | null>(null);
   const [publishTarget, setPublishTarget] = useState<ProjectBundle | null>(null);
+  const [restoreOpen, setRestoreOpen] = useState(false);
   const [importing, setImporting] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -186,11 +192,19 @@ export default function ProjectsPage() {
             <Button variant="outline" asChild>
               <Link href="/generate">Generate with AI</Link>
             </Button>
+            {auth.state === "signed-in" && (
+              <Button variant="outline" onClick={() => setRestoreOpen(true)}>
+                <HistoryIcon />
+                Restore from Synk
+              </Button>
+            )}
             <Button onClick={() => setCreateOpen(true)}>Create project</Button>
           </div>
         </div>
 
         {error && <p className="text-sm text-destructive">{error}</p>}
+
+        {!loading && projects.length > 0 && <SynkOnboardingBanner projects={projects} />}
 
         {loading ? (
           <div className="flex flex-1 items-center justify-center">
@@ -229,11 +243,12 @@ export default function ProjectsPage() {
                     <CardDescription>{bundle.project.description}</CardDescription>
                   )}
                 </CardHeader>
-                <CardContent>
+                <CardContent className="flex flex-col gap-2">
                   <p className="text-sm text-muted-foreground">
                     {bundle.nodes.length} node{bundle.nodes.length !== 1 ? "s" : ""} ·{" "}
                     {bundle.edges.length} edge{bundle.edges.length !== 1 ? "s" : ""}
                   </p>
+                  <ProjectSyncControl projectId={bundle.project.id} />
                 </CardContent>
                 <CardFooter className="flex items-center gap-2">
                   <Button size="sm" onClick={() => router.push(`/project/${bundle.project.id}`)}>
@@ -273,6 +288,8 @@ export default function ProjectsPage() {
         projectId={publishTarget?.project.id ?? ""}
         projectTitle={publishTarget?.project.title ?? "this project"}
       />
+
+      <RestoreDialog open={restoreOpen} onOpenChange={setRestoreOpen} />
     </div>
   );
 }

--- a/components/auth/AuthButton.tsx
+++ b/components/auth/AuthButton.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { GithubIcon, LogOutIcon, UserRoundIcon } from "lucide-react";
 import { signIn, signOut } from "next-auth/react";
 
@@ -13,14 +12,15 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { useAuthStatus, type AuthStatusUser } from "@/lib/hooks/useAuthStatus";
 
 /**
  * Sign-in / account entry point for the app shell (docs/spec/services.md
  * § Synk → Auth). Native to the existing chrome — an icon-sized control that
  * sits beside the theme toggle / in the sidebar footer.
  *
- * GRACEFUL ABSENCE: the component asks GET /api/auth/status once on mount and
- * renders *nothing* until it knows auth is configured. When it is not (the
+ * GRACEFUL ABSENCE: `useAuthStatus` asks GET /api/auth/status once on mount and
+ * this renders *nothing* until it knows auth is configured. When it is not (the
  * default local-first deployment), this stays null forever — no sign-in affords,
  * no services surface leaks, and local-first usage is untouched. The endpoint
  * returns only a boolean and the public profile; no secret reaches the client.
@@ -29,55 +29,14 @@ import {
  * changes between signed-in and signed-out.
  */
 
-interface AuthUser {
-  name: string | null;
-  email: string | null;
-  image: string | null;
-}
-
-type AuthStatus =
-  | { state: "loading" }
-  | { state: "unconfigured" }
-  | { state: "signed-out" }
-  | { state: "signed-in"; user: AuthUser };
-
-function initials(user: AuthUser): string {
+function initials(user: AuthStatusUser): string {
   const source = user.name ?? user.email ?? "";
   const trimmed = source.trim();
   return trimmed ? trimmed[0]!.toUpperCase() : "";
 }
 
 export function AuthButton() {
-  const [status, setStatus] = useState<AuthStatus>({ state: "loading" });
-
-  useEffect(() => {
-    let active = true;
-
-    async function loadStatus() {
-      try {
-        const res = await fetch("/api/auth/status", { cache: "no-store" });
-        if (!res.ok) throw new Error(`status ${res.status}`);
-        const data: { configured: boolean; user: AuthUser | null } = await res.json();
-        if (!active) return;
-        if (!data.configured) {
-          setStatus({ state: "unconfigured" });
-        } else if (data.user) {
-          setStatus({ state: "signed-in", user: data.user });
-        } else {
-          setStatus({ state: "signed-out" });
-        }
-      } catch {
-        // Treat any failure as "auth unavailable" — degrade to hidden, never
-        // block the local-first shell.
-        if (active) setStatus({ state: "unconfigured" });
-      }
-    }
-
-    void loadStatus();
-    return () => {
-      active = false;
-    };
-  }, []);
+  const status = useAuthStatus();
 
   // Hidden while loading and whenever auth is not configured.
   if (status.state === "loading" || status.state === "unconfigured") {

--- a/components/sync/ProjectSyncControl.tsx
+++ b/components/sync/ProjectSyncControl.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useState } from "react";
+import { CheckCircle2Icon, CloudIcon, Loader2Icon, TriangleAlertIcon } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { useAuthStatus } from "@/lib/hooks/useAuthStatus";
+import { useSyncStatus } from "@/lib/sync/use-sync-status";
+import { syncManager, type SyncStatus } from "@/lib/sync/sync-manager";
+
+interface ProjectSyncControlProps {
+  projectId: string;
+}
+
+function formatRelativeTime(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "recently";
+  const diffSec = Math.max(0, Math.round((Date.now() - then) / 1000));
+  if (diffSec < 5) return "just now";
+  if (diffSec < 60) return `${diffSec}s ago`;
+  const diffMin = Math.round(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.round(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.round(diffHr / 24);
+  return `${diffDay}d ago`;
+}
+
+function SyncStatusLabel({ status }: { status: SyncStatus }) {
+  switch (status.state) {
+    case "idle":
+      return null;
+    case "pending":
+      return <span className="text-xs text-muted-foreground">Backup pending…</span>;
+    case "syncing":
+      return <span className="text-xs text-muted-foreground">Backing up…</span>;
+    case "backed-up":
+      return (
+        <span className="flex items-center gap-1 text-xs text-muted-foreground">
+          <CheckCircle2Icon className="size-3.5 text-emerald-600 dark:text-emerald-500" />
+          Backed up {formatRelativeTime(status.at)}
+        </span>
+      );
+    case "error":
+      return (
+        <span className="flex items-center gap-1 text-xs text-destructive" title={status.message}>
+          <TriangleAlertIcon className="size-3.5" />
+          Backup failed
+        </span>
+      );
+    case "limit-exceeded":
+      return (
+        <span className="flex items-center gap-1 text-xs text-destructive">
+          <TriangleAlertIcon className="size-3.5" />
+          {status.limit}-entity limit exceeded ({status.actual}) — {status.tier} tier
+        </span>
+      );
+  }
+}
+
+/**
+ * Per-project Synk status + manual "Back up now" action (docs/spec/services.md
+ * § Synk → Client sync engine: "a manual 'Back up now' action, and visible
+ * per-project status"). Renders nothing when auth is unconfigured or the
+ * caller is signed out — mirrors `components/auth/AuthButton.tsx`'s graceful
+ * absence: this control is the *only* thing that appears once signed in, no
+ * local feature is gated on it.
+ */
+export function ProjectSyncControl({ projectId }: ProjectSyncControlProps) {
+  const auth = useAuthStatus();
+  const status = useSyncStatus(projectId);
+  const [backingUp, setBackingUp] = useState(false);
+
+  if (auth.state !== "signed-in") return null;
+
+  async function handleBackupNow() {
+    setBackingUp(true);
+    try {
+      await syncManager.backupNow(projectId);
+      const latest = syncManager.getStatus(projectId);
+      if (latest.state === "backed-up") {
+        toast.success("Backed up to Synk.");
+      } else if (latest.state === "limit-exceeded") {
+        toast.error(`${latest.limit}-entity limit exceeded (${latest.actual}) — ${latest.tier} tier.`);
+      } else if (latest.state === "error") {
+        toast.error(latest.message);
+      }
+    } finally {
+      setBackingUp(false);
+    }
+  }
+
+  const busy = backingUp || status.state === "syncing";
+
+  return (
+    <div className="flex items-center gap-2">
+      <SyncStatusLabel status={status} />
+      <Button
+        type="button"
+        size="sm"
+        variant="ghost"
+        className="h-7 cursor-pointer px-2 text-xs"
+        disabled={busy}
+        onClick={() => void handleBackupNow()}
+      >
+        {busy ? <Loader2Icon className="size-3.5 animate-spin" /> : <CloudIcon className="size-3.5" />}
+        Back up
+      </Button>
+    </div>
+  );
+}

--- a/components/sync/RestoreDialog.tsx
+++ b/components/sync/RestoreDialog.tsx
@@ -1,0 +1,293 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ArrowLeftIcon, HistoryIcon, Loader2Icon } from "lucide-react";
+import { toast } from "sonner";
+import { useRouter } from "next/navigation";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { importProjectFromFile } from "@/lib/utils/export";
+
+interface RestoreDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Skip the account project list and go straight to this project's versions. */
+  initialProjectId?: string;
+  initialProjectTitle?: string;
+}
+
+/** Wire shape of `GET /api/synk/projects` entries (lib/services/synk.ts `ProjectListing`) — only the fields this dialog renders. */
+interface ServerProjectListing {
+  project_id: string;
+  title: string;
+  latest_created_at: string | null;
+}
+
+/** Wire shape of `GET /api/synk/projects/{id}/backups` entries (lib/services/synk.ts `BackupListing`). */
+interface ServerBackupListing {
+  id: string;
+  created_at: string;
+  size_bytes: number;
+  entity_count: number;
+}
+
+function formatDateTime(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString();
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/**
+ * Restore flow (docs/spec/services.md § Synk → Client sync engine: "Restore
+ * is an explicit user action (pick a version → import as local project,
+ * existing collision handling applies)"). Two steps: pick one of the
+ * account's backed-up projects (skipped when `initialProjectId` is given, so
+ * a project card's "Restore…" action can jump straight to its own versions),
+ * then pick a retained version.
+ *
+ * Restoring fetches the raw bundle JSON (`GET /api/synk/backups/{id}`) and
+ * funnels it through the exact same `importProjectFromFile` path the manual
+ * JSON import and the Publik import button use (`lib/utils/export.ts`) — so
+ * ID-collision rewriting applies automatically and restoring always creates
+ * a (possibly re-numbered) NEW local project. It never overwrites a live
+ * local project in place, satisfying the spec's one-way-up boundary: this is
+ * the one explicit, user-initiated exception that reads server state back
+ * down, and even then only ever as a fresh import.
+ */
+export function RestoreDialog({ open, onOpenChange, initialProjectId, initialProjectTitle }: RestoreDialogProps) {
+  const router = useRouter();
+  const [step, setStep] = useState<"projects" | "versions">("projects");
+  const [loadingProjects, setLoadingProjects] = useState(false);
+  const [projects, setProjects] = useState<ServerProjectListing[]>([]);
+  const [selected, setSelected] = useState<{ id: string; title: string } | null>(null);
+  const [loadingBackups, setLoadingBackups] = useState(false);
+  const [backups, setBackups] = useState<ServerBackupListing[]>([]);
+  const [restoringId, setRestoringId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setError(null);
+    setRestoringId(null);
+
+    if (initialProjectId) {
+      setSelected({ id: initialProjectId, title: initialProjectTitle ?? initialProjectId });
+      setStep("versions");
+      void loadBackups(initialProjectId);
+      return;
+    }
+
+    setStep("projects");
+    setSelected(null);
+    setBackups([]);
+    void loadProjects();
+    // Fresh state every time the dialog (re)opens — see PublishDialog for the
+    // same "reset on open" pattern this mirrors.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, initialProjectId]);
+
+  async function loadProjects() {
+    setLoadingProjects(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/synk/projects", { cache: "no-store" });
+      if (!res.ok) {
+        setError(`Unable to load backed-up projects (HTTP ${res.status}).`);
+        return;
+      }
+      const body = (await res.json()) as { projects?: ServerProjectListing[] };
+      setProjects(body.projects ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to load backed-up projects.");
+    } finally {
+      setLoadingProjects(false);
+    }
+  }
+
+  async function loadBackups(projectId: string) {
+    setLoadingBackups(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/synk/projects/${encodeURIComponent(projectId)}/backups`, { cache: "no-store" });
+      if (!res.ok) {
+        setError(`Unable to load versions (HTTP ${res.status}).`);
+        return;
+      }
+      const body = (await res.json()) as { backups?: ServerBackupListing[] };
+      setBackups(body.backups ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to load versions.");
+    } finally {
+      setLoadingBackups(false);
+    }
+  }
+
+  function openProject(project: ServerProjectListing) {
+    setSelected({ id: project.project_id, title: project.title });
+    setStep("versions");
+    void loadBackups(project.project_id);
+  }
+
+  async function handleRestore(backupId: string) {
+    setRestoringId(backupId);
+    setError(null);
+    try {
+      const res = await fetch(`/api/synk/backups/${encodeURIComponent(backupId)}`, { cache: "no-store" });
+      if (!res.ok) {
+        toast.error(
+          res.status === 404 ? "This backup is no longer available." : `Unable to load backup (HTTP ${res.status}).`,
+        );
+        return;
+      }
+      const text = await res.text();
+      const file = new File([text], `${selected?.title ?? "restored"}.json`, { type: "application/json" });
+      const project = await importProjectFromFile(file);
+      toast.success(`Restored "${project.title}" as a new local project.`);
+      onOpenChange(false);
+      router.push(`/project/${project.id}`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown restore error";
+      toast.error(`Restore failed: ${message}`);
+    } finally {
+      setRestoringId(null);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        {step === "projects" ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>Restore from Synk</DialogTitle>
+              <DialogDescription>
+                Pick one of your account&apos;s backed-up projects, then a retained version. Restoring always
+                creates a new local project — it never overwrites a project you already have.
+              </DialogDescription>
+            </DialogHeader>
+
+            {loadingProjects ? (
+              <p className="py-6 text-center text-sm text-muted-foreground">Loading…</p>
+            ) : error ? (
+              <p className="text-sm text-destructive">{error}</p>
+            ) : projects.length === 0 ? (
+              <p className="py-6 text-center text-sm text-muted-foreground">
+                No projects have been backed up to Synk yet.
+              </p>
+            ) : (
+              <ul className="max-h-80 space-y-1 overflow-y-auto">
+                {projects.map((project) => (
+                  <li key={project.project_id}>
+                    <button
+                      type="button"
+                      onClick={() => openProject(project)}
+                      className="flex w-full cursor-pointer items-center justify-between rounded-md border px-3 py-2 text-left text-sm hover:bg-accent"
+                    >
+                      <span className="truncate font-medium">{project.title}</span>
+                      <span className="shrink-0 text-xs text-muted-foreground">
+                        {project.latest_created_at ? formatDateTime(project.latest_created_at) : "—"}
+                      </span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            <DialogFooter>
+              <Button variant="outline" onClick={() => onOpenChange(false)}>
+                Close
+              </Button>
+            </DialogFooter>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                {!initialProjectId && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="size-6 cursor-pointer"
+                    onClick={() => {
+                      setStep("projects");
+                      setSelected(null);
+                    }}
+                    aria-label="Back to project list"
+                  >
+                    <ArrowLeftIcon className="size-4" />
+                  </Button>
+                )}
+                <span className="truncate">Versions of &quot;{selected?.title}&quot;</span>
+              </DialogTitle>
+              <DialogDescription>
+                Pick a retained version to import as a new local project (7-day retention — the newest version is
+                always kept).
+              </DialogDescription>
+            </DialogHeader>
+
+            {loadingBackups ? (
+              <p className="py-6 text-center text-sm text-muted-foreground">Loading…</p>
+            ) : error ? (
+              <p className="text-sm text-destructive">{error}</p>
+            ) : backups.length === 0 ? (
+              <p className="py-6 text-center text-sm text-muted-foreground">No retained versions.</p>
+            ) : (
+              <ul className="max-h-80 space-y-1 overflow-y-auto">
+                {backups.map((backup) => (
+                  <li
+                    key={backup.id}
+                    className="flex items-center justify-between gap-2 rounded-md border px-3 py-2 text-sm"
+                  >
+                    <div className="min-w-0">
+                      <p className="truncate">{formatDateTime(backup.created_at)}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {backup.entity_count} entit{backup.entity_count === 1 ? "y" : "ies"} ·{" "}
+                        {formatSize(backup.size_bytes)}
+                      </p>
+                    </div>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      className="shrink-0 cursor-pointer"
+                      disabled={restoringId !== null}
+                      onClick={() => void handleRestore(backup.id)}
+                    >
+                      {restoringId === backup.id ? (
+                        <Loader2Icon className="size-3.5 animate-spin" />
+                      ) : (
+                        <HistoryIcon className="size-3.5" />
+                      )}
+                      Restore
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            <DialogFooter>
+              <Button variant="outline" onClick={() => onOpenChange(false)}>
+                Close
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/sync/SyncProvider.tsx
+++ b/components/sync/SyncProvider.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { syncManager } from "@/lib/sync/sync-manager";
+
+/**
+ * Boots the Synk client sync engine (docs/spec/services.md § Synk → Client
+ * sync engine, issue #244). Mounted once in `app/layout.tsx` so `syncManager`
+ * starts listening for local mutation notifications for the lifetime of the
+ * app shell — `.start()` is idempotent, so React Strict Mode's dev-only
+ * double-invoke of effects is harmless.
+ *
+ * `syncManager` itself stays dormant (no timers, no fetches) until
+ * `GET /api/auth/status` reports a signed-in user — this component's only
+ * other job is refreshing that cached auth check on window focus, so signing
+ * in (or out) in another tab is noticed promptly rather than only on the next
+ * mutation.
+ *
+ * Renders nothing — a pure side-effect component, the same shape as
+ * `components/ui/toaster.tsx`'s `AppToaster`.
+ */
+export function SyncProvider() {
+  useEffect(() => {
+    syncManager.start();
+
+    function onFocus() {
+      void syncManager.refreshAuth();
+    }
+    window.addEventListener("focus", onFocus);
+
+    return () => {
+      window.removeEventListener("focus", onFocus);
+      syncManager.stop();
+    };
+  }, []);
+
+  return null;
+}

--- a/components/sync/SynkOnboardingBanner.tsx
+++ b/components/sync/SynkOnboardingBanner.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useEffect, useReducer, useState } from "react";
+import { CloudUploadIcon, Loader2Icon, XIcon } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { useAuthStatus } from "@/lib/hooks/useAuthStatus";
+import { syncManager } from "@/lib/sync/sync-manager";
+import type { ProjectBundle } from "@/lib/data/types";
+
+const DISMISSED_KEY = "arkaik:synk-onboarding-dismissed";
+
+function readDismissed(): Set<string> {
+  if (typeof window === "undefined") return new Set();
+  try {
+    const raw = window.localStorage.getItem(DISMISSED_KEY);
+    if (!raw) return new Set();
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? new Set(parsed.filter((v): v is string => typeof v === "string")) : new Set();
+  } catch {
+    return new Set();
+  }
+}
+
+function writeDismissed(ids: Set<string>) {
+  try {
+    window.localStorage.setItem(DISMISSED_KEY, JSON.stringify(Array.from(ids)));
+  } catch {
+    // Best-effort only — a full localStorage or private-mode browser just
+    // means the banner may reappear next session, not a functional failure.
+  }
+}
+
+interface SynkOnboardingBannerProps {
+  /** The already-loaded local project list (app/projects/page.tsx owns the fetch) — avoids a second listProjects() round-trip. */
+  projects: ProjectBundle[];
+}
+
+/**
+ * Lokal → Synk onboarding, "the primary conversion funnel"
+ * (docs/spec/services.md § Synk → Client sync engine: "after first sign-in,
+ * existing local projects are offered for backup with one click each — the
+ * data never moves, it *gains* a backup. No migration of storage, no
+ * account-gating of local features"). Deliberately lightweight: a
+ * dismissible inline banner, not a modal wall — hidden entirely for signed-
+ * out/unconfigured users (this is the only thing that changes on sign-in),
+ * and it disappears on its own once every candidate is backed up.
+ */
+export function SynkOnboardingBanner({ projects }: SynkOnboardingBannerProps) {
+  const auth = useAuthStatus();
+  const [serverProjectIds, setServerProjectIds] = useState<Set<string> | null>(null);
+  const [dismissed, setDismissed] = useState<Set<string>>(() => readDismissed());
+  const [backingUpId, setBackingUpId] = useState<string | null>(null);
+
+  // Re-render whenever ANY project's live sync status changes, so a project
+  // that just got backed up (via this banner or the per-card control) drops
+  // out of the candidate list without a page reload.
+  const [, forceUpdate] = useReducer((c: number) => c + 1, 0);
+  useEffect(() => syncManager.subscribe(forceUpdate), []);
+
+  useEffect(() => {
+    if (auth.state !== "signed-in") {
+      setServerProjectIds(null);
+      return;
+    }
+    let active = true;
+    (async () => {
+      try {
+        const res = await fetch("/api/synk/projects", { cache: "no-store" });
+        if (!res.ok) {
+          if (active) setServerProjectIds(new Set());
+          return;
+        }
+        const body = (await res.json()) as { projects?: Array<{ project_id: string }> };
+        if (active) setServerProjectIds(new Set((body.projects ?? []).map((p) => p.project_id)));
+      } catch {
+        if (active) setServerProjectIds(new Set());
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, [auth.state]);
+
+  if (auth.state !== "signed-in" || serverProjectIds === null) return null;
+
+  const candidates = projects.filter((bundle) => {
+    const id = bundle.project.id;
+    if (serverProjectIds.has(id)) return false;
+    if (dismissed.has(id)) return false;
+    if (syncManager.getStatus(id).state === "backed-up") return false; // just backed up this session
+    return true;
+  });
+
+  if (candidates.length === 0) return null;
+
+  function dismissAll() {
+    const next = new Set(dismissed);
+    for (const bundle of candidates) next.add(bundle.project.id);
+    setDismissed(next);
+    writeDismissed(next);
+  }
+
+  async function backupOne(projectId: string) {
+    setBackingUpId(projectId);
+    try {
+      await syncManager.backupNow(projectId);
+      const status = syncManager.getStatus(projectId);
+      if (status.state === "backed-up") {
+        toast.success("Backed up to Synk.");
+      } else if (status.state === "limit-exceeded") {
+        toast.error(`${status.limit}-entity limit exceeded (${status.actual}) — ${status.tier} tier.`);
+      } else if (status.state === "error") {
+        toast.error(status.message);
+      }
+    } finally {
+      setBackingUpId(null);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border bg-muted/40 p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-start gap-2">
+          <CloudUploadIcon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+          <div>
+            <p className="text-sm font-medium">Back up your local projects to Synk</p>
+            <p className="text-xs text-muted-foreground">
+              Your data stays on this device — Synk only adds a backup. One click each, nothing moves.
+            </p>
+          </div>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="size-6 shrink-0 cursor-pointer"
+          onClick={dismissAll}
+          aria-label="Dismiss backup suggestions"
+        >
+          <XIcon className="size-4" />
+        </Button>
+      </div>
+
+      <ul className="flex flex-wrap gap-2">
+        {candidates.map((bundle) => (
+          <li key={bundle.project.id}>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="cursor-pointer"
+              disabled={backingUpId === bundle.project.id}
+              onClick={() => void backupOne(bundle.project.id)}
+            >
+              {backingUpId === bundle.project.id ? <Loader2Icon className="size-3.5 animate-spin" /> : null}
+              Back up &quot;{bundle.project.title}&quot;
+            </Button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/lib/hooks/useAuthStatus.ts
+++ b/lib/hooks/useAuthStatus.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Shared client-side view of `GET /api/auth/status` (docs/spec/services.md
+ * § Synk → Auth). Originally inlined in `components/auth/AuthButton.tsx`;
+ * factored out so the Synk client surfaces (per-project backup control,
+ * restore dialog, Lokal→Synk onboarding banner — issue #244) can each decide
+ * independently whether to render, without duplicating the fetch-once
+ * lifecycle. Every consumer, AuthButton included, polls the same cheap
+ * public-profile-only endpoint; no secret ever reaches the client.
+ */
+
+export interface AuthStatusUser {
+  name: string | null;
+  email: string | null;
+  image: string | null;
+}
+
+export type AuthStatus =
+  | { state: "loading" }
+  | { state: "unconfigured" }
+  | { state: "signed-out" }
+  | { state: "signed-in"; user: AuthStatusUser };
+
+export function useAuthStatus(): AuthStatus {
+  const [status, setStatus] = useState<AuthStatus>({ state: "loading" });
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadStatus() {
+      try {
+        const res = await fetch("/api/auth/status", { cache: "no-store" });
+        if (!res.ok) throw new Error(`status ${res.status}`);
+        const data: { configured: boolean; user: AuthStatusUser | null } = await res.json();
+        if (!active) return;
+        if (!data.configured) {
+          setStatus({ state: "unconfigured" });
+        } else if (data.user) {
+          setStatus({ state: "signed-in", user: data.user });
+        } else {
+          setStatus({ state: "signed-out" });
+        }
+      } catch {
+        // Treat any failure as "auth unavailable" — degrade to hidden, never
+        // block the local-first shell.
+        if (active) setStatus({ state: "unconfigured" });
+      }
+    }
+
+    void loadStatus();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return status;
+}

--- a/lib/sync/sync-manager.ts
+++ b/lib/sync/sync-manager.ts
@@ -1,0 +1,407 @@
+import { serializeBundle as canonicalSerializeBundle, type ProjectBundle } from "@arkaik/schema";
+
+import { getProvider } from "@/lib/data/provider-registry";
+import { subscribeToMutations } from "@/lib/data/local-provider";
+
+/**
+ * The client half of Synk (docs/spec/services.md § Synk → Client sync engine,
+ * issue #244 — the M4 "Lokal → Synk conversion funnel"). On every local
+ * mutation notification (issue #243's `subscribeToMutations`, the engine's
+ * trigger), debounce ~60s per project, then export → canonical-serialize →
+ * hash → `PUT /api/synk/projects/{id}`. Also drives a manual "Back up now"
+ * bypass and the per-project status the UI renders.
+ *
+ * Hard boundaries this module enforces (inherited from the spec):
+ *  - **One-way, up.** This module never writes a byte back into local
+ *    storage. It only reads (`exportProject`) and PUTs. Restore is a
+ *    different, explicit code path (components/sync/RestoreDialog.tsx) that
+ *    goes through the existing `importProject`/`importProjectFromFile` funnel
+ *    — never this module.
+ *  - **Dormant when signed out or unconfigured.** No timers, no fetches. The
+ *    engine checks a cached `AuthState` synchronously before ever arming a
+ *    debounce timer, and re-checks (fresh) immediately before every actual
+ *    backup attempt.
+ *  - **No data loss on failure.** A network failure or a 403 limit error
+ *    never retries on a timer of its own — the local bundle is untouched in
+ *    IndexedDB regardless, and the *next* mutation notification (or an
+ *    explicit "Back up now") is what retries. This mirrors the spec's own
+ *    phrasing: "network failures without data loss (retry on next
+ *    mutation)".
+ *
+ * ── Testability ─────────────────────────────────────────────────────────
+ * {@link createSyncManager} takes every side-effecting dependency as an
+ * injectable override (fetch, the mutation channel, the provider's
+ * `exportProject`, canonical serialization, hashing, timers, "now"). The
+ * pure debounce/hash/status-transition logic is exercised in plain Node by
+ * `tests/sync/sync-manager.test.js` with every dependency stubbed — no DOM,
+ * no IndexedDB, no network. {@link syncManager} is the real, browser-wired
+ * singleton every UI surface imports.
+ */
+
+/**
+ * Matches `lib/services/synk.ts`'s `BUNDLE_SHA256_HEADER` exactly (not
+ * imported from there: that module starts with `import "server-only"` and
+ * would break if pulled into a client bundle — see docs/spec/services.md's
+ * boundary notes). The header is advisory only (§ Backup protocol dedupe
+ * contract); a mismatch here would only cost a redundant server-side
+ * recomputation, never correctness.
+ */
+export const BUNDLE_SHA256_HEADER = "x-bundle-sha256";
+
+/** What the engine knows about the caller's session (GET /api/auth/status). */
+export interface AuthState {
+  configured: boolean;
+  signedIn: boolean;
+}
+
+/**
+ * Per-project sync status, driving the UI (docs/spec/services.md § Synk →
+ * Client sync engine: "visible per-project status (backed up · pending ·
+ * error · limit-exceeded)"). `limit-exceeded` carries the full structured
+ * 403 body so the UI can render it meaningfully (e.g. "250-entity limit
+ * exceeded (312) — synk tier").
+ */
+export type SyncStatus =
+  | { state: "idle" }
+  | { state: "pending" }
+  | { state: "syncing" }
+  | { state: "backed-up"; at: string }
+  | { state: "error"; message: string }
+  | { state: "limit-exceeded"; limit: number; actual: number; tier: string };
+
+const IDLE_STATUS: SyncStatus = { state: "idle" };
+
+/** Minimal per-project summary read from `GET /api/synk/projects` for onboarding + status hydration. */
+export interface ServerProjectSummary {
+  projectId: string;
+  lastBackupAt: string | null;
+}
+
+/** Mirrors `lib/data/local-provider.ts`'s `MutationEvent` shape (not imported — see the header-constant note above for the same reasoning; this one is just a plain data shape, no server-only concern, but staying import-free keeps this module's only value imports the two real seam functions it needs). */
+export interface MutationEvent {
+  projectId: string;
+}
+
+type TimerHandle = ReturnType<typeof setTimeout>;
+
+export interface SyncManagerDeps {
+  /** `fetch`-compatible; injected so tests never touch the network. */
+  fetchImpl: typeof fetch;
+  /** The mutation-notification channel (lib/data/local-provider.ts, issue #243) — the engine's trigger. */
+  subscribeToMutations: (cb: (event: MutationEvent) => void) => () => void;
+  /** Reads the current bundle for a project through the provider-injection seam (lib/data/provider-registry.ts). */
+  exportProject: (projectId: string) => Promise<ProjectBundle>;
+  /** Canonical serialization (packages/schema) — the exact bytes that get hashed and PUT. */
+  serializeBundle: (bundle: ProjectBundle) => string;
+  /** sha256 hex of the canonical bytes (Web Crypto in the real implementation). */
+  hashBundle: (canonical: string) => Promise<string>;
+  /** GET /api/auth/status, parsed to the two booleans the engine needs. */
+  getAuthState: () => Promise<AuthState>;
+  /** GET /api/synk/projects, parsed to a minimal per-project summary (for status hydration + onboarding). */
+  listServerProjects: () => Promise<ServerProjectSummary[]>;
+  /** Debounce window; ~60s per docs/spec/services.md, overridable for tests. */
+  debounceMs: number;
+  now: () => number;
+  setTimeoutFn: (cb: () => void, ms: number) => TimerHandle;
+  clearTimeoutFn: (handle: TimerHandle) => void;
+}
+
+interface PutBackupResponse {
+  status: number;
+  body: unknown;
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : "Unknown error";
+}
+
+/** Web Crypto SHA-256 over UTF-8 bytes, lowercase hex — the same format as `lib/services/synk.ts`'s `sha256Hex`. */
+async function defaultHashBundle(canonical: string): Promise<string> {
+  const bytes = new TextEncoder().encode(canonical);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function defaultGetAuthState(fetchImpl: typeof fetch): Promise<AuthState> {
+  try {
+    const res = await fetchImpl("/api/auth/status", { cache: "no-store" });
+    if (!res.ok) return { configured: false, signedIn: false };
+    const body = (await res.json()) as { configured: boolean; user: unknown | null };
+    return { configured: Boolean(body.configured), signedIn: Boolean(body.configured && body.user) };
+  } catch {
+    return { configured: false, signedIn: false };
+  }
+}
+
+async function defaultListServerProjects(fetchImpl: typeof fetch): Promise<ServerProjectSummary[]> {
+  try {
+    const res = await fetchImpl("/api/synk/projects", { cache: "no-store" });
+    if (!res.ok) return [];
+    const body = (await res.json()) as {
+      projects?: Array<{ project_id: string; latest_created_at: string | null }>;
+    };
+    return (body.projects ?? []).map((p) => ({ projectId: p.project_id, lastBackupAt: p.latest_created_at }));
+  } catch {
+    return [];
+  }
+}
+
+function defaultDeps(): SyncManagerDeps {
+  const fetchImpl: typeof fetch = (...args) => fetch(...args);
+  return {
+    fetchImpl,
+    subscribeToMutations,
+    exportProject: (projectId) => getProvider().exportProject(projectId),
+    serializeBundle: canonicalSerializeBundle,
+    hashBundle: defaultHashBundle,
+    getAuthState: () => defaultGetAuthState(fetchImpl),
+    listServerProjects: () => defaultListServerProjects(fetchImpl),
+    debounceMs: 60_000,
+    now: () => Date.now(),
+    setTimeoutFn: (cb, ms) => setTimeout(cb, ms),
+    clearTimeoutFn: (handle) => clearTimeout(handle),
+  };
+}
+
+export interface SyncManager {
+  /** Idempotent: subscribes to mutation notifications and kicks off an initial auth check. No-ops on repeat calls. */
+  start(): void;
+  /** Unsubscribes from mutations and clears every pending debounce timer. */
+  stop(): void;
+  /** Bypasses any pending debounce and attempts a backup immediately ("Back up now"). */
+  backupNow(projectId: string): Promise<void>;
+  getStatus(projectId: string): SyncStatus;
+  /** useSyncExternalStore-friendly: fires whenever ANY project's status changes. */
+  subscribe(listener: () => void): () => void;
+  /** Re-checks auth (cached between calls otherwise) — called on start, before every backup attempt, and can be called by the UI on window focus. */
+  refreshAuth(): Promise<AuthState>;
+  getAuthState(): AuthState;
+}
+
+/**
+ * Build a SyncManager over injected dependencies. See the module doc above
+ * for the testability rationale. Every side effect (network, timers,
+ * hashing, the provider read, the mutation subscription) is a field on
+ * {@link SyncManagerDeps}; omitted fields fall back to the real browser
+ * wiring via {@link defaultDeps}.
+ */
+export function createSyncManager(overrides: Partial<SyncManagerDeps> = {}): SyncManager {
+  const deps: SyncManagerDeps = { ...defaultDeps(), ...overrides };
+
+  let started = false;
+  let unsubscribeMutations: (() => void) | null = null;
+  let authState: AuthState = { configured: false, signedIn: false };
+  let hydratedFromServer = false;
+
+  let statusMap: Map<string, SyncStatus> = new Map();
+  const listeners = new Set<() => void>();
+  const timers = new Map<string, TimerHandle>();
+
+  function emit() {
+    for (const listener of listeners) listener();
+  }
+
+  function setStatus(projectId: string, status: SyncStatus) {
+    statusMap = new Map(statusMap);
+    statusMap.set(projectId, status);
+    emit();
+  }
+
+  /** Seed a project's status from the server's backup listing — but only if
+   * nothing local (a pending timer, an in-flight sync, a prior error) has
+   * already claimed this session's view of that project's status. */
+  function seedIfUnknown(projectId: string, atIso: string) {
+    if (statusMap.has(projectId)) return;
+    setStatus(projectId, { state: "backed-up", at: atIso });
+  }
+
+  function clearTimer(projectId: string) {
+    const handle = timers.get(projectId);
+    if (handle !== undefined) {
+      deps.clearTimeoutFn(handle);
+      timers.delete(projectId);
+    }
+  }
+
+  /** Runs once per "became signed in" transition (docs/spec/services.md's
+   * onboarding funnel needs the server's view to know what's already backed
+   * up; the per-project status badges benefit from it too, on cold load). */
+  async function hydrateFromServer() {
+    if (hydratedFromServer) return;
+    hydratedFromServer = true;
+    try {
+      const projects = await deps.listServerProjects();
+      for (const p of projects) {
+        if (p.lastBackupAt) seedIfUnknown(p.projectId, p.lastBackupAt);
+      }
+    } catch {
+      hydratedFromServer = false; // soft failure — allow a later refreshAuth to retry
+    }
+  }
+
+  async function refreshAuth(): Promise<AuthState> {
+    const next = await deps.getAuthState();
+    const justSignedIn = !authState.signedIn && next.signedIn;
+    authState = next;
+    if (justSignedIn) void hydrateFromServer();
+    return authState;
+  }
+
+  function onMutation(event: MutationEvent) {
+    if (!started) return;
+    // Dormant while signed out/unconfigured: no timer is ever armed, per the
+    // spec's "SyncManager stays dormant (no timers, no fetches)".
+    if (!authState.configured || !authState.signedIn) return;
+    scheduleDebounced(event.projectId);
+  }
+
+  function scheduleDebounced(projectId: string) {
+    clearTimer(projectId);
+    setStatus(projectId, { state: "pending" });
+    const handle = deps.setTimeoutFn(() => {
+      void performBackup(projectId);
+    }, deps.debounceMs);
+    timers.set(projectId, handle);
+  }
+
+  async function putBackup(projectId: string, canonical: string, hash: string | null): Promise<PutBackupResponse> {
+    const headers: Record<string, string> = { "content-type": "application/json" };
+    if (hash) headers[BUNDLE_SHA256_HEADER] = hash;
+    const res = await deps.fetchImpl(`/api/synk/projects/${encodeURIComponent(projectId)}`, {
+      method: "PUT",
+      headers,
+      body: canonical,
+    });
+    let body: unknown = null;
+    try {
+      body = await res.json();
+    } catch {
+      body = null;
+    }
+    return { status: res.status, body };
+  }
+
+  async function performBackup(projectId: string): Promise<void> {
+    clearTimer(projectId);
+
+    // Refresh immediately before attempting (§ "refresh ... before a backup
+    // attempt") — a stale cached "signed in" would otherwise fire a doomed PUT.
+    await refreshAuth();
+    if (!authState.configured || !authState.signedIn) {
+      // Stays wherever it was (e.g. "pending"): the local bundle is safe in
+      // IndexedDB regardless, and the next mutation or an explicit
+      // backupNow() re-attempts once signed in again.
+      return;
+    }
+
+    setStatus(projectId, { state: "syncing" });
+
+    let bundle: ProjectBundle;
+    try {
+      bundle = await deps.exportProject(projectId);
+    } catch (err) {
+      setStatus(projectId, { state: "error", message: errorMessage(err) });
+      return;
+    }
+
+    const canonical = deps.serializeBundle(bundle);
+    let hash: string | null;
+    try {
+      hash = await deps.hashBundle(canonical);
+    } catch {
+      hash = null; // the header is advisory-only — a hash failure never blocks the PUT
+    }
+
+    let response: PutBackupResponse;
+    try {
+      response = await putBackup(projectId, canonical, hash);
+    } catch (err) {
+      // Network failure: no data lost, the local bundle is untouched — the
+      // next mutation notification (or a manual "Back up now") retries.
+      setStatus(projectId, { state: "error", message: errorMessage(err) });
+      return;
+    }
+
+    switch (response.status) {
+      case 200:
+      case 201: {
+        setStatus(projectId, { state: "backed-up", at: new Date(deps.now()).toISOString() });
+        return;
+      }
+      case 403: {
+        const body = (response.body ?? {}) as { limit?: number; actual?: number; tier?: string };
+        setStatus(projectId, {
+          state: "limit-exceeded",
+          limit: typeof body.limit === "number" ? body.limit : 0,
+          actual: typeof body.actual === "number" ? body.actual : 0,
+          tier: typeof body.tier === "string" ? body.tier : "synk",
+        });
+        return;
+      }
+      case 401: {
+        // Session lapsed mid-flight: stop believing we're signed in so the
+        // next mutation stays dormant until a fresh sign-in proves otherwise.
+        authState = { ...authState, signedIn: false };
+        setStatus(projectId, { state: "error", message: "Signed out — sign in to back up this project." });
+        return;
+      }
+      case 503: {
+        setStatus(projectId, { state: "error", message: "Synk backups are not available on this deployment." });
+        return;
+      }
+      default: {
+        const body = (response.body ?? {}) as { message?: string; error?: string };
+        setStatus(projectId, {
+          state: "error",
+          message: body.message ?? body.error ?? `Backup failed (HTTP ${response.status}).`,
+        });
+      }
+    }
+  }
+
+  return {
+    start() {
+      if (started) return;
+      started = true;
+      unsubscribeMutations = deps.subscribeToMutations(onMutation);
+      void refreshAuth();
+    },
+    stop() {
+      started = false;
+      unsubscribeMutations?.();
+      unsubscribeMutations = null;
+      for (const handle of timers.values()) deps.clearTimeoutFn(handle);
+      timers.clear();
+    },
+    async backupNow(projectId: string) {
+      await performBackup(projectId);
+    },
+    getStatus(projectId: string) {
+      return statusMap.get(projectId) ?? IDLE_STATUS;
+    },
+    subscribe(listener: () => void) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    refreshAuth,
+    getAuthState() {
+      return authState;
+    },
+  };
+}
+
+/**
+ * The app-wide singleton (docs/spec/services.md § Synk → Client sync engine:
+ * "SyncManager (lib/sync/)"). `components/sync/SyncProvider.tsx` calls
+ * `.start()` once from a client-only effect; every other UI surface (the
+ * per-project status control, the onboarding banner) imports this same
+ * instance so their view of status stays consistent app-wide. Constructing it
+ * here is side-effect-free — `defaultDeps()` only captures function
+ * references, it never calls `fetch`, IndexedDB, or Web Crypto at import
+ * time — so importing this module during SSR/prerender is safe.
+ */
+export const syncManager: SyncManager = createSyncManager();

--- a/lib/sync/use-sync-status.ts
+++ b/lib/sync/use-sync-status.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+import { syncManager, type SyncStatus } from "./sync-manager";
+
+/**
+ * `useSyncExternalStore`-friendly view of one project's Synk backup status
+ * (docs/spec/services.md § Synk → Client sync engine: "visible per-project
+ * status"). Re-renders whenever {@link syncManager} reports a change for
+ * ANY project — cheap at this app's scale, and `syncManager.getStatus`
+ * returns a stable object reference for an unchanged project, so React skips
+ * re-rendering components whose own project didn't change.
+ */
+export function useSyncStatus(projectId: string): SyncStatus {
+  return useSyncExternalStore(
+    syncManager.subscribe,
+    () => syncManager.getStatus(projectId),
+    () => syncManager.getStatus(projectId),
+  );
+}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "test:cli": "npm run build -w arkaik && node tests/cli/run-cli-tests.js && node tests/cli/init.test.js && node tests/cli/log-release.test.js && node tests/cli/sync.test.js && node tests/cli/pack-open.test.js && node tests/cli/push.test.js",
     "test:auth": "node tests/services/auth-guard.test.js",
     "test:publik": "node tests/services/publik-api.test.js",
-    "test:synk": "node tests/services/synk-api.test.js"
+    "test:synk": "node tests/services/synk-api.test.js",
+    "test:sync": "node tests/sync/sync-manager.test.js"
   },
   "dependencies": {
     "@auth/pg-adapter": "^1.11.2",

--- a/tests/sync/load-sync-manager.js
+++ b/tests/sync/load-sync-manager.js
@@ -1,0 +1,84 @@
+/**
+ * Loads lib/sync/sync-manager.ts into a running Node process without a
+ * bundler — the same transpile-on-the-fly approach as the other tests/*
+ * loaders (see tests/services/load-synk-api.js, tests/data/load-local-provider.js).
+ *
+ * sync-manager.ts's non-type runtime imports are:
+ *  - `@arkaik/schema`               (serializeBundle)      → the real built package
+ *  - `@/lib/data/provider-registry` (getProvider)           → a tiny stub
+ *  - `@/lib/data/local-provider`    (subscribeToMutations)  → a tiny stub
+ *
+ * The provider-registry/local-provider stubs only need to exist so the
+ * transpiled module's `require()` calls resolve — `createSyncManager()`'s
+ * `overrides` parameter lets every test replace `subscribeToMutations`,
+ * `exportProject`, `fetchImpl`, etc. directly, so the module's *default*
+ * wiring (built from these stubs) is constructed but never actually invoked
+ * by any test in tests/sync/sync-manager.test.js. The real @arkaik/schema
+ * package IS loaded for real, so `serializeBundle` behaves exactly as it
+ * does in the browser when a test exercises the default hash/serialize path.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const ts = require("typescript");
+const { loadSchema, BUILD_DIR: SCHEMA_BUILD_DIR } = require("../schema/load-schema");
+
+const ROOT = path.join(__dirname, "..", "..");
+const BUILD_DIR = path.join(__dirname, ".test-build-sync-manager");
+
+const COMPILER_OPTIONS = {
+  module: ts.ModuleKind.CommonJS,
+  target: ts.ScriptTarget.ES2020,
+  esModuleInterop: true,
+};
+
+function transpile(srcAbsPath, fileName, rewrites) {
+  const source = fs.readFileSync(srcAbsPath, "utf8");
+  let { outputText } = ts.transpileModule(source, { fileName, compilerOptions: COMPILER_OPTIONS });
+  for (const [specifier, replacement] of rewrites) {
+    const pattern = new RegExp(
+      `require\\((['"])${specifier.replace(/[.*+?^${}()|[\]\\/]/g, "\\$&")}\\1\\)`,
+      "g",
+    );
+    outputText = outputText.replace(pattern, `require(${JSON.stringify(replacement)})`);
+  }
+  return outputText;
+}
+
+function loadSyncManager() {
+  loadSchema();
+  const schemaIndex = path.join(SCHEMA_BUILD_DIR, "index.js");
+
+  fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+  fs.mkdirSync(BUILD_DIR, { recursive: true });
+  fs.writeFileSync(path.join(BUILD_DIR, "package.json"), JSON.stringify({ type: "commonjs" }));
+
+  const write = (name, text) => fs.writeFileSync(path.join(BUILD_DIR, name), text);
+
+  // Never functionally exercised — every test overrides subscribeToMutations
+  // / exportProject directly via createSyncManager()'s deps parameter.
+  write(
+    "provider-registry-stub.js",
+    "module.exports = { getProvider: () => { throw new Error(\"getProvider() stub should never be called — override exportProject in the test.\"); } };\n",
+  );
+  write(
+    "local-provider-stub.js",
+    "module.exports = { subscribeToMutations: () => { throw new Error(\"subscribeToMutations stub should never be called — override it in the test.\"); } };\n",
+  );
+
+  write(
+    "sync-manager.js",
+    transpile(path.join(ROOT, "lib", "sync", "sync-manager.ts"), "sync-manager.ts", [
+      ["@arkaik/schema", schemaIndex],
+      ["@/lib/data/provider-registry", path.join(BUILD_DIR, "provider-registry-stub.js")],
+      ["@/lib/data/local-provider", path.join(BUILD_DIR, "local-provider-stub.js")],
+    ]),
+  );
+
+  const names = ["provider-registry-stub.js", "local-provider-stub.js", "sync-manager.js"];
+  for (const name of names) delete require.cache[path.join(BUILD_DIR, name)];
+
+  return require(path.join(BUILD_DIR, "sync-manager.js"));
+}
+
+module.exports = { loadSyncManager, BUILD_DIR, SCHEMA_BUILD_DIR };

--- a/tests/sync/sync-manager.test.js
+++ b/tests/sync/sync-manager.test.js
@@ -1,0 +1,606 @@
+#!/usr/bin/env node
+
+/**
+ * Unit tests for lib/sync/sync-manager.ts (issue #244, docs/spec/services.md
+ * § Synk → Client sync engine). Pure logic only — every side effect (fetch,
+ * the mutation channel, the provider's exportProject, hashing, timers) is
+ * stubbed via `createSyncManager()`'s dependency-injection, per the loader's
+ * doc comment. No DOM, no IndexedDB, no real network.
+ *
+ * Coverage (the acceptance list from issue #244):
+ *  - dormant when signed out / unconfigured: no timers, no fetches
+ *  - debounce: a mutation notification arms exactly one per-project timer;
+ *    repeated mutations before it fires coalesce into one
+ *  - "Back up now" bypasses the debounce timer
+ *  - export → serialize → hash → PUT, with the correct method/URL/header
+ *  - status transitions: pending → syncing → backed-up / error / limit-exceeded
+ *  - 403 renders the structured { limit, actual, tier } body
+ *  - network failure and 401 leave the local bundle untouched and simply
+ *    wait for the next mutation (or manual backupNow) to retry — no
+ *    automatic retry timer of the engine's own
+ *  - hash failure never blocks the PUT (advisory-only header)
+ *  - server-list hydration seeds "backed-up" status without clobbering a
+ *    status already known this session
+ *  - subscribe/unsubscribe, stop() teardown, start() idempotency
+ *  - the REAL @arkaik/schema canonical serialize + real Web Crypto SHA-256
+ *    produce a correct, verifiable hash end-to-end
+ */
+
+const crypto = require("crypto");
+const fs = require("fs");
+const { loadSyncManager, BUILD_DIR, SCHEMA_BUILD_DIR } = require("./load-sync-manager");
+
+let failures = 0;
+function check(name, cond, detail) {
+  if (cond) {
+    console.log(`PASS: ${name}`);
+  } else {
+    failures++;
+    console.log(`FAIL: ${name}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+function fakeResponse(status, body) {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    json: async () => body,
+  };
+}
+
+/** A controllable fake `setTimeout`/`clearTimeout` pair — records the
+ * requested delay per handle and lets tests fire callbacks on demand instead
+ * of waiting out a real 60s debounce. */
+function makeFakeTimers() {
+  let nextId = 1;
+  const pending = new Map(); // id -> { cb, ms }
+  return {
+    setTimeoutFn: (cb, ms) => {
+      const id = nextId++;
+      pending.set(id, { cb, ms });
+      return id;
+    },
+    clearTimeoutFn: (id) => {
+      pending.delete(id);
+    },
+    fireAll: () => {
+      const entries = Array.from(pending.entries());
+      pending.clear();
+      for (const [, { cb }] of entries) cb();
+    },
+    pendingCount: () => pending.size,
+    pendingMs: () => Array.from(pending.values()).map((t) => t.ms),
+  };
+}
+
+/** Drains the microtask queue (a real macrotask boundary guarantees every
+ * currently-queued promise continuation — however many hops — has run). */
+function flush() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function noopUnsubscribe() {}
+
+async function main() {
+  const { createSyncManager } = loadSyncManager();
+
+  // --- A. dormant when signed out: no timer armed, backupNow no-ops -------
+  {
+    let exportCalled = false;
+    let fetchCalled = false;
+    const timers = makeFakeTimers();
+    let capturedOnMutation = null;
+    const manager = createSyncManager({
+      subscribeToMutations: (cb) => {
+        capturedOnMutation = cb;
+        return noopUnsubscribe;
+      },
+      getAuthState: async () => ({ configured: true, signedIn: false }),
+      listServerProjects: async () => [],
+      exportProject: async () => {
+        exportCalled = true;
+        return { project: { id: "p1", title: "T" }, nodes: [], edges: [] };
+      },
+      fetchImpl: async () => {
+        fetchCalled = true;
+        return fakeResponse(201, { id: "b1", deduped: false });
+      },
+      setTimeoutFn: timers.setTimeoutFn,
+      clearTimeoutFn: timers.clearTimeoutFn,
+    });
+    manager.start();
+    await manager.refreshAuth();
+    capturedOnMutation({ projectId: "p1" });
+    check("signed-out: mutation arms no timer", timers.pendingCount() === 0);
+    check("signed-out: status stays idle", manager.getStatus("p1").state === "idle");
+
+    await manager.backupNow("p1");
+    check("signed-out: backupNow does not call exportProject", !exportCalled);
+    check("signed-out: backupNow does not call fetch", !fetchCalled);
+    check("signed-out: status still idle after backupNow", manager.getStatus("p1").state === "idle");
+  }
+
+  // --- B. dormant when unconfigured (no DATABASE_URL / auth unset) --------
+  {
+    const timers = makeFakeTimers();
+    let capturedOnMutation = null;
+    let fetchCalled = false;
+    const manager = createSyncManager({
+      subscribeToMutations: (cb) => {
+        capturedOnMutation = cb;
+        return noopUnsubscribe;
+      },
+      getAuthState: async () => ({ configured: false, signedIn: false }),
+      listServerProjects: async () => [],
+      exportProject: async () => ({ project: { id: "p1", title: "T" }, nodes: [], edges: [] }),
+      fetchImpl: async () => {
+        fetchCalled = true;
+        return fakeResponse(201, {});
+      },
+      setTimeoutFn: timers.setTimeoutFn,
+      clearTimeoutFn: timers.clearTimeoutFn,
+    });
+    manager.start();
+    await manager.refreshAuth();
+    capturedOnMutation({ projectId: "p1" });
+    check("unconfigured: mutation arms no timer", timers.pendingCount() === 0);
+    await manager.backupNow("p1");
+    check("unconfigured: backupNow never calls fetch", !fetchCalled);
+  }
+
+  // --- C/D. debounce: one timer per project, coalesces repeats ------------
+  {
+    const timers = makeFakeTimers();
+    let capturedOnMutation = null;
+    const manager = createSyncManager({
+      subscribeToMutations: (cb) => {
+        capturedOnMutation = cb;
+        return noopUnsubscribe;
+      },
+      getAuthState: async () => ({ configured: true, signedIn: true }),
+      listServerProjects: async () => [],
+      exportProject: async () => ({ project: { id: "p1", title: "T" }, nodes: [], edges: [] }),
+      fetchImpl: async () => fakeResponse(201, { id: "b1", deduped: false }),
+      setTimeoutFn: timers.setTimeoutFn,
+      clearTimeoutFn: timers.clearTimeoutFn,
+      debounceMs: 61234,
+    });
+    manager.start();
+    await manager.refreshAuth();
+
+    capturedOnMutation({ projectId: "p1" });
+    check("signed-in: mutation sets pending status", manager.getStatus("p1").state === "pending");
+    check("signed-in: exactly one timer armed", timers.pendingCount() === 1);
+    check("debounce delay matches configured debounceMs", timers.pendingMs()[0] === 61234);
+
+    capturedOnMutation({ projectId: "p1" });
+    check(
+      "a second mutation before the timer fires coalesces (still one timer)",
+      timers.pendingCount() === 1,
+    );
+
+    capturedOnMutation({ projectId: "p2" });
+    check("a different project gets its own timer", timers.pendingCount() === 2);
+  }
+
+  // --- E. backupNow bypasses the debounce ----------------------------------
+  {
+    const timers = makeFakeTimers();
+    let capturedOnMutation = null;
+    let fetchCallCount = 0;
+    const manager = createSyncManager({
+      subscribeToMutations: (cb) => {
+        capturedOnMutation = cb;
+        return noopUnsubscribe;
+      },
+      getAuthState: async () => ({ configured: true, signedIn: true }),
+      listServerProjects: async () => [],
+      exportProject: async () => ({ project: { id: "p1", title: "T" }, nodes: [], edges: [] }),
+      hashBundle: async () => "stub-hash",
+      fetchImpl: async () => {
+        fetchCallCount++;
+        return fakeResponse(201, { id: "b1", deduped: false });
+      },
+      setTimeoutFn: timers.setTimeoutFn,
+      clearTimeoutFn: timers.clearTimeoutFn,
+    });
+    manager.start();
+    await manager.refreshAuth();
+
+    capturedOnMutation({ projectId: "p1" });
+    check("backupNow test: timer armed before bypass", timers.pendingCount() === 1);
+
+    await manager.backupNow("p1");
+    check("backupNow clears the pending debounce timer", timers.pendingCount() === 0);
+    check("backupNow performed exactly one PUT", fetchCallCount === 1);
+    check("backupNow: final status is backed-up", manager.getStatus("p1").state === "backed-up");
+  }
+
+  // --- F/G. status transitions + request shape -----------------------------
+  {
+    let captured = null;
+    const manager = createSyncManager({
+      subscribeToMutations: () => noopUnsubscribe,
+      getAuthState: async () => ({ configured: true, signedIn: true }),
+      listServerProjects: async () => [],
+      exportProject: async () => ({ project: { id: "p1", title: "T" }, nodes: [], edges: [] }),
+      hashBundle: async () => "abc123",
+      fetchImpl: async (url, init) => {
+        captured = { url, init };
+        return fakeResponse(201, { id: "b1", deduped: false });
+      },
+      now: () => Date.parse("2026-07-13T12:00:00.000Z"),
+    });
+
+    const transitions = [];
+    manager.subscribe(() => transitions.push(manager.getStatus("p1").state));
+
+    await manager.backupNow("p1");
+    check("request method is PUT", captured.init.method === "PUT");
+    check("request URL targets the project's backup endpoint", captured.url === "/api/synk/projects/p1");
+    check(
+      "request carries the advisory x-bundle-sha256 header",
+      captured.init.headers["x-bundle-sha256"] === "abc123",
+    );
+    check("content-type is application/json", captured.init.headers["content-type"] === "application/json");
+    check(
+      "status transitions syncing → backed-up",
+      transitions.includes("syncing") && transitions[transitions.length - 1] === "backed-up",
+      JSON.stringify(transitions),
+    );
+    const status = manager.getStatus("p1");
+    check(
+      "stored (201) sets backed-up with the injected now() as ISO",
+      status.state === "backed-up" && status.at === "2026-07-13T12:00:00.000Z",
+      JSON.stringify(status),
+    );
+  }
+
+  // --- G. deduped (200) also reads as backed-up ----------------------------
+  {
+    const manager = createSyncManager({
+      subscribeToMutations: () => noopUnsubscribe,
+      getAuthState: async () => ({ configured: true, signedIn: true }),
+      listServerProjects: async () => [],
+      exportProject: async () => ({ project: { id: "p1", title: "T" }, nodes: [], edges: [] }),
+      hashBundle: async () => "abc123",
+      fetchImpl: async () => fakeResponse(200, { deduped: true }),
+      now: () => Date.parse("2026-07-13T12:00:00.000Z"),
+    });
+    await manager.backupNow("p1");
+    check("deduped 200 also sets backed-up", manager.getStatus("p1").state === "backed-up");
+  }
+
+  // --- H. 403 renders the structured limit body ----------------------------
+  {
+    const manager = createSyncManager({
+      subscribeToMutations: () => noopUnsubscribe,
+      getAuthState: async () => ({ configured: true, signedIn: true }),
+      listServerProjects: async () => [],
+      exportProject: async () => ({ project: { id: "p1", title: "T" }, nodes: [], edges: [] }),
+      hashBundle: async () => "abc123",
+      fetchImpl: async () =>
+        fakeResponse(403, { error: "limit_exceeded", limit: 250, actual: 312, tier: "synk" }),
+    });
+    await manager.backupNow("p1");
+    const status = manager.getStatus("p1");
+    check(
+      "403 sets limit-exceeded with { limit, actual, tier }",
+      status.state === "limit-exceeded" && status.limit === 250 && status.actual === 312 && status.tier === "synk",
+      JSON.stringify(status),
+    );
+  }
+
+  // --- I. network failure: error status, no auto-retry timer, retries on the next mutation ---
+  {
+    const timers = makeFakeTimers();
+    let capturedOnMutation = null;
+    let attempt = 0;
+    const manager = createSyncManager({
+      subscribeToMutations: (cb) => {
+        capturedOnMutation = cb;
+        return noopUnsubscribe;
+      },
+      getAuthState: async () => ({ configured: true, signedIn: true }),
+      listServerProjects: async () => [],
+      exportProject: async () => ({ project: { id: "p1", title: "T" }, nodes: [], edges: [] }),
+      hashBundle: async () => "abc123",
+      fetchImpl: async () => {
+        attempt++;
+        throw new Error("network down");
+      },
+      setTimeoutFn: timers.setTimeoutFn,
+      clearTimeoutFn: timers.clearTimeoutFn,
+    });
+    manager.start();
+    await manager.refreshAuth();
+
+    await manager.backupNow("p1");
+    let status = manager.getStatus("p1");
+    check(
+      "network failure sets an error status carrying the failure message",
+      status.state === "error" && status.message.includes("network down"),
+      JSON.stringify(status),
+    );
+    check("a network failure does not arm its own retry timer", timers.pendingCount() === 0);
+
+    // The local bundle was never lost — it's still in exportProject's backing
+    // store, untouched. The next mutation is what retries.
+    capturedOnMutation({ projectId: "p1" });
+    status = manager.getStatus("p1");
+    check(
+      "the next mutation notification re-arms the debounce (retry-on-next-mutation)",
+      status.state === "pending" && timers.pendingCount() === 1,
+      JSON.stringify(status),
+    );
+  }
+
+  // --- J. 401 mid-flight marks the session signed-out; further mutations stay dormant ---
+  {
+    const timers = makeFakeTimers();
+    let capturedOnMutation = null;
+    const manager = createSyncManager({
+      subscribeToMutations: (cb) => {
+        capturedOnMutation = cb;
+        return noopUnsubscribe;
+      },
+      getAuthState: async () => ({ configured: true, signedIn: true }),
+      listServerProjects: async () => [],
+      exportProject: async () => ({ project: { id: "p1", title: "T" }, nodes: [], edges: [] }),
+      hashBundle: async () => "abc123",
+      fetchImpl: async () => fakeResponse(401, { error: "unauthorized" }),
+      setTimeoutFn: timers.setTimeoutFn,
+      clearTimeoutFn: timers.clearTimeoutFn,
+    });
+    manager.start();
+    await manager.refreshAuth();
+
+    await manager.backupNow("p1");
+    check("401 sets an error status", manager.getStatus("p1").state === "error");
+    check("401 flips the cached auth state to signed-out", manager.getAuthState().signedIn === false);
+
+    capturedOnMutation({ projectId: "p1" });
+    check(
+      "after a 401, a further mutation stays dormant (no timer)",
+      timers.pendingCount() === 0,
+    );
+  }
+
+  // --- K. 503 renders a clear "not available" message ----------------------
+  {
+    const manager = createSyncManager({
+      subscribeToMutations: () => noopUnsubscribe,
+      getAuthState: async () => ({ configured: true, signedIn: true }),
+      listServerProjects: async () => [],
+      exportProject: async () => ({ project: { id: "p1", title: "T" }, nodes: [], edges: [] }),
+      hashBundle: async () => "abc123",
+      fetchImpl: async () =>
+        fakeResponse(503, { error: "services_unavailable", message: "arkaik services (Synk) are not configured." }),
+    });
+    await manager.backupNow("p1");
+    const status = manager.getStatus("p1");
+    check(
+      "503 sets an error status mentioning unavailability",
+      status.state === "error" && /not available/i.test(status.message),
+      JSON.stringify(status),
+    );
+  }
+
+  // --- L. a hash failure never blocks the PUT (advisory-only header) -------
+  {
+    let captured = null;
+    const manager = createSyncManager({
+      subscribeToMutations: () => noopUnsubscribe,
+      getAuthState: async () => ({ configured: true, signedIn: true }),
+      listServerProjects: async () => [],
+      exportProject: async () => ({ project: { id: "p1", title: "T" }, nodes: [], edges: [] }),
+      hashBundle: async () => {
+        throw new Error("crypto unavailable");
+      },
+      fetchImpl: async (url, init) => {
+        captured = init;
+        return fakeResponse(201, { id: "b1", deduped: false });
+      },
+    });
+    await manager.backupNow("p1");
+    check("a hash failure still results in a PUT", captured !== null);
+    check(
+      "the advisory header is simply omitted when hashing fails",
+      !("x-bundle-sha256" in captured.headers),
+    );
+    check("backup still succeeds despite the hash failure", manager.getStatus("p1").state === "backed-up");
+  }
+
+  // --- M. exportProject failure never calls fetch ---------------------------
+  {
+    let fetchCalled = false;
+    const manager = createSyncManager({
+      subscribeToMutations: () => noopUnsubscribe,
+      getAuthState: async () => ({ configured: true, signedIn: true }),
+      listServerProjects: async () => [],
+      exportProject: async () => {
+        throw new Error("project not found");
+      },
+      fetchImpl: async () => {
+        fetchCalled = true;
+        return fakeResponse(201, {});
+      },
+    });
+    await manager.backupNow("p1");
+    check("an exportProject failure never calls fetch", !fetchCalled);
+    check(
+      "an exportProject failure sets an error status with its message",
+      manager.getStatus("p1").state === "error" && manager.getStatus("p1").message.includes("project not found"),
+    );
+  }
+
+  // --- N. server-list hydration seeds backed-up status without clobbering ---
+  {
+    let resolveList;
+    const listPromise = new Promise((resolve) => {
+      resolveList = resolve;
+    });
+    let capturedOnMutation = null;
+    const manager = createSyncManager({
+      subscribeToMutations: (cb) => {
+        capturedOnMutation = cb;
+        return noopUnsubscribe;
+      },
+      getAuthState: async () => ({ configured: true, signedIn: true }),
+      listServerProjects: () => listPromise,
+      exportProject: async () => ({ project: { id: "p2", title: "T" }, nodes: [], edges: [] }),
+    });
+    manager.start();
+    await manager.refreshAuth(); // resolves auth; hydrateFromServer is now in flight (awaiting listPromise)
+
+    // p2 gets a locally-known status (pending) BEFORE the server list resolves.
+    capturedOnMutation({ projectId: "p2" });
+    check("p2 has a local pending status before hydration resolves", manager.getStatus("p2").state === "pending");
+
+    resolveList([
+      { projectId: "p1", lastBackupAt: "2026-01-01T00:00:00.000Z" },
+      { projectId: "p2", lastBackupAt: "2026-01-02T00:00:00.000Z" },
+    ]);
+    await flush();
+
+    const p1 = manager.getStatus("p1");
+    check(
+      "hydration seeds a never-locally-known project as backed-up",
+      p1.state === "backed-up" && p1.at === "2026-01-01T00:00:00.000Z",
+      JSON.stringify(p1),
+    );
+    check(
+      "hydration does NOT clobber a status already known this session",
+      manager.getStatus("p2").state === "pending",
+      JSON.stringify(manager.getStatus("p2")),
+    );
+  }
+
+  // --- O. subscribe/unsubscribe ----------------------------------------------
+  {
+    const manager = createSyncManager({
+      subscribeToMutations: () => noopUnsubscribe,
+      getAuthState: async () => ({ configured: true, signedIn: true }),
+      listServerProjects: async () => [],
+      exportProject: async () => ({ project: { id: "p1", title: "T" }, nodes: [], edges: [] }),
+      hashBundle: async () => "abc",
+      fetchImpl: async () => fakeResponse(201, { id: "b1", deduped: false }),
+    });
+    let calls = 0;
+    const unsubscribe = manager.subscribe(() => {
+      calls++;
+    });
+    await manager.backupNow("p1");
+    check("subscriber is notified on status changes", calls > 0);
+
+    unsubscribe();
+    const callsAtUnsubscribe = calls;
+    await manager.backupNow("p1");
+    check("unsubscribe() actually stops delivery", calls === callsAtUnsubscribe);
+  }
+
+  // --- P. stop() unsubscribes and clears pending timers -----------------------
+  {
+    const timers = makeFakeTimers();
+    let capturedOnMutation = null;
+    let unsubscribeCalled = false;
+    const manager = createSyncManager({
+      subscribeToMutations: (cb) => {
+        capturedOnMutation = cb;
+        return () => {
+          unsubscribeCalled = true;
+        };
+      },
+      getAuthState: async () => ({ configured: true, signedIn: true }),
+      listServerProjects: async () => [],
+      exportProject: async () => ({ project: { id: "p1", title: "T" }, nodes: [], edges: [] }),
+      setTimeoutFn: timers.setTimeoutFn,
+      clearTimeoutFn: timers.clearTimeoutFn,
+    });
+    manager.start();
+    await manager.refreshAuth();
+    capturedOnMutation({ projectId: "p1" });
+    check("stop() test: a timer is pending before stop()", timers.pendingCount() === 1);
+
+    manager.stop();
+    check("stop() unsubscribes from the mutation channel", unsubscribeCalled);
+    check("stop() clears every pending debounce timer", timers.pendingCount() === 0);
+  }
+
+  // --- Q. start() is idempotent ------------------------------------------------
+  {
+    let subscribeCallCount = 0;
+    const manager = createSyncManager({
+      subscribeToMutations: () => {
+        subscribeCallCount++;
+        return noopUnsubscribe;
+      },
+      getAuthState: async () => ({ configured: false, signedIn: false }),
+      listServerProjects: async () => [],
+      exportProject: async () => ({ project: { id: "p1", title: "T" }, nodes: [], edges: [] }),
+    });
+    manager.start();
+    manager.start();
+    manager.start();
+    check("start() only subscribes once even when called repeatedly", subscribeCallCount === 1);
+  }
+
+  // --- R. real canonical serialize + real Web Crypto hash, cross-checked ------
+  {
+    let capturedBody = null;
+    let capturedHeaders = null;
+    const bundle = {
+      schema_version: 2,
+      project: {
+        id: "p-real",
+        title: "Real Bundle",
+        created_at: "2026-01-01T00:00:00.000Z",
+        updated_at: "2026-01-01T00:00:00.000Z",
+        archived_at: null,
+      },
+      nodes: [
+        { id: "V-b", project_id: "p-real", species: "view", title: "B", status: "idea", platforms: ["web"] },
+        { id: "V-a", project_id: "p-real", species: "view", title: "A", status: "idea", platforms: ["web"] },
+      ],
+      edges: [],
+    };
+    const manager = createSyncManager({
+      subscribeToMutations: () => noopUnsubscribe,
+      getAuthState: async () => ({ configured: true, signedIn: true }),
+      listServerProjects: async () => [],
+      exportProject: async () => bundle,
+      // serializeBundle and hashBundle are NOT overridden — the real
+      // @arkaik/schema canonical serializer and real Web Crypto SHA-256 run.
+      fetchImpl: async (url, init) => {
+        capturedBody = init.body;
+        capturedHeaders = init.headers;
+        return fakeResponse(201, { id: "b-real", deduped: false });
+      },
+    });
+
+    await manager.backupNow("p-real");
+
+    check("real serializeBundle sorted the nodes by id", capturedBody.indexOf('"V-a"') < capturedBody.indexOf('"V-b"'));
+    const expectedHash = crypto.createHash("sha256").update(capturedBody, "utf8").digest("hex");
+    check(
+      "the real Web Crypto hash matches an independent Node sha256 of the exact bytes sent",
+      capturedHeaders["x-bundle-sha256"] === expectedHash,
+      `${capturedHeaders["x-bundle-sha256"]} !== ${expectedHash}`,
+    );
+    check("real end-to-end backup still lands on backed-up", manager.getStatus("p-real").state === "backed-up");
+  }
+
+  fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+  fs.rmSync(SCHEMA_BUILD_DIR, { recursive: true, force: true });
+
+  if (failures > 0) {
+    console.log(`\n${failures} sync-manager test(s) failed.`);
+    process.exit(1);
+  }
+  console.log("\nAll sync-manager tests passed.");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

The client half of Synk (docs/spec/services.md § Synk → Client sync engine) — the final M4 issue, delivering the "Lokal → Synk" primary conversion funnel.

- **`lib/sync/sync-manager.ts`** — a fully dependency-injected `SyncManager`. Subscribes to `subscribeToMutations` (issue #243's local-provider seam), debounces ~60s per project, then `exportProject` (via `getProvider()`) → `serializeBundle` (canonical, `@arkaik/schema`) → SHA-256 (Web Crypto) → `PUT /api/synk/projects/{id}` with the advisory `x-bundle-sha256` header. Stays fully **dormant** (no timers, no fetches) when signed out or unconfigured; a 403/401/network failure never self-retries — the *next mutation* (or a manual "Back up now") is what retries, so nothing is ever lost. A module-level singleton (`syncManager`) is exported and booted by a new `components/sync/SyncProvider.tsx` mounted in `app/layout.tsx`.
- **`components/sync/ProjectSyncControl.tsx`** — per-project status on `/projects` cards: backed up (with relative time) · pending · syncing · error · limit-exceeded (rendering the structured `{ limit, actual, tier }` body, e.g. "250-entity limit exceeded (312) — synk tier"), plus a manual "Back up now" button that bypasses the debounce.
- **`components/sync/RestoreDialog.tsx`** — lists the account's backed-up projects (`GET /api/synk/projects`) → retained versions (`GET /api/synk/projects/{id}/backups`) → fetches a version (`GET /api/synk/backups/{id}`) and imports it through the **existing** `importProjectFromFile` funnel, so ID-collision rewriting applies automatically and a live local project is **never overwritten in place**. Verified end-to-end with Playwright (see below).
- **`components/sync/SynkOnboardingBanner.tsx`** — after first sign-in, offers one-click backup for local projects that aren't yet backed up server-side (comparing local project ids against `GET /api/synk/projects`, with a dismissible localStorage-backed skip list). Lightweight inline banner, no modal wall; data never moves, no local feature is account-gated.
- **`lib/hooks/useAuthStatus.ts`** — the `GET /api/auth/status` polling logic factored out of `components/auth/AuthButton.tsx` (which now uses it) so every Synk client surface shares one lifecycle instead of duplicating it.

Boundaries respected: `lib/services/synk.ts`, `app/api/**`, `db/**`, and `packages/**` are untouched (read-only consumer of the as-built Synk API).

## Verification

- `npm run lint` — clean (0 errors; 2 pre-existing unrelated warnings)
- `npm run build` — clean, no env vars
- `npm run generate` — no generated-artifact drift
- Full `npm run test:*` battery green, including the new `npm run test:sync` (46 assertions: dormancy, debounce coalescing, "Back up now" bypass, request shape, status transitions, 403/401/503/network-failure/hash-failure handling, retry-on-next-mutation, server-list hydration without clobbering a known status, subscribe/unsubscribe, `start()`/`stop()` lifecycle, and a real-`@arkaik/schema`-+-real-Web-Crypto integration case cross-checked against an independent Node `sha256`)
- `test:sync` wired as a new step in the CI **services** job's test list (`.github/workflows/ci.yml`)
- End-to-end against local Postgres 16 (`initdb`/`pg_ctl` as the `postgres` user): migrations apply and re-apply idempotently; `test:publik`, `test:auth`, `test:synk` all still pass (no server-side regression, as expected — this PR is read-only against those modules)
- End-to-end in a real browser (Playwright, `next dev`, no OAuth needed):
  - **Signed-out/unconfigured**: `/projects` renders normally, zero Synk UI surface, zero console/page errors
  - **Signed-in** (network-level stubbed `/api/auth/status` + `/api/synk/*`, per the issue's guidance not to block on live OAuth): the onboarding banner offers backup for an un-backed-up local project; "Back up now" issues the expected `PUT` (correct method/URL/`x-bundle-sha256` header/body) and flips the status label to "Backed up …"; the restore dialog lists the mocked account project → its versions → restoring imports a new local project and navigates to it
  - **Collision rewrite**: restoring a backup whose `project.id` collides with an already-imported local project creates a *new*, distinctly-IDed local project — the original card is untouched and both appear side by side

## Deviations / notes

- `SyncManager`'s "real" wiring (`getProvider`, `subscribeToMutations`, `@arkaik/schema`) lives in the same `sync-manager.ts` file per the issue's file naming, with the test loader (`tests/sync/load-sync-manager.js`) stubbing those two sibling imports at the require level — the same transpile-and-rewrite pattern already used by `tests/data/load-provider-registry.js` and `tests/services/load-synk-api.js`. `createSyncManager()`'s dependency injection means those stubs are never actually invoked by any test.
- Restore is exposed both as a project-agnostic "Restore from Synk" entry point on `/projects` (browsing the whole account) and implicitly reachable per-project once a project is selected in step one — there's no separate per-card "Restore…" shortcut in this pass, since the two-step dialog already covers that path with one extra click. Happy to add a per-card shortcut if preferred.
- Server-side backup-status hydration (showing "backed up 3 days ago" on a fresh page load, before any new mutation) is a value-add beyond the literal acceptance list, implemented via a one-time `GET /api/synk/projects` read on sign-in that seeds the status map without clobbering any status already known this session — covered by dedicated tests.

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QpXVmp8QNHQF3s2cCvtead)_