### PR TITLE
Add maps projection system and refactor library/sidebar for species filtering

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,9 +8,10 @@ This project uses Next.js 16 with breaking changes. Read `node_modules/next/dist
 
 - Product graph browser built with React Flow on Next.js App Router
 - 4-species model (`flow`, `view`, `data-model`, `api-endpoint`) with playlist-driven flow expansion
-- Project shell routes include both canvas and library (`/project/[id]/canvas`, `/project/[id]/library`)
-- Local-first data with provider abstraction (localStorage now, Supabase planned)
-- See `docs/` for detailed documentation
+- Project shell routes: `/project/[id]/canvas`, `/project/[id]/library`, `/project/[id]/changelog`
+- Canonical data model lives in `packages/schema` (`@arkaik/schema`); `lib/data/types.ts` re-exports it. After schema changes run `npm run generate` (artifacts are drift-checked in CI)
+- Local-first data with provider abstraction: IndexedDB via Dexie (`lib/data/local-provider.ts`), resolved through `getProvider()`. Hosted services (Publik/Synk under `app/api/`) are backups/shares, not providers — no Supabase anywhere
+- See `docs/` for detailed documentation; product direction in `docs/vision.md` § Core Product
 
 ## Documentation
 
@@ -23,7 +24,7 @@ When reviewing or making changes:
 
 ## Conventions
 
-- State: local hooks (`useNodes`, `useEdges`, `useProject`, `useProjects`, `useGraphNavigation`) — no global store
+- State: local hooks (`useNodes`, `useEdges`, `useProject`, `useProjects`, `useJournal`) — no global store
 - Styling: Tailwind + shadcn/ui + class-variance-authority
 - Config: typed const arrays in `lib/config/` — add new taxonomies there
 - Data: all mutations go through `DataProvider` interface in `lib/data/`

--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ It's not a task tracker, not a wiki, not a design tool. It's a navigable, multi-
 - **Playlist composition** — flows contain ordered sequences of views and sub-flows, with condition and junction branching
 - **Per-platform tracking** — Web, iOS, Android variants with independent statuses and notes per view
 - **8 lifecycle statuses** — idea, backlog, prioritized, development, releasing, live, archived, blocked
-- **Local-first** — all data in `localStorage`, works offline, no account required
-- **JSON import/export** — full project bundles for backup, sharing, and self-hosting
+- **Journal & changelog** — an append-only event log records how the graph changed; releases, timelines, and a backlog are derived from it
+- **Local-first** — all data in your browser (IndexedDB), works offline, no account required; optional Synk backups with a free account
+- **Publish & share** — Publik snapshots (`arkaik.app/p/{id}`) and full JSON import/export for backup, sharing, and self-hosting
+- **Agent-native** — an `arkaik` CLI, a Claude Code plugin/skill for coding agents that maintain the map as a side effect of development, and machine-readable schema surfaces (`/llms.txt`)
 - **Seed example** — ships with a "Pebbles" example project to explore immediately
 - **Dark mode** — light/dark theme toggle
 
@@ -36,24 +38,32 @@ Open [http://localhost:3000](http://localhost:3000) — create a project or load
 app/
   layout.tsx                  # Root layout: fonts, theme, global CSS
   page.tsx                    # Home / landing page
-  projects/page.tsx           # Project list, create, import, seed
-  project/[id]/page.tsx       # Main graph canvas
+  projects/page.tsx           # Project list, create, import, seed, restore
+  project/[id]/canvas/        # Graph canvas (the Journey map)
+  project/[id]/library/       # Filterable node browser
+  project/[id]/changelog/     # Releases + backlog from the journal
+  p/[id]/                     # Publik snapshot preview
+  api/                        # Publik, Synk, and auth route handlers
 components/
   graph/
     Canvas.tsx                # React Flow wrapper + node/edge type registry
     nodes/                    # FlowNode, ViewNode, DataModelNode, ApiEndpointNode
     edges/                    # ComposeEdge, CrossLayerEdge, FloatingDottedEdge
-  layout/                     # Breadcrumb, StatusBadge, PlatformDots, StageIcon
+  layout/                     # ProjectSidebar, ProjectSwitcher, StatusBadge, etc.
   panels/                     # NodeDetailPanel, NewNodeForm, PlaylistEditor, etc.
   ui/                         # shadcn/ui primitives (button, card, dialog, etc.)
 lib/
   config/                     # Typed const arrays: species, statuses, platforms, edge-types, stages
-  data/                       # DataProvider interface + localStorage implementation
-  hooks/                      # useNodes, useEdges, useProject, useGraphNavigation, etc.
+  data/                       # DataProvider interface + IndexedDB (Dexie) implementation
+  hooks/                      # useNodes, useEdges, useProject, useJournal, etc.
   utils/                      # export, layout, cycle detection, platform-status rollups
+packages/
+  schema/                     # @arkaik/schema — canonical zod model, validation, projections (MIT)
+  cli/                        # arkaik — init, validate, log, release, sync, pack, open, push (MIT)
+plugin/                       # Claude Code plugin: the agent skill + generated assets (MIT)
 seed/
   pebbles.json                # Example project data
-docs/                         # Architecture, graph model, data layer, conventions, vision
+docs/                         # Architecture, graph model, data layer, conventions, vision, specs
 ```
 
 ## Tech Stack
@@ -64,7 +74,8 @@ docs/                         # Architecture, graph model, data layer, conventio
 | UI | React 19 |
 | Graph canvas | React Flow (`@xyflow/react` 12) |
 | Styling | Tailwind CSS 4 + shadcn/ui + CVA |
-| Storage | `localStorage` (Supabase planned) |
+| Storage | IndexedDB via Dexie (local-first); optional Postgres-backed services (Publik, Synk) |
+| Schema | `@arkaik/schema` — canonical zod model, generated JSON Schema + validator |
 
 ## Documentation
 
@@ -74,21 +85,9 @@ See [`docs/`](docs/README.md) for detailed documentation:
 - [Graph Model](docs/graph-model.md) — 4-species taxonomy, composition, statuses, edge types
 - [Data Layer](docs/data-layer.md) — DataProvider interface, local storage, import/export
 - [Conventions](docs/conventions.md) — coding patterns, file organization, state management
-- [Vision](docs/vision.md) — product strategy: the four layers (format, toolchain, app, services), modes & tiers, roadmap
-- [Specs](docs/spec/bundle-format.md) — draft specifications for the bundle format v2, the event journal, and the toolchain
+- [Vision](docs/vision.md) — product strategy: the four layers (format, toolchain, app, services), the core product ("one graph, many maps"), modes & tiers, roadmap
+- [Specs](docs/spec/bundle-format.md) — normative specifications: bundle format v2, event journal, toolchain, services, maps, MCP server
 - [Contributing](CONTRIBUTING.md) — license split, how to submit changes
-
-## Migration Path
-
-> Superseded by the phased roadmap in [docs/vision.md](docs/vision.md) (git-native toolchain first). Kept as the original engineering sketch of the backend evolution.
-
-| **Phase** | **What** | **How** |
-| --- | --- | --- |
-| MVP (now) | Local-first, single user | `local-provider` with localStorage |
-| Phase 2 | Supabase backend | Write `supabase-provider`, swap provider, add RLS on `project_id` |
-| Phase 3 | Auth + profiles | Supabase Auth, `profiles` table, `project_members` join table |
-| Phase 4 | Multi-tenant SaaS | Each user sees their projects, can create new ones |
-| Open source | Self-hosted | Same repo, `local-provider` or self-hosted Supabase |
 
 ---
 

--- a/app/project/[id]/canvas/page.tsx
+++ b/app/project/[id]/canvas/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useParams } from "next/navigation";
-import { useState, useCallback, useMemo, useEffect } from "react";
+import { useState, useCallback, useMemo, useEffect, useRef } from "react";
 import { type Edge, type Node, type NodeMouseHandler, type Connection, type EdgeMouseHandler } from "@xyflow/react";
 import { Code2Icon, CopyIcon, DownloadIcon, PlusIcon } from "lucide-react";
 import { toast } from "sonner";
@@ -193,25 +193,49 @@ export default function ProjectCanvasPage() {
     return nodesById.get(rootNodeId) ?? null;
   }, [nodesById, projectBundle?.project.root_node_id]);
 
+  // Compose closure from the explicit root: views chain the walk onward, flows
+  // are surfaced as collapsed cards whose interiors stay behind playlist
+  // expansion (walking into a flow's compose children would double-render its
+  // playlist). Pairs are in BFS discovery order.
+  const composeClosure = useMemo(() => {
+    const pairs: Array<{ parentId: string; child: DataNode }> = [];
+    const flowIds = new Set<string>();
+
+    if (!explicitRootNode) return { pairs, flowIds };
+
+    if (explicitRootNode.species === "flow") {
+      flowIds.add(explicitRootNode.id);
+      return { pairs, flowIds };
+    }
+
+    const visited = new Set<string>([explicitRootNode.id]);
+    const queue: DataNode[] = [explicitRootNode];
+
+    while (queue.length > 0) {
+      const parent = queue.shift()!;
+
+      for (const childId of composeChildIdsByParent.get(parent.id) ?? []) {
+        if (visited.has(childId)) continue;
+        const child = nodesById.get(childId);
+        if (!child || !FLOW_CHILD_SPECIES.has(child.species)) continue;
+
+        visited.add(childId);
+        pairs.push({ parentId: parent.id, child });
+
+        if (child.species === "flow") {
+          flowIds.add(child.id);
+        } else {
+          queue.push(child);
+        }
+      }
+    }
+
+    return { pairs, flowIds };
+  }, [composeChildIdsByParent, explicitRootNode, nodesById]);
+
   const topLevelFlowIds = useMemo(() => {
     if (explicitRootNode) {
-      const ids = new Set<string>();
-
-      if (explicitRootNode.species === "flow") {
-        ids.add(explicitRootNode.id);
-      }
-
-      const rootChildFlowIds = (composeChildIdsByParent.get(explicitRootNode.id) ?? [])
-        .map((nodeId) => nodesById.get(nodeId))
-        .filter((node): node is DataNode => Boolean(node))
-        .filter((node) => node.species === "flow")
-        .map((node) => node.id);
-
-      for (const flowId of rootChildFlowIds) {
-        ids.add(flowId);
-      }
-
-      return ids;
+      return composeClosure.flowIds;
     }
 
     return new Set(
@@ -219,7 +243,7 @@ export default function ProjectCanvasPage() {
         .filter((node) => node.species === "flow" && !composeParentByChild.has(node.id))
         .map((node) => node.id),
     );
-  }, [composeChildIdsByParent, composeParentByChild, dataNodes, explicitRootNode, nodesById]);
+  }, [composeClosure, composeParentByChild, dataNodes, explicitRootNode]);
 
   const allFlowIds = useMemo(
     () => new Set(dataNodes.filter((node) => node.species === "flow").map((node) => node.id)),
@@ -276,7 +300,9 @@ export default function ProjectCanvasPage() {
     return collectReferencedNodeIds(getPlaylistEntries(nodeId));
   }, [getPlaylistEntries]);
 
-  // Auto-expand root flows on initial load.
+  // Prune stale expansion entries, and expand the first top-level flow once on
+  // initial load so a fresh project opens on a real map instead of a bare root.
+  const autoExpandedRef = useRef(false);
   useEffect(() => {
     setExpandedFlows((prev) => {
       const next = new Set<string>();
@@ -287,13 +313,20 @@ export default function ProjectCanvasPage() {
         }
       }
 
+      if (!autoExpandedRef.current && next.size === 0 && topLevelFlowIds.size > 0) {
+        autoExpandedRef.current = true;
+        const [firstTopLevelFlowId] = topLevelFlowIds;
+        next.add(firstTopLevelFlowId);
+        return next;
+      }
+
       if (next.size === prev.size) {
         return prev;
       }
 
       return next;
     });
-  }, [allFlowIds]);
+  }, [allFlowIds, topLevelFlowIds]);
 
   const [pendingConnection, setPendingConnection] = useState<Connection | null>(null);
   const [edgeDialogOpen, setEdgeDialogOpen] = useState(false);
@@ -1215,16 +1248,11 @@ export default function ProjectCanvasPage() {
     if (explicitRootNode) {
       addDataNode(explicitRootNode);
 
-      const rootChildren = (composeChildIdsByParent.get(explicitRootNode.id) ?? [])
-        .map((childId) => nodesById.get(childId))
-        .filter((child): child is DataNode => Boolean(child))
-        .filter((child) => child.species === "flow");
-
-      rootChildren.forEach((child) => {
+      composeClosure.pairs.forEach(({ parentId, child }) => {
         addDataNode(child);
-        addComposeEdge(explicitRootNode.id, child.id);
+        addComposeEdge(parentId, child.id);
 
-        if (expandedFlows.has(child.id)) {
+        if (child.species === "flow" && expandedFlows.has(child.id)) {
           renderedExpandedFlows.add(child.id);
           const childSequence = renderSequence(
             getPlaylistEntries(child.id),
@@ -1237,7 +1265,7 @@ export default function ProjectCanvasPage() {
         }
       });
 
-      if (explicitRootNode.species === "flow" && expandedFlows.has(explicitRootNode.id) && rootChildren.length === 0) {
+      if (explicitRootNode.species === "flow" && expandedFlows.has(explicitRootNode.id) && composeClosure.pairs.length === 0) {
         renderedExpandedFlows.add(explicitRootNode.id);
         const rootSequence = renderSequence(
           getPlaylistEntries(explicitRootNode.id),
@@ -1303,7 +1331,7 @@ export default function ProjectCanvasPage() {
     return { nodes: visibleNodes, edges: visibleEdges };
   }, [
     explicitRootNode,
-    composeChildIdsByParent,
+    composeClosure,
     composeParentByChild,
     dataEdges,
     dataNodes,

--- a/app/project/[id]/canvas/page.tsx
+++ b/app/project/[id]/canvas/page.tsx
@@ -300,9 +300,7 @@ export default function ProjectCanvasPage() {
     return collectReferencedNodeIds(getPlaylistEntries(nodeId));
   }, [getPlaylistEntries]);
 
-  // Prune stale expansion entries, and expand the first top-level flow once on
-  // initial load so a fresh project opens on a real map instead of a bare root.
-  const autoExpandedRef = useRef(false);
+  // Prune expansion entries whose flow no longer exists.
   useEffect(() => {
     setExpandedFlows((prev) => {
       const next = new Set<string>();
@@ -313,20 +311,32 @@ export default function ProjectCanvasPage() {
         }
       }
 
-      if (!autoExpandedRef.current && next.size === 0 && topLevelFlowIds.size > 0) {
-        autoExpandedRef.current = true;
-        const [firstTopLevelFlowId] = topLevelFlowIds;
-        next.add(firstTopLevelFlowId);
-        return next;
-      }
-
       if (next.size === prev.size) {
         return prev;
       }
 
       return next;
     });
-  }, [allFlowIds, topLevelFlowIds]);
+  }, [allFlowIds]);
+
+  // Expand the first top-level flow once on initial load so a fresh project
+  // opens on a real map instead of a bare root. Gated on all three sources:
+  // nodes/edges resolve before the project bundle, and during that window the
+  // top-level set is computed without the explicit root (orphan flows only).
+  // The decision also lives outside the state updater (updaters must stay
+  // pure — StrictMode double-invokes them).
+  const autoExpandedRef = useRef(false);
+  const pendingFitFlowRef = useRef<string | null>(null);
+  const [fitSignal, setFitSignal] = useState(0);
+  useEffect(() => {
+    if (autoExpandedRef.current || nodesLoading || edgesLoading || projectLoading) return;
+    if (topLevelFlowIds.size === 0) return;
+    autoExpandedRef.current = true;
+
+    const [firstTopLevelFlowId] = topLevelFlowIds;
+    pendingFitFlowRef.current = firstTopLevelFlowId;
+    setExpandedFlows((prev) => (prev.size === 0 ? new Set([firstTopLevelFlowId]) : prev));
+  }, [edgesLoading, nodesLoading, projectLoading, topLevelFlowIds]);
 
   const [pendingConnection, setPendingConnection] = useState<Connection | null>(null);
   const [edgeDialogOpen, setEdgeDialogOpen] = useState(false);
@@ -1370,6 +1380,19 @@ export default function ProjectCanvasPage() {
     };
   }, [graphData]);
 
+  // The one-time ReactFlow fitView frames the pre-expansion layout; once the
+  // auto-expanded flow's playlist nodes land in a computed layout, re-frame.
+  useEffect(() => {
+    const flowId = pendingFitFlowRef.current;
+    if (!flowId) return;
+
+    const marker = `${VISUAL_NODE_ID_SEPARATOR}${flowId}:`;
+    if (!layoutedNodes.some((node) => node.id.includes(marker))) return;
+
+    pendingFitFlowRef.current = null;
+    setFitSignal((value) => value + 1);
+  }, [layoutedNodes]);
+
   const nodes = layoutReady ? layoutedNodes : graphData.nodes;
   const edges = graphData.edges;
 
@@ -1437,7 +1460,7 @@ export default function ProjectCanvasPage() {
         </div>
       </header>
       <div className="flex-1 min-h-0 relative">
-        <Canvas nodes={nodes} edges={edges} onNodeClick={handleNodeClick} onConnect={handleConnect} onEdgeClick={handleEdgeClick} />
+        <Canvas nodes={nodes} edges={edges} onNodeClick={handleNodeClick} onConnect={handleConnect} onEdgeClick={handleEdgeClick} fitSignal={fitSignal} />
       </div>
       <NodeDetailPanel
         open={panelOpen}

--- a/app/project/[id]/library/page.tsx
+++ b/app/project/[id]/library/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { useParams, usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useParams, useSearchParams } from "next/navigation";
 import { PlusIcon } from "lucide-react";
 import { LibraryFilterBar, type LibraryDisplayMode, type LibrarySpeciesFilter } from "@/components/library/LibraryFilterBar";
 import { NodeCard } from "@/components/library/NodeCard";
@@ -33,6 +33,15 @@ const SPECIES_EMPTY_LABELS: Record<LibrarySpeciesFilter, string> = {
   flow: "flows",
   "data-model": "data models",
   "api-endpoint": "API endpoints",
+};
+
+// The sidebar owns species selection; the header subtitle mirrors it so the
+// active filter stays visible on the page itself.
+const SPECIES_SUBTITLE_LABELS: Record<SpeciesId, string> = {
+  view: "Views",
+  flow: "Flows",
+  "data-model": "Data Models",
+  "api-endpoint": "API Endpoints",
 };
 
 const SPECIES_LABEL_BY_ID = Object.fromEntries(
@@ -134,8 +143,6 @@ function sortNodes(
 
 export default function ProjectLibraryPage() {
   const params = useParams();
-  const pathname = usePathname();
-  const router = useRouter();
   const searchParams = useSearchParams();
   const id = Array.isArray(params.id) ? params.id[0] : params.id ?? "";
 
@@ -214,19 +221,6 @@ export default function ProjectLibraryPage() {
     });
   }
 
-  function handleSpeciesChange(nextSpecies: LibrarySpeciesFilter) {
-    const nextParams = new URLSearchParams(searchParams.toString());
-
-    if (nextSpecies === "all") {
-      nextParams.delete("species");
-    } else {
-      nextParams.set("species", nextSpecies);
-    }
-
-    const nextQuery = nextParams.toString();
-    router.replace(nextQuery ? `${pathname}?${nextQuery}` : pathname);
-  }
-
   async function handleCreateNodeFromPanel(species: "flow" | "view", title: string) {
     return addNode({
       id: generateNodeId(species, title, nodesById.keys()),
@@ -269,7 +263,9 @@ export default function ProjectLibraryPage() {
           <p className="truncate text-sm font-medium">
             {projectBundle?.project.title ?? "Untitled project"}
           </p>
-          <p className="truncate text-xs text-muted-foreground">Library</p>
+          <p className="truncate text-xs text-muted-foreground">
+            {speciesFilter === "all" ? "Library" : `Library · ${SPECIES_SUBTITLE_LABELS[speciesFilter]}`}
+          </p>
         </div>
         <div className="ml-auto flex items-center gap-3">
           <Button size="sm" className="cursor-pointer" onClick={() => setNewNodeOpen(true)}>
@@ -282,10 +278,8 @@ export default function ProjectLibraryPage() {
       <div className="min-h-0 flex-1 overflow-auto p-4 md:p-6">
         <div className="mx-auto flex w-full max-w-7xl flex-col gap-4">
           <LibraryFilterBar
-            species={speciesFilter}
             search={search}
             displayMode={displayMode}
-            onSpeciesChange={handleSpeciesChange}
             onSearchChange={setSearch}
             onDisplayModeChange={setDisplayMode}
           />

--- a/components/graph/Canvas.tsx
+++ b/components/graph/Canvas.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useRef, type CSSProperties } from "react";
+import { useCallback, useEffect, useMemo, useRef, type CSSProperties } from "react";
 import { ReactFlow, Controls, Background, type Node, type Edge, type NodeMouseHandler, type OnConnect, type EdgeMouseHandler, type ReactFlowInstance } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { useTheme } from "next-themes";
@@ -34,12 +34,28 @@ interface CanvasProps {
   onNodeClick?: NodeMouseHandler;
   onConnect?: OnConnect;
   onEdgeClick?: EdgeMouseHandler;
+  /** Increment to re-frame the viewport around the current graph (e.g. after a programmatic layout change). */
+  fitSignal?: number;
 }
 
-export function Canvas({ nodes, edges, onNodeClick, onConnect, onEdgeClick }: CanvasProps) {
+export function Canvas({ nodes, edges, onNodeClick, onConnect, onEdgeClick, fitSignal }: CanvasProps) {
   const reactFlowRef = useRef<ReactFlowInstance<Node, Edge> | null>(null);
+  const lastFitSignal = useRef(fitSignal);
   const { resolvedTheme } = useTheme();
   const isDark = resolvedTheme === "dark";
+
+  useEffect(() => {
+    if (fitSignal === undefined || fitSignal === lastFitSignal.current) return;
+    lastFitSignal.current = fitSignal;
+
+    // Wait for React Flow to measure freshly mounted nodes — unmeasured nodes
+    // are excluded from the fit bounds. minZoom overrides the instance default
+    // (0.5) so wide graphs can be framed in full.
+    const timer = setTimeout(() => {
+      void reactFlowRef.current?.fitView({ padding: 0.1, duration: 300, minZoom: 0.15 });
+    }, 150);
+    return () => clearTimeout(timer);
+  }, [fitSignal]);
 
   const flowStyle = useMemo(() => {
     return {

--- a/components/layout/ProjectSidebar.tsx
+++ b/components/layout/ProjectSidebar.tsx
@@ -7,8 +7,8 @@ import {
   DatabaseIcon,
   GitBranchIcon,
   HistoryIcon,
-  LayoutPanelTopIcon,
   MonitorIcon,
+  RouteIcon,
   ServerIcon,
   Settings2Icon,
   Share2Icon,
@@ -25,9 +25,6 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
-  SidebarMenuSub,
-  SidebarMenuSubButton,
-  SidebarMenuSubItem,
   SidebarRail,
   SidebarSeparator,
 } from "@/components/ui/sidebar";
@@ -40,6 +37,8 @@ interface ProjectSidebarProps {
   currentQueryString?: string;
 }
 
+// One library page per species, driven from here — the sidebar is the only
+// species selector (vision.md § Core Product, Information Architecture).
 const LIBRARY_ITEMS = [
   { label: "Views", species: "view", icon: MonitorIcon },
   { label: "Flows", species: "flow", icon: GitBranchIcon },
@@ -72,41 +71,54 @@ export function ProjectSidebar({
 
       <SidebarContent>
         <SidebarGroup>
-          <SidebarGroupLabel>Navigate</SidebarGroupLabel>
+          <SidebarGroupLabel>Maps</SidebarGroupLabel>
           <SidebarMenu>
             <SidebarMenuItem>
-              <SidebarMenuButton asChild isActive={currentView === "canvas"} tooltip="Canvas">
+              <SidebarMenuButton asChild isActive={currentView === "canvas"} tooltip="Journey map">
                 <Link href={canvasHref}>
-                  <LayoutPanelTopIcon />
-                  <span>Canvas</span>
+                  <RouteIcon />
+                  <span>Journey</span>
                 </Link>
               </SidebarMenuButton>
             </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarGroup>
 
+        <SidebarGroup>
+          <SidebarGroupLabel>Library</SidebarGroupLabel>
+          <SidebarMenu>
             <SidebarMenuItem>
-              <SidebarMenuButton asChild isActive={currentView === "library"} tooltip="Library">
+              <SidebarMenuButton
+                asChild
+                isActive={currentView === "library" && currentSpecies === null}
+                tooltip="All nodes"
+              >
                 <Link href={libraryHref}>
                   <BookOpenIcon />
-                  <span>Library</span>
+                  <span>All nodes</span>
                 </Link>
               </SidebarMenuButton>
-              <SidebarMenuSub>
-                {LIBRARY_ITEMS.map((item) => (
-                  <SidebarMenuSubItem key={item.species}>
-                    <SidebarMenuSubButton
-                      asChild
-                      isActive={currentView === "library" && currentSpecies === item.species}
-                    >
-                      <Link href={`${libraryHref}?species=${item.species}`}>
-                        <item.icon />
-                        <span>{item.label}</span>
-                      </Link>
-                    </SidebarMenuSubButton>
-                  </SidebarMenuSubItem>
-                ))}
-              </SidebarMenuSub>
             </SidebarMenuItem>
+            {LIBRARY_ITEMS.map((item) => (
+              <SidebarMenuItem key={item.species}>
+                <SidebarMenuButton
+                  asChild
+                  isActive={currentView === "library" && currentSpecies === item.species}
+                  tooltip={item.label}
+                >
+                  <Link href={`${libraryHref}?species=${item.species}`}>
+                    <item.icon />
+                    <span>{item.label}</span>
+                  </Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            ))}
+          </SidebarMenu>
+        </SidebarGroup>
 
+        <SidebarGroup>
+          <SidebarGroupLabel>Project</SidebarGroupLabel>
+          <SidebarMenu>
             <SidebarMenuItem>
               <SidebarMenuButton asChild isActive={currentView === "changelog"} tooltip="Changelog">
                 <Link href={changelogHref}>

--- a/components/library/LibraryFilterBar.tsx
+++ b/components/library/LibraryFilterBar.tsx
@@ -2,98 +2,70 @@
 
 import { SearchIcon, Grid3X3Icon, Table2Icon } from "lucide-react";
 import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
-import { SPECIES, type SpeciesId } from "@/lib/config/species";
+import { type SpeciesId } from "@/lib/config/species";
 import { cn } from "@/lib/utils";
 
+// Species selection is owned by the sidebar (?species= deep links); this bar
+// only carries search and the display-mode toggle.
 export type LibrarySpeciesFilter = "all" | SpeciesId;
 export type LibraryDisplayMode = "gallery" | "directory";
 
 interface LibraryFilterBarProps {
-  species: LibrarySpeciesFilter;
   search: string;
   displayMode: LibraryDisplayMode;
-  onSpeciesChange: (species: LibrarySpeciesFilter) => void;
   onSearchChange: (query: string) => void;
   onDisplayModeChange: (mode: LibraryDisplayMode) => void;
 }
 
 export function LibraryFilterBar({
-  species,
   search,
   displayMode,
-  onSpeciesChange,
   onSearchChange,
   onDisplayModeChange,
 }: LibraryFilterBarProps) {
   return (
     <div className="rounded-xl border bg-card/70 p-3 md:p-4">
-      <div className="flex flex-col gap-3">
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Species</span>
-          <Button
-            type="button"
-            variant={species === "all" ? "default" : "outline"}
-            size="sm"
-            onClick={() => onSpeciesChange("all")}
-          >
-            All
-          </Button>
-          {SPECIES.map((option) => (
-            <Button
-              key={option.id}
-              type="button"
-              variant={species === option.id ? "default" : "outline"}
-              size="sm"
-              onClick={() => onSpeciesChange(option.id)}
-            >
-              {option.label}
-            </Button>
-          ))}
+      <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <div className="relative w-full md:max-w-md">
+          <SearchIcon className="pointer-events-none absolute left-2 top-2.5 size-4 text-muted-foreground" />
+          <Input
+            value={search}
+            onChange={(event) => onSearchChange(event.target.value)}
+            placeholder="Search title or description"
+            className="pl-8"
+            aria-label="Search nodes"
+          />
         </div>
 
-        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-          <div className="relative w-full md:max-w-md">
-            <SearchIcon className="pointer-events-none absolute left-2 top-2.5 size-4 text-muted-foreground" />
-            <Input
-              value={search}
-              onChange={(event) => onSearchChange(event.target.value)}
-              placeholder="Search title or description"
-              className="pl-8"
-              aria-label="Search nodes"
-            />
-          </div>
-
-          <div className="inline-flex items-center rounded-md border bg-background p-1">
-            <button
-              type="button"
-              className={cn(
-                "inline-flex items-center gap-1.5 rounded px-2.5 py-1.5 text-xs font-medium transition-colors",
-                displayMode === "gallery"
-                  ? "bg-primary text-primary-foreground"
-                  : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
-              )}
-              onClick={() => onDisplayModeChange("gallery")}
-              aria-pressed={displayMode === "gallery"}
-            >
-              <Grid3X3Icon className="size-3.5" />
-              Grid
-            </button>
-            <button
-              type="button"
-              className={cn(
-                "inline-flex items-center gap-1.5 rounded px-2.5 py-1.5 text-xs font-medium transition-colors",
-                displayMode === "directory"
-                  ? "bg-primary text-primary-foreground"
-                  : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
-              )}
-              onClick={() => onDisplayModeChange("directory")}
-              aria-pressed={displayMode === "directory"}
-            >
-              <Table2Icon className="size-3.5" />
-              Table
-            </button>
-          </div>
+        <div className="inline-flex items-center rounded-md border bg-background p-1">
+          <button
+            type="button"
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded px-2.5 py-1.5 text-xs font-medium transition-colors",
+              displayMode === "gallery"
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+            )}
+            onClick={() => onDisplayModeChange("gallery")}
+            aria-pressed={displayMode === "gallery"}
+          >
+            <Grid3X3Icon className="size-3.5" />
+            Grid
+          </button>
+          <button
+            type="button"
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded px-2.5 py-1.5 text-xs font-medium transition-colors",
+              displayMode === "directory"
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
+            )}
+            onClick={() => onDisplayModeChange("directory")}
+            aria-pressed={displayMode === "directory"}
+          >
+            <Table2Icon className="size-3.5" />
+            Table
+          </button>
         </div>
       </div>
     </div>

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,12 +10,14 @@
 
 ## Specifications
 
-Normative (draft) specs for the arkaik format and tooling:
+Normative specs for the arkaik format and tooling (each carries its own implementation status):
 
 - [Bundle Format v2](spec/bundle-format.md) — schema versioning, references, asset values, ID conventions, canonical serialization
 - [Journal & Events](spec/journal.md) — event vocabulary, JSONL sidecar, authority model, releases & projections
 - [Toolchain & Packaging](spec/toolchain.md) — npm workspace, `@arkaik/schema`, the `arkaik` CLI, skill distribution
 - [Services](spec/services.md) — Publik sharing, Synk backups, backend decision record, tier enforcement, self-hosting
+- [Maps & Projections](spec/maps.md) — the multi-map model: `MapDefinition`, subgraph semantics, built-in archetypes, storage
+- [MCP Server](spec/mcp.md) — the agent plane: stdio tools over the repo bundle, validator-gated dual-write, distribution
 
 ## LLM & Prompt Surfaces
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,10 +25,18 @@ app/
       layout.tsx        # Shared project shell with persistent sidebar + project switcher
       page.tsx          # Redirects to /project/[id]/canvas
       canvas/
-        page.tsx        # Main canvas — playlist expansion and status rollups
+        page.tsx        # The Journey map canvas — compose-closure traversal, playlist expansion, status rollups
       library/
-        page.tsx        # Filterable gallery/directory node browser
+        page.tsx        # Gallery/directory node browser (species via sidebar ?species= links)
+      changelog/
+        page.tsx        # Releases + backlog derived from the journal
+  p/
+    [id]/
+      page.tsx          # Publik snapshot preview (server-rendered)
+  api/                  # Publik, Synk, and auth route handlers (spec/services.md)
 ```
+
+Planned project routes (spec'd, not yet built — vision.md § Roadmap, Core Product phases): `/project/[id]/maps` (+ `/maps/[mapId]`), `/project/[id]/delivery`, `/project/[id]/overview`.
 
 The canvas page (`app/project/[id]/canvas/page.tsx`) is the core of the graph renderer. It:
 
@@ -87,11 +95,11 @@ components/
 ## Data Flow
 
 ```
-localStorage
+IndexedDB (Dexie)
     ↕ (read/write)
-localProvider (implements DataProvider)
+localProvider (implements DataProvider, via getProvider())
     ↕ (async calls)
-Hooks: useNodes, useEdges, useProject, useProjects
+Hooks: useNodes, useEdges, useProject, useProjects, useJournal
     ↕ (state)
 app/project/[id]/layout.tsx (sidebar shell + route-aware navigation)
   ↕ (props)
@@ -161,7 +169,7 @@ LLM affordance assets:
 - `public/robots.txt` and `app/sitemap.ts` support discoverability.
 ```
 
-All data mutations flow through the `DataProvider` interface (`lib/data/data-provider.ts`). The current implementation is `localProvider` backed by IndexedDB (Dexie — `lib/data/db.ts`), which writes per project rather than rewriting the whole store on every mutation. The interface is designed for a future Supabase migration — swap the provider, keep the hooks and UI unchanged.
+All data mutations flow through the `DataProvider` interface (`lib/data/data-provider.ts`). The current implementation is `localProvider` backed by IndexedDB (Dexie — `lib/data/db.ts`), which writes per project rather than rewriting the whole store on every mutation. The interface plus the `getProvider()`/`setProvider()` seam (`lib/data/provider-registry.ts`) let the backend change without touching hooks or UI — the seam a future read-only repo-bundle provider ([rfcs/arkaik-dev.md](rfcs/arkaik-dev.md)) injects through.
 
 ## Playlist Expansion
 
@@ -169,20 +177,14 @@ The project page manages one expansion set as local `useState`:
 
 - `expandedFlows` — which flows show their direct flow/view children
 
-When `project.root_node_id` is present, that node is rendered as the primary anchor and top-level compose children fan out from it. When it is missing, root nodes are inferred from nodes with no compose parent.
+When `project.root_node_id` is present, the canvas walks the full compose closure from that node — views always render and chain the walk onward; flows render as collapsed cards. When it is missing, root nodes are inferred from nodes with no compose parent. The first top-level flow auto-expands on initial load.
 
-Expanded flows reveal ordered children from `metadata.playlist` and `composes` edges.
+Expanded flows reveal ordered children from `metadata.playlist` and `composes` edges. Positions are computed by ELK (`lib/utils/elk-layout.ts`, layered algorithm over compose edges).
 
-Nodes are positioned dynamically:
-
-- Root flows: horizontal row near the top of the canvas
-- Root views: horizontal row below root flows
-- Flow children: vertical column to the right of the parent flow
-
-Canvas visibility rule:
+Canvas visibility rule (Journey map):
 
 - Rendered nodes: `flow`, `view`
-- Hidden from canvas cards: `data-model`, `api-endpoint` (still persisted in project data)
+- Not rendered here: `data-model`, `api-endpoint` (still persisted; they render on the System map once roadmap CP-C lands — [spec/maps.md](spec/maps.md))
 
 View card variants:
 
@@ -214,7 +216,7 @@ The library route (`app/project/[id]/library/page.tsx`) is the project-wide brow
 
 - **Gallery view**: card layout using `NodeCard` for scanning titles, species/status badges, and flow playlist previews.
 - **Directory view**: sortable table using `NodeTable` for dense auditing (`id`, `title`, `species`, `status`, `used in`).
-- **Filter controls**: `LibraryFilterBar` owns species filtering and text search.
+- **Filter controls**: species selection is owned by the sidebar (`?species=` deep links); `LibraryFilterBar` owns text search and the gallery/directory display toggle.
 
 Library interactions reuse the same edit/create surfaces as canvas (`NodeDetailPanel`, `NewNodeForm`) so data mutation paths stay identical.
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -28,12 +28,12 @@ docs/                   # This documentation
 ## State Management
 
 - **No global store.** No Zustand, Redux, or Context-based state.
-- Reusable state logic lives in hooks: `useNodes`, `useEdges`, `useProject`, `useProjects`, `useGraphNavigation`.
+- Reusable state logic lives in hooks: `useNodes`, `useEdges`, `useProject`, `useProjects`, `useJournal`.
 - Hook intent:
   - `useNodes` and `useEdges` handle project graph CRUD.
   - `useProject` handles project-level metadata (including `root_node_id` and card preferences).
   - `useProjects` powers project lists/switching in route shell UI.
-  - `useGraphNavigation` remains a generic helper for graph navigation state when needed.
+  - `useJournal` exposes the read-only event log for timelines and the changelog.
 - The project canvas page (`app/project/[id]/canvas/page.tsx`) uses `useNodes` and `useEdges` for data, and manages flow expansion as local `useState` (`expandedFlows`).
 - Data flows via props from the project page down to canvas components.
 - Route-shell concerns such as the project switcher and persistent sidebar should stay in the project layout and use route state plus lightweight hooks instead of introducing shared global state.
@@ -121,4 +121,4 @@ Non-interactive but focusable elements (e.g. branch nodes, static cards) use `cu
   - Current graph node components include `FlowNode.tsx`, `ViewNode.tsx`, `DataModelNode.tsx`, `ApiEndpointNode.tsx`
 - **Types:** PascalCase (`SpeciesId`, `ProjectBundle`)
 - **Config arrays:** UPPER_SNAKE_CASE (`SPECIES`, `STATUSES`, `EDGE_TYPES`)
-- **Hooks:** camelCase with `use` prefix (`useNodes`, `useGraphNavigation`)
+- **Hooks:** camelCase with `use` prefix (`useNodes`, `useJournal`)

--- a/docs/data-layer.md
+++ b/docs/data-layer.md
@@ -2,7 +2,7 @@
 
 ## Data Types
 
-Defined in `lib/data/types.ts`:
+Canonically defined in `packages/schema/src/` (`@arkaik/schema`) and re-exported through `lib/data/types.ts`:
 
 ### Node
 
@@ -21,14 +21,16 @@ interface Node {
 
 ### NodeMetadata
 
-Defined in `lib/data/types.ts`:
-
 | Field | Type | Purpose |
 |-------|------|---------|
-| `stage` | `string` | Optional lifecycle marker used by node headers |
+| `stage` | `string` | Optional lifecycle marker used by node headers (`beta` / `monitoring` / `deprecated`) |
 | `playlist` | `FlowPlaylist` | Ordered playlist structure for flow sequencing with support for inline branching |
 | `platformNotes` | `Partial<Record<PlatformId, string>>` | Per-platform notes in the detail panel |
 | `platformStatuses` | `Partial<Record<PlatformId, StatusId>>` | Per-platform source-of-truth statuses for views |
+| `platformScreenshots` | `Partial<Record<PlatformId, string>>` | Per-platform screenshot asset values (path, URL, or data URI — [spec/bundle-format.md](spec/bundle-format.md) § Asset Values) |
+| `refs` | `Ref[]` | Typed external references ([spec/bundle-format.md](spec/bundle-format.md) § References) |
+
+Unknown metadata keys are preserved (`catchall`) — the forward-compatibility rule of the format.
 
 `FlowPlaylist` structure:
 
@@ -69,6 +71,7 @@ interface Project {
   id: string;
   title: string;
   description?: string;
+  version?: string;    // Current version label of the mapped product (Level 1)
   root_node_id?: string; // Optional node id used as the canvas anchor
   metadata?: ProjectMetadata; // Optional project-level UI preferences
   created_at: string;  // ISO 8601
@@ -76,8 +79,9 @@ interface Project {
   archived_at?: string | null; // ISO 8601 when archived
 }
 
-interface ProjectMetadata {
+interface ProjectMetadata extends Record<string, unknown> {
   view_card_variant?: "compact" | "large";
+  // maps?: MapDefinition[] — specified in spec/maps.md, lands with roadmap CP-B
 }
 ```
 
@@ -85,9 +89,11 @@ interface ProjectMetadata {
 
 ```typescript
 interface ProjectBundle {
+  schema_version?: number;   // Absent means 1 (spec/bundle-format.md)
   project: Project;
   nodes: Node[];
   edges: Edge[];
+  journal?: JournalEvent[];  // Level 2 embedded interchange projection (spec/journal.md)
 }
 ```
 
@@ -112,11 +118,15 @@ interface DataProvider {
   createNode(node: Node): Promise<Node>;
   updateNode(id: string, patch: Partial<Omit<Node, "id" | "project_id">>): Promise<Node>;
   deleteNode(id: string): Promise<void>;
+  deleteNodes(ids: string[]): Promise<void>;
 
   // Edges
   getEdges(projectId: string): Promise<Edge[]>;
   createEdge(edge: Edge): Promise<Edge>;
   deleteEdge(id: string): Promise<void>;
+
+  // Journal
+  getJournal(projectId: string): Promise<JournalEvent[]>;
 
   // Import/Export
   exportProject(id: string): Promise<ProjectBundle>;
@@ -128,14 +138,15 @@ interface DataProvider {
 
 ## Local Provider
 
-Implemented in `lib/data/local-provider.ts`.
+Implemented in `lib/data/local-provider.ts`, resolved through the provider seam `lib/data/provider-registry.ts` (`getProvider()` / `setProvider()`).
 
-- **Storage key:** `arkaik:store`
-- **Backend:** `localStorage` with an in-memory `Map<string, ProjectBundle>`
-- **Indexing:** Dual index maps — `nodeIndex` (node ID → project ID) and `edgeIndex` (edge ID → project ID) for fast lookups
-- **Persistence:** Auto-persists to `localStorage` on every mutation
-- **Cascade:** `deleteNode` also removes all edges referencing that node
-- **Normalization:** Legacy structural fields from pre-playlist storage are stripped on load/import, and ordered `metadata.playlist.entries` values are hydrated from legacy data when present
+- **Backend:** IndexedDB via Dexie (`lib/data/db.ts`, database `arkaik`) — three tables: `projects` (one row per project: the bundle snapshot minus its journal), `journals` (per-project event arrays), `meta` (bookkeeping)
+- **Writes:** Row-level per project — a mutation to project A rewrites only A's row
+- **Dual-write:** Every graph mutation patches the snapshot *and* appends the derived journal events (`lib/data/emit-events.ts`, actor `arkaik-app`) in the same Dexie transaction; `saveProject`/`importProject`/`archiveProject` deliberately do not emit
+- **Notifications:** `subscribeToMutations(cb)` fires per affected project after the transaction commits (consumed by the Synk `SyncManager`)
+- **Cascade:** `deleteNode` also removes all edges referencing that node (no separate `edge.removed` events — implied by `node.deleted`)
+- **Legacy migration:** on first open, any old `arkaik:store` `localStorage` payload is imported once (running `migrateBundle` per bundle) and kept as a passive backup
+- **Normalization:** legacy structural fields are stripped and playlists hydrated via the explicit migration chain in `lib/data/migrate.ts` (`schema_version`-aware)
 
 ## Import / Export
 
@@ -161,7 +172,7 @@ Arkaik now publishes a machine-readable schema and example bundle for import/exp
 | ProjectBundle schema | `public/schema/project-bundle.json` | Canonical JSON Schema for the bundle format |
 | Example bundle | `public/schema/example-bundle.json` | Complete, valid reference example |
 
-These assets mirror the TypeScript model in `lib/data/types.ts` and help external tooling generate importable bundles.
+These assets are generated from the canonical zod source in `packages/schema` (`npm run generate`, drift-checked in CI) and help external tooling generate importable bundles.
 
 ## Hooks
 
@@ -171,9 +182,9 @@ Hooks in `lib/hooks/` provide React state wrappers around the provider:
 |------|---------|---------|
 | `useProject(id)` | `{ project, loading, updateProject }` | Load and update project-level metadata/settings |
 | `useProjects()` | `{ projects, loading }` | Load the active project list for shell navigation |
-| `useNodes(projectId)` | `{ nodes, loading, addNode, removeNode, updateNode }` | CRUD for nodes |
+| `useNodes(projectId)` | `{ nodes, loading, addNode, removeNode, removeNodes, updateNode }` | CRUD for nodes |
 | `useEdges(projectId)` | `{ edges, loading, addEdge, removeEdge }` | CRUD for edges |
-| `useGraphNavigation()` | `{ expandedNodeIds, zoomLevel, breadcrumbs, expand, collapse, navigateTo }` | Generic graph navigation state utility |
+| `useJournal(projectId)` | `{ journal, loading }` | Read-only journal events for timelines and the changelog |
 
 The project canvas page (`app/project/[id]/canvas/page.tsx`) uses `useProject` for root-node anchoring and project-level card-style preferences, and still manages `expandedFlows` as local state.
 
@@ -199,11 +210,12 @@ Flows do not expose an editable rollup status in UI. Flow cards and panel gauges
 The `DataProvider` interface abstracts storage so the backend can change without touching hooks or UI:
 
 1. **Current:** IndexedDB via `localProvider` (Dexie — `lib/data/db.ts`). The `localProvider` export name is kept; it is repointed at the IndexedDB implementation, so the hooks and UI are unchanged.
-2. **Planned:** Supabase (auth, RLS, realtime sync)
+2. **Hosted services** are *not* providers: Publik shares snapshots and Synk backs them up one-way ([spec/services.md](spec/services.md)); the browser stays the source of truth. (The old "Supabase provider" plan is superseded — see the backend decision record in [spec/services.md](spec/services.md).)
+3. **Future second provider:** the read-only repo-bundle provider contemplated by [rfcs/arkaik-dev.md](rfcs/arkaik-dev.md), injected through `setProvider()`.
 
 Storage layout: a `projects` table keyed by `id` holds one row per project (the bundle snapshot minus its journal), so a mutation to project A rewrites only project A's row — not the whole store as the previous `localStorage` backend did. The embedded journal lives in its own `journals` table (keyed by `projectId`), leaving room for a future app-side journal append that need not rewrite the graph snapshot. On first load, any legacy `arkaik:store` `localStorage` payload is imported once into IndexedDB (running `migrateBundle` per bundle) and the source payload is kept as a passive backup.
 
-To add a new provider: implement the `DataProvider` interface and repoint the `localProvider` export (or introduce a provider seam).
+To add a new provider: implement the `DataProvider` interface and inject it via `setProvider()` (`lib/data/provider-registry.ts`) — the seam every hook already reads through.
 
 ## Seed Data
 

--- a/docs/graph-model.md
+++ b/docs/graph-model.md
@@ -15,11 +15,11 @@ Current taxonomy has exactly 4 species.
 
 Config source: [lib/config/species.ts](../lib/config/species.ts)
 
-## Canvas Visibility
+## Canvas Visibility (Journey Map)
 
-- Canvas rendering currently shows only `flow` and `view` as visible React Flow nodes.
-- `data-model` and `api-endpoint` remain persisted graph species and can still be edited from panels/import-export, but they are not rendered as standalone canvas cards.
-- View cards surface API relationships inline via embedded actions instead of separate API nodes.
+- The canvas is the **Journey map** ([vision.md § Core Product](vision.md), [spec/maps.md](spec/maps.md)): it renders `flow` and `view` species as React Flow nodes over the full compose closure from the root — views chain the traversal onward, flows render as collapsed, expandable cards.
+- `data-model` and `api-endpoint` remain persisted graph species, editable from panels and import/export. They render as standalone cards on the **System map** (roadmap CP-C); on the Journey map they surface inline on View cards via embedded API actions and in the detail panel's Connections section.
+- Cross-layer edges (`calls`, `displays`, `queries`) draw whenever both endpoints are visible.
 
 Source: [app/project/[id]/canvas/page.tsx](../app/project/[id]/canvas/page.tsx), [components/graph/nodes/ViewNode.tsx](../components/graph/nodes/ViewNode.tsx)
 
@@ -32,7 +32,7 @@ Project library is available at `/project/[id]/library` with two browsing modes:
 
 Filtering:
 
-- Species filter supports `all`, `flow`, `view`, `data-model`, `api-endpoint`.
+- Species selection is owned by the **sidebar** (`?species=` deep links: `all` when absent, or one of `flow`, `view`, `data-model`, `api-endpoint`); the in-page bar carries search and the display-mode toggle only.
 - Search matches node title and description text.
 
 Library source:
@@ -59,7 +59,7 @@ Source: [app/project/[id]/canvas/page.tsx](../app/project/[id]/canvas/page.tsx),
 
 Source: [app/project/[id]/canvas/page.tsx](../app/project/[id]/canvas/page.tsx)
 
-All flows start collapsed. Any visible flow can be expanded in-canvas. Top-level expansion (root flow and/or direct flow children of `project.root_node_id`, or inferred root flows when no explicit root exists) is accordion-style: opening one top-level flow collapses any other top-level flow already open.
+The canvas walks the compose closure from the anchor (`project.root_node_id`, or inferred roots when absent): views are always rendered and chain the walk onward; flows are rendered as collapsed cards whose interiors (playlists) render only when expanded. Flows start collapsed, except that the first **top-level flow** (a flow reached without passing through another flow) auto-expands on initial load. Top-level expansion is accordion-style: opening one top-level flow collapses any other top-level flow already open.
 
 Expanded flow children follow a strict alternating drill layout:
 

--- a/docs/spec/bundle-format.md
+++ b/docs/spec/bundle-format.md
@@ -6,7 +6,7 @@ order: 1
 
 # Bundle Format v2
 
-> Status: **Draft specification** — describes the target format. Implemented behavior is documented in [data-layer.md](../data-layer.md); the currently published contract is v1 at `public/schema/project-bundle.json`.
+> Status: **Implemented** — v2 is the published contract at `public/schema/project-bundle.json`, generated from the canonical zod source in `packages/schema` ([toolchain.md](toolchain.md)). Implemented behavior is documented in [data-layer.md](../data-layer.md). This document remains the normative contract.
 > The key words MUST, MUST NOT, SHOULD, and MAY are to be interpreted as in RFC 2119.
 
 ## Overview

--- a/docs/spec/journal.md
+++ b/docs/spec/journal.md
@@ -6,7 +6,7 @@ order: 2
 
 # Journal & Events
 
-> Status: **Draft specification** — describes the target format (Format Level 2, see [bundle-format.md](bundle-format.md)). Nothing in this document is implemented yet.
+> Status: **Implemented** (Format Level 2, see [bundle-format.md](bundle-format.md)) — the event vocabulary, JSONL sidecar IO, cross-checks, and projections live in `packages/schema/src/journal*.ts` and `projections.ts`; the app dual-writes via `lib/data/emit-events.ts`, and the CLI reads/writes the sidecar (`arkaik log`, `arkaik release`). This document remains the normative contract.
 > The key words MUST, MUST NOT, SHOULD, and MAY are to be interpreted as in RFC 2119.
 
 ## Purpose

--- a/docs/spec/maps.md
+++ b/docs/spec/maps.md
@@ -1,0 +1,90 @@
+---
+title: "Spec: Maps & Projections"
+navTitle: "Maps"
+order: 5
+---
+
+# Maps & Projections
+
+> Status: **Draft specification** — describes the target model for the app's multi-map experience (vision.md § Core Product). Nothing in this document is implemented yet; today the app renders a single canvas route.
+> The key words MUST, MUST NOT, SHOULD, and MAY are to be interpreted as in RFC 2119.
+
+## Purpose
+
+A product graph is one dataset with many legitimate readings: a navigation drill-down, a systems diagram, a delivery board, an executive dashboard. A **map** is a named, parameterized *projection* over the bundle — scope + selection + rendering mode — so the same graph can be read from the angle the question demands.
+
+Maps follow the projection doctrine established by the journal ([journal.md](journal.md) § Projections): **pure functions over (snapshot, journal), defined once in `@arkaik/schema`, consumed everywhere.** The app renders a map, the CLI prints it, the MCP server ([mcp.md](mcp.md)) serves it to agents. Every human surface has an agent-consumable twin.
+
+## MapDefinition
+
+```ts
+interface MapDefinition extends Record<string, unknown> {
+  id: string;                    // kebab-case, unique within the project; built-in ids reserved
+  title: string;
+  description?: string;
+  kind: "journey" | "system";    // selects the renderer and the defaults below
+  species?: SpeciesId[];         // node filter; defaults by kind
+  edge_types?: EdgeTypeId[];     // edge filter; defaults by kind
+  root_node_id?: string;         // scope anchor; journey falls back to project.root_node_id
+  depth?: number;                // traversal bound from the root; absent = unbounded
+  layout?: { direction?: "DOWN" | "RIGHT" };
+}
+```
+
+| Rule | Detail |
+|---|---|
+| Defaults by kind | `journey`: `species: ["flow","view"]`, `edge_types: ["composes"]`. `system`: `species: ["view","api-endpoint","data-model"]`, `edge_types: ["calls","displays","queries"]` |
+| Reserved ids | `journey` and `system` name the built-in maps every project has implicitly. A stored definition MUST NOT reuse them (validator warning `map-shadows-built-in`) |
+| Unknown fields | Preserved and ignored, like every other format object (`Record<string, unknown>`) |
+| Unknown kinds | Consumers MUST preserve definitions with unrecognized `kind` values and SHOULD list them as unrenderable rather than dropping them |
+
+## Storage
+
+Custom maps live at **`project.metadata.maps: MapDefinition[]`**.
+
+This is a purely additive optional field in an already-`catchall` object (`ProjectMetadataSchema`), so per [bundle-format.md](bundle-format.md) § Schema Versioning it requires **no `schema_version` bump** — the same class of change as `metadata.refs` was. Every existing consumer (app import, published validator, Publik/Synk round-trips, canonical serialization) preserves it today.
+
+Maps-as-data is the point: a human saves a map from a dialog, **an agent authors one by writing JSON** — "make me a map of the admin area" is a metadata patch, not a feature request.
+
+## Subgraph Algorithm
+
+`computeMapSubgraph(definition, nodes, edges)` — the normative selection semantics, in order:
+
+1. **Species filter.** Keep nodes whose `species` is in the (defaulted) `species` list.
+2. **Edge filter.** Keep edges whose `edge_type` is in the (defaulted) `edge_types` list **and** whose two endpoints both survived step 1.
+3. **Scope.** If `root_node_id` is present and resolves to a surviving node: **undirected BFS** from it through the surviving edges, bounded by `depth` when present; keep only visited nodes and traversed edges. Undirected, because a scoped map means *"the neighborhood of this anchor"* — an admin view's map must include the API that calls into it, not only what it calls. (A directed variant was considered and rejected for v1; a `direction` knob MAY be added later without breaking this contract.)
+4. **Unresolvable root → empty subgraph**, never an error — the same posture as `computeChangelog` with an unknown version.
+
+The function is deterministic, pure, and generic over the node/edge element type (callers pass full app nodes or raw parsed JSON and get the same elements back).
+
+## Built-in Maps
+
+| Map | Kind | Answers | Rendering |
+|---|---|---|---|
+| **Journey** | `journey` | "How does a user move through the product?" | The existing canvas: compose closure from the root, playlist expansion, flows collapsible, visual node duplication for reuse |
+| **System** | `system` | "Which screens render this model? What does this endpoint feed?" | Direct render of `computeMapSubgraph`: all selected species as cards, cross-layer edges drawn, ELK-layered by species tier (views / api-endpoints / data-models) |
+
+**Renderer division of labor:** System is a *direct* projection render. Journey consumes the definition's root and species but owns its drawing logic (playlist ordering, expansion state, visual duplication of reused views) — renderer logic over a projection, exactly as `ReleaseCard` is renderer logic over `computeChangelog`. Delivery and Overview (vision.md § Core Product) are projections too, but render as a board and a dashboard rather than a canvas; their selection logic is specified with their implementation phases.
+
+## Validation
+
+Stored map definitions are checked by `validateBundle()` at **warning severity only** — a stale or dangling map must never fail an import or a CI gate:
+
+| Finding | Trigger |
+|---|---|
+| `map-duplicate-id` | Two stored definitions share an `id` |
+| `map-shadows-built-in` | A stored definition uses a reserved built-in id |
+| `map-unknown-root` | `root_node_id` does not resolve to a node |
+| `map-unknown-species` | A `species` entry is not a known species id |
+| `map-unknown-edge-type` | An `edge_types` entry is not a known edge type id |
+
+## Orphans
+
+Nodes unreachable from any root (the Pebbles seed ships two orphan flows) are not an error: they appear in the System map (which is unscoped by default) and in the library. The Journey renderer MAY later surface an "unanchored" cluster; hiding data silently is the failure mode this spec exists to end.
+
+## Non-Goals (v1)
+
+- **Per-map layout persistence** — positions are computed (ELK), not stored.
+- **Map sharing / cross-project maps** — a definition is project-scoped data.
+- **"Area" / domain tags on nodes** — root-scoping covers the admin-vs-user-app case for now; a first-class area concept is a future format revision if root-scoping proves insufficient.
+- **Journaling map edits** — `project.metadata` changes are not journal events today; unchanged by this spec.

--- a/docs/spec/mcp.md
+++ b/docs/spec/mcp.md
@@ -1,0 +1,90 @@
+---
+title: "Spec: MCP Server (Agent Plane)"
+navTitle: "MCP Server"
+order: 6
+---
+
+# MCP Server — the Agent Plane
+
+> Status: **Draft specification** — describes the target `arkaik-mcp` package. Nothing in this document is implemented yet; there is no MCP server in the codebase today. Agents currently interact through the skill ([toolchain.md](toolchain.md) § Skill Distribution), the CLI, and the raw format.
+> The key words MUST, MUST NOT, SHOULD, and MAY are to be interpreted as in RFC 2119.
+
+## Purpose
+
+The skill makes agents good *writers* of the map; the format makes them competent *readers*. What's missing is a **conversational surface**: an agent asked "what's blocked on iOS?" or "link this new endpoint to the checkout view" should not need to parse a 4,000-line JSON file into context or shell out to a CLI with flags. The MCP server exposes the map as **tools** — the same projections humans see as pages ([maps.md](maps.md), [journal.md](journal.md) § Projections), plus validated dual-write mutations.
+
+This is the **audience-symmetry principle** (vision.md § Core Product) made concrete: every human surface has an agent-consumable twin, produced by the same `@arkaik/schema` functions.
+
+## Packaging & Transport
+
+| Decision | Detail |
+|---|---|
+| Package | New workspace package `packages/mcp`, npm name **`arkaik-mcp`** (unscoped, symmetric with `arkaik`), MIT — toolchain side of the license split |
+| Bin / install story | `npx -y arkaik-mcp` is the whole setup; esbuild-bundled single file like the CLI |
+| Transport | **stdio** (v1). The server is spawned per session by the agent host; no daemon, no port |
+| Not a CLI subcommand | The `arkaik` CLI stays dependency-free; the MCP SDK would end that. The CLI usage text gains a pointer line; an `arkaik mcp` alias MAY wrap the package later |
+| SDK note | `@modelcontextprotocol/sdk` is the default choice; if its zod version conflicts with the workspace's zod 4, fall back to the SDK's low-level `Server` API with raw JSON-Schema tool definitions. `@arkaik/schema` remains the only validation authority either way |
+
+## Bundle Discovery (Kommit-first)
+
+The server operates on the **repo bundle** — the Kommit mode where the map already lives next to the code, maintained as a side effect of development. Resolution order:
+
+1. `--bundle <path>` argument
+2. `ARKAIK_BUNDLE` environment variable
+3. `docs/arkaik/bundle.json` under the current working directory
+
+The journal is the sidecar resolved by the rules in [journal.md](journal.md) § Storage Shapes. The server MUST reload the bundle per tool call (files are small; external edits — a human, another agent, `git pull` — must be picked up).
+
+## Tool Catalog (v1)
+
+All tool results are JSON text content. Read tools are projections; write tools follow the Write Path below.
+
+| Tool | Input | Returns | Journal events |
+|---|---|---|---|
+| `list_nodes` | `species?`, `status?`, `platform?`, `query?`, `limit?` | node summaries `{id, title, species, status, platforms}` | — |
+| `get_node` | `node_id` | full node + edges with neighbor titles + where-used flows + `computeNodeTimeline` | — |
+| `create_node` | `species`, `title`, `description?`, `status?`, `platforms`, `metadata?` | created node (id via `deriveNodeId`) | `node.created` |
+| `update_node` | `node_id`, `patch` | updated node | via `diffNodeUpdate`: `node.updated` / `node.status_changed` (± `platform`) / `ref.added` / `ref.removed` |
+| `delete_node` | `node_id` | removed node + cascaded edge ids | `node.deleted` (edge cascade implied per [journal.md](journal.md)) |
+| `add_edge` | `source_id`, `target_id`, `edge_type` | created edge (id via `edgeId`) | `edge.added` |
+| `remove_edge` | `edge_id` | ack | `edge.removed` |
+| `propose_idea` | `title`, `description?`, `node_id?` | event | `idea.proposed` |
+| `file_request` | `title`, `description?`, `source?`, `node_id?` | event | `request.filed` |
+| `get_changelog` | `version?` | release list, or one `computeChangelog` slice | — |
+| `get_backlog` | — | `computeBacklog` (open ideas & requests) | — |
+| `list_maps` | — | built-in + stored `MapDefinition`s with node/edge counts | — |
+| `get_map` | `map_id` | `computeMapSubgraph` result | — |
+| `validate_bundle` | — | `validateBundle` findings (errors + warnings, with paths) | — |
+
+`arkaik release` (tagging, note drafting, compaction) stays **CLI-only** in v1 — it is a ceremony with side effects beyond the bundle, owned by `packages/cli/src/commands/release.ts`.
+
+## Write Path (dual-write, validator-gated)
+
+Every mutating tool MUST follow, in order:
+
+1. Load bundle + journal (fresh).
+2. Apply the mutation **in memory** and derive the matching journal events (shared derivation — see Reuse Seams).
+3. Run `validateBundle` on the mutated bundle with the new events folded in. **Any error → return the pathed findings and write nothing.** Warnings pass through in the tool result.
+4. Persist: append each event to the journal sidecar (JSONL, one line per event, `actor: "arkaik-mcp"`), then rewrite the snapshot with `serializeBundle` (canonical form — clean git diffs).
+
+This is the skill's dual-write doctrine ([journal.md](journal.md) § Authority) enforced structurally: an MCP mutation is *incapable* of the snapshot-without-history drift that free-form file edits invite.
+
+## Reuse Seams (two enabling moves)
+
+1. **CLI file-IO becomes importable.** `packages/cli` exposes a subpath export `arkaik/io` (bundle read/write, journal sidecar IO, validation wrapper) built as a second esbuild entry. `packages/mcp` depends on `arkaik` and imports these verbatim — no drift between what the CLI and the MCP server consider "the bundle on disk". Filesystem code stays out of `@arkaik/schema`, which remains browser-safe.
+2. **Dual-write derivation moves to the schema package.** `lib/data/emit-events.ts` is already pure; its core moves to `packages/schema/src/derive.ts` with the actor as a parameter. The app keeps a thin re-export binding `actor: "arkaik-app"`; the MCP server binds `"arkaik-mcp"`; the skill doctrine stays the human-readable statement of the same rules.
+
+## Distribution
+
+- **npm:** `npx -y arkaik-mcp` — zero-install for any MCP host.
+- **Claude Code plugin:** the plugin gains a generated `plugin/.mcp.json` declaring the server (`command: "npx", args: ["-y", "arkaik-mcp"]`), emitted by `scripts/generate/generate-plugin.js` and covered by the CI drift check. Installing the plugin then delivers **skill + MCP together**: the doctrine and the tools, one install.
+
+## Testing
+
+`tests/mcp/run-mcp-tests.js` follows the CLI harness pattern: spawn the built server against a tmpdir fixture bundle + journal sidecar, speak JSON-RPC over stdio (`initialize`, `tools/list`, `tools/call`), and assert: read-tool shapes; a write round-trip (update → journal line appended → `validate_bundle` clean → snapshot canonical); and the gate (a mutation that would dangle an edge is refused with pathed findings and the files untouched).
+
+## Non-Goals (v1)
+
+- **Hosted MCP / REST over Synk projects.** The natural Klub-tier follow-up: the same tool catalog served over authenticated transport against account-backed projects, enforced on the existing `lib/services/limits.ts` seam. Requires a device-token auth flow (shared open question with `arkaik push --to synk`, [services.md](services.md)). Specified when scheduled — nothing in this document precludes it.
+- **Multi-bundle workspaces** — one server instance, one bundle.
+- **Release ceremony** — CLI-only, above.

--- a/docs/spec/services.md
+++ b/docs/spec/services.md
@@ -6,7 +6,7 @@ order: 4
 
 # Services — Publik & Synk
 
-> Status: **Draft specification** — describes the M4 target. Nothing in this document is implemented yet; there is no server surface in the codebase today (no `app/api/`, no database, no auth).
+> Status: **Implemented (M4)** — the free surface is live: `app/api/publik` + `app/api/synk` route handlers, `lib/services/`, Auth.js at `auth.ts`, migrations under `db/migrations/`, and the client sync engine in `lib/sync/`. Basik/Klub monetization (M5) remains unbuilt and is gated behind the Core Product phases (vision.md § Roadmap). This document remains the normative contract.
 > The key words MUST, MUST NOT, SHOULD, and MAY are to be interpreted as in RFC 2119.
 
 ## Scope

--- a/docs/spec/toolchain.md
+++ b/docs/spec/toolchain.md
@@ -6,7 +6,7 @@ order: 3
 
 # Toolchain & Packaging
 
-> Status: **Draft specification** — describes the target packages and CLI. Today the toolchain exists only as the copy-paste skill and standalone validator under `docs/arkaik-skill/`.
+> Status: **Implemented** — `packages/schema` (`@arkaik/schema`) and `packages/cli` (`arkaik`) are live workspace packages; the skill ships as a Claude Code plugin (`plugin/`) with generated assets, and `scripts/generate/` drift-checks every generated artifact in CI. The legacy copy-paste skill remains under `docs/arkaik-skill/`. This document remains the normative contract; the MCP server companion is specified in [mcp.md](mcp.md).
 > The key words MUST, SHOULD, and MAY are to be interpreted as in RFC 2119.
 
 ## Why npm

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -24,16 +24,18 @@ This is deliberately layered (see [Format Levels](#format-levels)): nobody is fo
 
 The second half of the thesis: **arkaik is not just an app**. Its most committed users keep their product map *in their repository, next to their code*, maintained by coding agents as a side effect of development — that is exactly how arkaik itself uses the [agent skill](arkaik-skill/skill.md) with the Pebbles project. For them, the repo is the source of truth and arkaik.app is a lens. Serving that persona well requires treating the format and the tooling as products in their own right.
 
+And a corollary this vision previously under-served, now that the lower layers have shipped: **the lens itself**. One canvas cannot simultaneously serve a strategist zooming out, an operator zooming in, and an agent querying programmatically. The app answer is **one graph, many maps** — the same bundle read through purpose-built projections, each consumable by humans as a page and by agents as a function ([§ Core Product](#core-product-one-graph-many-maps), normative spec in [spec/maps.md](spec/maps.md)).
+
 ## The Four Layers
 
 arkaik is structured as four layers, each usable without the ones above it.
 
 | Layer | What it is | License | Status |
 |---|---|---|---|
-| **1. Format** | The open, versioned `ProjectBundle` + journal + references specification | MIT (planned split) | Partial — v1 schema published at `public/schema/project-bundle.json`, unversioned; v2 specified in [spec/bundle-format.md](spec/bundle-format.md) |
-| **2. Toolchain** | An npm package: `arkaik` CLI (validate, init, log, release, sync, pack), the agent skill, a zero-dependency validator artifact | MIT (planned split) | Planned — today the skill is copy-paste (`docs/arkaik-skill/`) and the validator is standalone |
-| **3. App** | arkaik.app — the graph viewer/editor (hosted; later possibly a local viewer via static export) | AGPL-3.0 | Live — local-first via `localStorage`, no accounts |
-| **4. Services** | Sync, hosting, sharing, integrations: the Synk/Basik/Klub tiers, Publik snapshots, Inkognito BYO-Supabase | AGPL / commercial | Planned |
+| **1. Format** | The open, versioned `ProjectBundle` + journal + references specification | MIT | **Shipped** — v2 published at `public/schema/project-bundle.json`, generated from `@arkaik/schema` ([spec/bundle-format.md](spec/bundle-format.md)) |
+| **2. Toolchain** | npm packages: `@arkaik/schema`, the `arkaik` CLI (init, validate, log, release, sync, pack, open, push), the agent skill + Claude Code plugin, a zero-dependency validator artifact | MIT | **Shipped** — `packages/schema`, `packages/cli`, `plugin/`; MCP server specified next ([spec/mcp.md](spec/mcp.md)) |
+| **3. App** | arkaik.app — the graph viewer/editor (hosted; later possibly a local viewer via static export) | AGPL-3.0 | Live — local-first via IndexedDB (Dexie), optional Synk accounts; **core experience under reconstruction** ([§ Core Product](#core-product-one-graph-many-maps)) |
+| **4. Services** | Sync, hosting, sharing, integrations: the Synk/Basik/Klub tiers, Publik snapshots, Inkognito self-hosting | AGPL / commercial | **Free surface shipped** — Publik + Synk with Auth.js accounts; monetization (Basik/Klub) deliberately gated behind Core Product |
 
 Design rule: **each layer only depends on the layer below it.** The app renders anything that conforms to the format; the services sync anything the app can hold. A user can adopt the format with zero arkaik infrastructure (a JSON file in a repo), and every additional layer is opt-in convenience.
 
@@ -122,6 +124,59 @@ Screenshots and previews are where storage gets critical, and the rule that keep
 | Data URI | Inline in the bundle | Lokal / legacy only — discouraged |
 
 Today the app stores screenshots as base64 data URIs inside the bundle (`metadata.platformScreenshots`, written by `components/panels/NodeDetailPanel.tsx`). That is a size bomb: it presses against the 5 MB import cap, the 4 MB export warning, and the localStorage quota simultaneously, and it is the one place the current code and the published schema have already drifted apart. The v2 spec legitimizes all three forms; `arkaik pack` inlines or uploads assets when a self-contained interchange file is needed. Journal events never carry asset payloads — only the fact that an asset changed.
+
+## Core Product: One Graph, Many Maps
+
+> Normative companion: [spec/maps.md](spec/maps.md). Agent plane: [spec/mcp.md](spec/mcp.md).
+
+### The Honest Diagnosis
+
+The lower layers sprinted ahead of the lens. Today the canvas anchors on `project.root_node_id` and renders only its *flow* children — a view-rooted bundle (the Pebbles seed's exact shape) renders **one card out of 147 nodes**. Data models and API endpoints never appear on the canvas at all, which silences 201 of the seed's 277 edges. The library's species filter duplicates the sidebar. There is no surface that answers "what is in flight on Android?" — the question per-platform statuses exist for. A map that is rich in data and poor in readings is a filing cabinet, not a map.
+
+### The App Thesis
+
+A **map is a named, parameterized projection over (snapshot, journal)**: a scope (root anchor), a selection (species, edge types), and a rendering mode (canvas, board, dashboard). Projections live in `@arkaik/schema` beside `computeChangelog` — the app renders them, the CLI prints them, the MCP server serves them.
+
+**Audience symmetry** is the design rule that follows: *every human surface has an agent-consumable twin*, produced by the same function. A strategist reads the Overview; an agent calls the same aggregation. An operator drags through the Delivery board; an agent queries the same (node × platform, status) tuples. Nothing is rendered that cannot be queried, and nothing is queryable that has no home on screen.
+
+### The Built-in Maps
+
+| Map | Centered on | Answers | Rendering |
+|---|---|---|---|
+| **Journey** | Navigation | "How does a user move through the product?" | Compose/playlist drill-down canvas (today's canvas, with the traversal fixed) |
+| **System** | The model | "Which screens render this data model? What does this endpoint feed?" | All four species as cards, cross-layer edges drawn, ELK-layered by species tier |
+| **Delivery** | Product status | "What is in flight on Android? What shipped on iOS?" | Board of (node × platform) items grouped by status — a view `live` on iOS and `prioritized` on Android appears in **both** columns, by design |
+| **Overview** | The whole | "Where does this product stand?" | Dashboard: per-platform delivery gauges, release pulse and backlog from the journal, inventory, coverage/health indicators |
+
+**Custom maps are data**, not features: a `MapDefinition` stored at `project.metadata.maps` scopes any archetype to a root anchor — the admin area versus the user app is two saved maps, not a format extension. Humans create them in a dialog; **agents author them by writing JSON**. ("Area" tags remain a future format revision if root-scoping proves insufficient — see Open Questions.)
+
+### The Information Architecture
+
+The sidebar reorganizes around three groups, replacing the single-canvas "Navigate":
+
+- **Project** — the product-level reading: Overview, Delivery, Changelog. This is where strategists land.
+- **Maps** — the graph readings: Journey, System, and saved custom maps. This is where structure is explored and edited.
+- **Library** — the dense inventory: one page per species, driven by the sidebar (the sidebar is the *only* species selector; the in-page species filter is removed as redundant). This is where operators audit.
+
+Zooming is a continuum, not a mode switch: Overview links into maps, maps open the node detail panel, the panel deep-links back into scoped maps and the library.
+
+### The Agent Plane
+
+The skill made agents good *writers*; the format made them competent *readers*. The **MCP server** ([spec/mcp.md](spec/mcp.md)) makes them conversational participants: the projections above exposed as tools, plus validator-gated dual-write mutations (`actor: "arkaik-mcp"`). Repo-local (Kommit, stdio, `npx -y arkaik-mcp`) first — zero infrastructure, serving the persona that already lives in the repo. A hosted agent surface over Synk projects is the natural Klub-tier follow-up, on the tier-enforcement seam that already exists.
+
+### Continuity Guardrails (unchanged)
+
+- **Graph model**: the four species, playlist-driven flows (`metadata.playlist.entries`), optional `project.root_node_id` anchor. Config source: `lib/config/species.ts`
+- **Platform and status**: per-platform status editing on `view` nodes; `flow` status stays a computed rollup; the journal extends with history, never replaces. `release.tagged` keeps its optional `platform`. Config: `lib/config/platforms.ts`, `lib/config/statuses.ts`
+- **Reuse-first authoring**: where-used visibility, insert-between operations, the shared node detail panel. References: `components/panels/NodeDetailPanel.tsx`, `components/panels/InsertBetweenDialog.tsx`, `lib/utils/where-used.ts`
+- **Data layer**: the `DataProvider` abstraction, local-first operation, import/export. References: `lib/data/data-provider.ts`, `lib/data/local-provider.ts`, `lib/utils/export.ts`
+
+### Non-Goals
+
+- Not a task tracker — refs *link to* issues and PRs; arkaik never becomes the place where they are managed
+- Not a wiki, not a design tool
+- No event-sourcing purism: the snapshot is never silently re-projected from the journal (see the authority rules in [spec/journal.md](spec/journal.md))
+- No per-map stored layouts, no map sharing in v1 ([spec/maps.md](spec/maps.md) § Non-Goals)
 
 ## Modes & Tiers
 
@@ -256,16 +311,21 @@ The split executes when the packages are physically extracted (`packages/schema`
 
 ## Roadmap
 
-Sequencing principle: **git-native toolchain first.** It serves arkaik's own dogfooding workflow immediately, builds bottom-up adoption the way Storybook and Changesets did, and lets the SaaS tiers arrive later as convenience on top of a proven format — rather than a format invented under a SaaS deadline.
+Two sequencing principles:
 
-### Phase 0 — Enablers
+1. **Git-native toolchain first.** It serves arkaik's own dogfooding workflow immediately, builds bottom-up adoption the way Storybook and Changesets did, and lets the SaaS tiers arrive later as convenience on top of a proven format — rather than a format invented under a SaaS deadline. *This principle has run its course: Phases 0–4 are shipped.*
+2. **Core product before monetization.** The business-model scaffolding exists (tier limits, enforcement sockets, Publik/Synk), but charging for a lens that renders one card of a 147-node bundle would be selling the filing cabinet. Phase 5 stays parked until the Core Product phases below make the app worth paying for.
+
+Phases 0–4 are kept below as the shipped record; statements inside them describe the pre-implementation state they fixed.
+
+### Phase 0 — Enablers *(shipped)*
 
 - CI: lint, build, run the validator against all seeds (`seed/pebbles.json`, `seed/arkaik-self-map.json`, `public/schema/example-bundle.json`), fixture tests (valid/invalid bundles)
 - Fix `rewriteBundleProjectId` in `lib/utils/export.ts`, which silently drops unknown top-level bundle keys on import-ID collision — a landmine for any format extension
 - Align the `TASK_EXTEND` prompt in `lib/prompts/blocks.ts` with the skill's surgical-patch doctrine (it currently instructs LLMs to regenerate the full bundle)
 - License split decision recorded; `CONTRIBUTING.md` / `GOVERNANCE.md` stubs
 
-### Phase 1 — Single Source of Truth
+### Phase 1 — Single Source of Truth *(shipped)*
 
 The bundle contract currently lives in five places that drift independently: `lib/data/types.ts`, `public/schema/project-bundle.json`, `docs/arkaik-skill/references/schema.md`, `docs/arkaik-skill/scripts/validate-bundle.js`, and `lib/prompts/blocks.ts` (drift is already real: `platformScreenshots` exists only in the first). Collapse them **before** the journal would make it six:
 
@@ -273,21 +333,21 @@ The bundle contract currently lives in five places that drift independently: `li
 - Generated artifacts, committed and drift-checked in CI: the JSON Schema, a zero-dependency bundled `validate-bundle.js` (agents in repos without the CLI still need `node validate-bundle.js`), the skill's schema reference fragment, and the prompt generator's schema block
 - App consumes the package: `lib/data/types.ts` becomes a re-export; `assertProjectBundleShape` is replaced by real validation — closing the duplicate-node-ID class of import failures at the app door
 
-### Phase 2 — Format v2 & Journal Read Path
+### Phase 2 — Format v2 & Journal Read Path *(shipped)*
 
 - Bundle v2 per [spec/bundle-format.md](spec/bundle-format.md): `schema_version`, refs, asset value forms, optional embedded `journal[]`
 - Journal per [spec/journal.md](spec/journal.md): JSONL sidecar, union-merge gitattributes, event vocabulary
 - Skill v2: dual-write (patch snapshot + append events), templated per project, versioned frontmatter so `arkaik init --update` can upgrade it
 - App reads journals: per-node status timeline in the detail panel, changelog view — rendering only, no app-side event emission yet
 
-### Phase 3 — Toolchain & Write Path
+### Phase 3 — Toolchain & Write Path *(shipped)*
 
 - `packages/cli`: `init`, `validate`, `log`, `release` (tagging, release notes, compaction), `sync`, `pack`, `open`; skill distribution as a Claude Code plugin as a second channel
 - Deterministic IDs adopted **in the app** for nodes and edges (today `lib/utils/id.ts` generates random UUID suffixes and canvas edges use raw UUIDs, so any app round-trip violates the conventions the skill enforces), plus canonical serialization (sorted keys/nodes/edges) so app exports diff cleanly in git
 - App-side event emission, unblocked by the IndexedDB (Dexie) migration that landed — the old localStorage backend rewrote the whole store on every mutation and could not absorb a growing journal; the per-project store (with a separate journal table) now can
 - `arkaik dev` (local viewer) decision: requires making `/project/[id]` routing static-export friendly; evaluated on its own merits, not assumed
 
-### Phase 4 — Services: The Free Surface
+### Phase 4 — Services: The Free Surface *(shipped)*
 
 Backend decision: **Vercel-native** — Next.js route handlers + managed Postgres (Neon); no Supabase. Normative spec: [spec/services.md](spec/services.md).
 
@@ -297,61 +357,27 @@ Backend decision: **Vercel-native** — Next.js route handlers + managed Postgre
 - Provider-injection seam + mutation notifications in the data layer — shared prerequisite with the `arkaik dev` RFC
 - Inkognito as full-stack self-hosting: `db/migrations/*.sql` shipped release-aligned
 
+### Core Product Phases (current focus)
+
+The execution of [§ Core Product](#core-product-one-graph-many-maps). CP-A ships the usability floor and the specs; each subsequent phase turns one spec'd surface real. Sizes: S/M/L.
+
+| Phase | Scope | Size | Depends on |
+|---|---|---|---|
+| **CP-A — Usability floor + specs** | Canvas compose-closure traversal fix + first-flow auto-expand (a view-rooted bundle renders its real tree); library species filter removed (sidebar is the single selector); sidebar regrouped Project / Maps / Library; [spec/maps.md](spec/maps.md) + [spec/mcp.md](spec/mcp.md) written; stale docs refreshed; seed showcases version + journal | S–M | — |
+| **CP-B — Maps in the schema** | `packages/schema/src/maps.ts`: `MapDefinition`, `BUILT_IN_MAPS`, `computeMapSubgraph`, `listMaps`; typed `metadata.maps` in `bundle.ts`; warning-severity validation rules; `emit-events` core moves to `schema/derive.ts` (MCP prerequisite); `npm run generate` ripple + tests | M | — |
+| **CP-C — Maps routes & canvas decomposition** | `/maps` index + `/maps/[mapId]`; `/canvas` becomes a redirect; the canvas monolith decomposes (`journey-graph`, `graph-build`, `system-graph` utils; `JourneyMap`/`SystemMap`/`RawBundleSheet` components; `useElkLayout`); ELK gains cross-layer edge + species-partition options (spike partitioning first); System map renders all four species; custom-map dialog; dead navigation code deleted | L | CP-B |
+| **CP-D — Delivery board** | `lib/utils/delivery.ts` ((node × platform, status) tuples via `getNodePlatformStatuses`; flows excluded — rollups aren't deliverables); `/delivery` board with the `delivery` status-preset columns + all-statuses toggle; detail panel opens on the clicked platform tab (`initialPlatform`) | M | ∥ CP-C |
+| **CP-E — Overview** | `/overview` dashboard composing existing projections (platform gauges, release pulse, backlog, inventory, delivery snapshot, maps) + `lib/utils/coverage.ts` health indicators; `/project/[id]` lands on Overview | M | CP-B; richer after CP-C/D |
+| **CP-F — MCP server** | `packages/mcp` per [spec/mcp.md](spec/mcp.md): stdio tools over the repo bundle, validator-gated dual-write, `arkaik/io` reuse seam, plugin `.mcp.json`, JSON-RPC test harness | L | CP-B; ∥ CP-C/D/E |
+
 ### Phase 5 — Services: Monetization & Depth
+
+> Gated on the Core Product phases: pricing a broken lens would convert nobody and burn the launch. Revisit when Overview/Delivery/Maps are live.
 
 - Payments (Stripe), pricing page, Basik/Klub tier activation on the Phase 4 enforcement points
 - Real-time sync and multi-device semantics for Basik/Klub — designed on the journal substrate, the first phase allowed to think in events
 - Server-side integrations (ref status sync) as the Klub differentiator; hosted asset buckets + `arkaik pack` upload path
 - Collaboration explorations on top of event streams
-
-## Core Product Direction (Unchanged)
-
-The strategy above must preserve the current graph and UX foundations.
-
-### Graph Model Continuity
-
-The core model remains centered on four species:
-
-- `flow`: ordered sequence container
-- `view`: reusable screen/page node
-- `data-model`: data entity node
-- `api-endpoint`: API contract node
-
-Flow behavior remains playlist-driven (`metadata.playlist.entries`) and can anchor from optional `project.root_node_id`.
-
-Config source: `lib/config/species.ts`
-
-### UX Continuity
-
-- Keep canvas route for spatial graph editing and sequence expansion
-- Keep library route for dense browsing, filtering, and metadata audit workflows
-- Keep sidebar shell for stable in-project navigation between both modes
-- Keep reuse-first authoring with where-used visibility and insert-between operations
-
-Implementation references: `app/project/[id]/canvas/page.tsx`, `app/project/[id]/library/page.tsx`, `components/layout/ProjectSidebar.tsx`, `components/panels/NodeDetailPanel.tsx`, `components/panels/InsertBetweenDialog.tsx`, `lib/utils/where-used.ts`, `lib/utils/elk-layout.ts`
-
-### Platform And Status Continuity
-
-- Keep per-platform status editing on `view` nodes
-- Keep `flow` status as computed rollup from descendant views
-- Keep lifecycle state visible in cards, panels, and table rows
-- The journal extends this model with history; it does not replace it. `release.tagged` events carry an optional `platform` so per-platform release rhythms (web weekly, iOS monthly) stay expressible
-
-Config sources: `lib/config/platforms.ts`, `lib/config/statuses.ts`
-
-### Data Layer Continuity
-
-- Preserve the `DataProvider` abstraction so UI and hooks stay backend-agnostic
-- Continue local-first operation with import/export
-- Add tier-aware backend behavior without breaking existing contracts
-
-Implementation references: `lib/data/data-provider.ts`, `lib/data/local-provider.ts`, `lib/utils/export.ts`
-
-### Non-Goals
-
-- Not a task tracker — refs *link to* issues and PRs; arkaik never becomes the place where they are managed
-- Not a wiki, not a design tool
-- No event-sourcing purism: the snapshot is never silently re-projected from the journal (see the authority rules in [spec/journal.md](spec/journal.md))
 
 ## Open Questions
 
@@ -365,3 +391,8 @@ Implementation references: `lib/data/data-provider.ts`, `lib/data/local-provider
 - [ ] Per-platform releases: is optional `platform` on `release.tagged` enough, or do platforms need independent version sequences?
 - [ ] Publik and journals: default-exclude is decided; is opt-in inclusion ever safe (history can leak internal names and dates)?
 - [ ] Kommit naming: confirm "Kommit" (working name) against the existing K-family
+- [ ] Map naming: confirm "Journey" / "System" / "Delivery" / "Overview" labels (alternatives recorded in [spec/maps.md](spec/maps.md))
+- [ ] Delivery board and flows: should flows appear as items (rollup as pseudo-deliverable) behind a filter, or stay excluded?
+- [ ] Per-map layout persistence: are ELK-computed positions enough, or do maps eventually store user-arranged layouts?
+- [ ] "Area" tags: does root-scoped map coverage hold up, or do nodes need first-class area/domain membership (a format revision)?
+- [ ] Hosted agent plane: device-token auth flow for MCP/`arkaik push --to synk` — Klub launch requirement or fast-follow?

--- a/seed/pebbles.json
+++ b/seed/pebbles.json
@@ -1,14 +1,25 @@
 {
+  "schema_version": 2,
   "project": {
     "id": "pebbles",
     "title": "Pebbles",
     "description": "Pebbles is an atomic diary app allowing to record memories and enrich them with emotions, instants, thoughts, related to people and get weekly and monthly wraps.",
+    "version": "0.4.0",
     "root_node_id": "V-landing",
     "metadata": {
-      "view_card_variant": "large"
+      "view_card_variant": "large",
+      "maps": [
+        {
+          "id": "recording-loop",
+          "title": "Recording loop",
+          "description": "The core capture journey, scoped to the record-pebble flow.",
+          "kind": "journey",
+          "root_node_id": "F-record-pebble"
+        }
+      ]
     },
     "created_at": "2026-04-01T00:00:00.000Z",
-    "updated_at": "2026-07-03T00:00:00.000Z"
+    "updated_at": "2026-07-09T14:30:00.000Z"
   },
   "nodes": [
     {
@@ -4124,6 +4135,1520 @@
       "source_id": "API-buy-glyph",
       "target_id": "DM-karma-events",
       "edge_type": "queries"
+    }
+  ],
+  "journal": [
+    {
+      "id": "01KN44ARM0JH4YFMX52BGKNPKY",
+      "ts": "2026-04-01T09:00:00.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-landing",
+      "species": "view",
+      "title": "Landing"
+    },
+    {
+      "id": "01KN44ASK852PG8CBAZNCSBCP3",
+      "ts": "2026-04-01T09:00:01.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-login",
+      "species": "view",
+      "title": "Login"
+    },
+    {
+      "id": "01KN44ATJGXCN7A82WMF0M86J5",
+      "ts": "2026-04-01T09:00:02.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-register",
+      "species": "view",
+      "title": "Register"
+    },
+    {
+      "id": "01KN44AVHR9RMJT63P3JJ2KHBA",
+      "ts": "2026-04-01T09:00:03.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-home",
+      "species": "view",
+      "title": "Home"
+    },
+    {
+      "id": "01KN44AWH0XG024XKAK7T77Q4J",
+      "ts": "2026-04-01T09:00:04.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-timeline",
+      "species": "view",
+      "title": "Path"
+    },
+    {
+      "id": "01KN44AXG8NYZCR26AAJ7N2TCA",
+      "ts": "2026-04-01T09:00:05.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-pebble-record",
+      "species": "view",
+      "title": "Record Pebble"
+    },
+    {
+      "id": "01KN44AYFG4XTCMGR63HYQWQ0B",
+      "ts": "2026-04-01T09:00:06.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-pebble-intensity",
+      "species": "view",
+      "title": "Set Intensity & Valence"
+    },
+    {
+      "id": "01KN44AZERH180VYAM1Z6FM5JH",
+      "ts": "2026-04-01T09:00:07.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-emotion-pearl",
+      "species": "view",
+      "title": "Shape Emotion Pearl"
+    },
+    {
+      "id": "01KN44B0E0SGSENRGXMSBYDH2N",
+      "ts": "2026-04-01T09:00:08.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-instant-attach",
+      "species": "view",
+      "title": "Attach Instants"
+    },
+    {
+      "id": "01KN44B1D8K5KFKMYQWAZHDFCG",
+      "ts": "2026-04-01T09:00:09.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-soul-link",
+      "species": "view",
+      "title": "Link Soul"
+    },
+    {
+      "id": "01KN44B2CGVQHGV8NM89YA7J3R",
+      "ts": "2026-04-01T09:00:10.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-domain-attach",
+      "species": "view",
+      "title": "Attach Domain"
+    },
+    {
+      "id": "01KN44B3BRQJ59050EZFG8PHN3",
+      "ts": "2026-04-01T09:00:11.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-cards-thoughts",
+      "species": "view",
+      "title": "Add Cards & Thoughts"
+    },
+    {
+      "id": "01KN44B4B0GXGR8GXW8M8XE6JT",
+      "ts": "2026-04-01T09:00:12.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-quick-pebble-editor",
+      "species": "view",
+      "title": "Quick Pebble Editor"
+    },
+    {
+      "id": "01KN44B5A8Q927011CVMSZRXXZ",
+      "ts": "2026-04-01T09:00:13.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-pebble-detail",
+      "species": "view",
+      "title": "Pebble Detail"
+    },
+    {
+      "id": "01KN44B69GVKCSPPFQ23J0MMV3",
+      "ts": "2026-04-01T09:00:14.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-pebble-revelation",
+      "species": "view",
+      "title": "Pebble Revelation"
+    },
+    {
+      "id": "01KN44B78RXTXW2B7NW5RB16ER",
+      "ts": "2026-04-01T09:00:15.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-record-celebration",
+      "species": "view",
+      "title": "Record Celebration"
+    },
+    {
+      "id": "01KN44B88056ANQJDPK8G8CDWX",
+      "ts": "2026-04-01T09:00:16.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-collections-list",
+      "species": "view",
+      "title": "Collections"
+    },
+    {
+      "id": "01KN44B978TR3KW0VRKV2GNS5G",
+      "ts": "2026-04-01T09:00:17.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-collection-detail",
+      "species": "view",
+      "title": "Collection Detail"
+    },
+    {
+      "id": "01KN44BA6GXDKZSM6XY2NZ76S2",
+      "ts": "2026-04-01T09:00:18.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-collection-create",
+      "species": "view",
+      "title": "Create Collection"
+    },
+    {
+      "id": "01KN44BB5RPGAM7JRSREN2SAHK",
+      "ts": "2026-04-01T09:00:19.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-collection-edit",
+      "species": "view",
+      "title": "Edit Collection"
+    },
+    {
+      "id": "01KN44BC50M4AKD1AW4V2CYDT5",
+      "ts": "2026-04-01T09:00:20.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-souls-list",
+      "species": "view",
+      "title": "Souls Directory"
+    },
+    {
+      "id": "01KN44BD48DSPQHE4HX3EKMWD0",
+      "ts": "2026-04-01T09:00:21.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-soul-detail",
+      "species": "view",
+      "title": "Soul Detail"
+    },
+    {
+      "id": "01KN44BE3GD452HZK2SR92GX0B",
+      "ts": "2026-04-01T09:00:22.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-soul-create",
+      "species": "view",
+      "title": "Add Soul"
+    },
+    {
+      "id": "01KN44BF2R15QW3D5ESFMVS57C",
+      "ts": "2026-04-01T09:00:23.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-soul-edit",
+      "species": "view",
+      "title": "Edit Soul"
+    },
+    {
+      "id": "01KN44BG20BX91AF4R5DN3YED8",
+      "ts": "2026-04-01T09:00:24.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-glyphs-list",
+      "species": "view",
+      "title": "Glyphs"
+    },
+    {
+      "id": "01KN44BH18HGP6NBM2QVSHAHF7",
+      "ts": "2026-04-01T09:00:25.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-glyph-detail",
+      "species": "view",
+      "title": "Glyph Detail"
+    },
+    {
+      "id": "01KN44BJ0GRDHWD8ZJ5ATEC1VJ",
+      "ts": "2026-04-01T09:00:26.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-glyph-carve",
+      "species": "view",
+      "title": "Carve Glyph"
+    },
+    {
+      "id": "01KN44BJZRTNW5XK61Y89BXFEC",
+      "ts": "2026-04-01T09:00:27.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-glyph-attach",
+      "species": "view",
+      "title": "Attach Glyph"
+    },
+    {
+      "id": "01KN44BKZ0EQDXXNMKVT265BBG",
+      "ts": "2026-04-01T09:00:28.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-bounce-tempo",
+      "species": "view",
+      "title": "Bounce Tempo"
+    },
+    {
+      "id": "01KN44BMY8J1MG6X3RD8XN48HK",
+      "ts": "2026-04-01T09:00:29.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-collection-rise",
+      "species": "view",
+      "title": "Collection Rise"
+    },
+    {
+      "id": "01KN44BNXGG9XW2PVJ7S0K12B1",
+      "ts": "2026-04-01T09:00:30.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-achievements",
+      "species": "view",
+      "title": "Achievements"
+    },
+    {
+      "id": "01KN44BPWRK3WYWECQT3XBRJPW",
+      "ts": "2026-04-01T09:00:31.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-weekly-cairn-intro",
+      "species": "view",
+      "title": "Weekly Cairn Intro"
+    },
+    {
+      "id": "01KN44BQW0S9XV4XEF85GRNC74",
+      "ts": "2026-04-01T09:00:32.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-weekly-cairn",
+      "species": "view",
+      "title": "Weekly Cairn"
+    },
+    {
+      "id": "01KN44BRV843HB1QMJTFZNCS2Q",
+      "ts": "2026-04-01T09:00:33.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-weekly-cairn-review",
+      "species": "view",
+      "title": "Weekly Cairn Review"
+    },
+    {
+      "id": "01KN44BSTGA4WH313K6417W6RJ",
+      "ts": "2026-04-01T09:00:34.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-monthly-cairn-intro",
+      "species": "view",
+      "title": "Monthly Cairn Intro"
+    },
+    {
+      "id": "01KN44BTSR4B12NG3VS9HKP446",
+      "ts": "2026-04-01T09:00:35.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-monthly-cairn",
+      "species": "view",
+      "title": "Monthly Cairn"
+    },
+    {
+      "id": "01KN44BVS0DN03WQ089BXV0F4P",
+      "ts": "2026-04-01T09:00:36.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-monthly-cairn-review",
+      "species": "view",
+      "title": "Monthly Cairn Review"
+    },
+    {
+      "id": "01KN44BWR80M5VDBACP24Y6P3F",
+      "ts": "2026-04-01T09:00:37.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-onboarding-intro",
+      "species": "view",
+      "title": "Onboarding — Your life is a path"
+    },
+    {
+      "id": "01KN44BXQG24Z05F6RHV8SRN52",
+      "ts": "2026-04-01T09:00:38.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-onboarding-concept",
+      "species": "view",
+      "title": "Onboarding — Drop a pebble, keep the moment"
+    },
+    {
+      "id": "01KN44BYPRGKGSHGT8XAHMXS43",
+      "ts": "2026-04-01T09:00:39.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-onboarding-qualify",
+      "species": "view",
+      "title": "Onboarding — Qualify and relate"
+    },
+    {
+      "id": "01KN44BZP0YFDM866X0WQXRX7H",
+      "ts": "2026-04-01T09:00:40.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-onboarding-carving",
+      "species": "view",
+      "title": "Onboarding — Get your pebble"
+    },
+    {
+      "id": "01KN44C0N8V73F9A63EE7X0EDH",
+      "ts": "2026-04-01T09:00:41.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-settings",
+      "species": "view",
+      "title": "Settings"
+    },
+    {
+      "id": "01KN44C1MGB2MZY3MX49HGCJT7",
+      "ts": "2026-04-01T09:00:42.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-profile",
+      "species": "view",
+      "title": "Profile"
+    },
+    {
+      "id": "01KN44C2KRAC1CEQYSG31AK08N",
+      "ts": "2026-04-01T09:00:43.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-record-pebble",
+      "species": "flow",
+      "title": "Record Pebble"
+    },
+    {
+      "id": "01KN44C3K0Y28FN6B2W5ZMFNRS",
+      "ts": "2026-04-01T09:00:44.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-onboarding",
+      "species": "flow",
+      "title": "Onboarding"
+    },
+    {
+      "id": "01KN44C4J8M3FGFKN14P5ES3B5",
+      "ts": "2026-04-01T09:00:45.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-manage-collections",
+      "species": "flow",
+      "title": "Manage Collections"
+    },
+    {
+      "id": "01KN44C5HG2WGQK7B9GAPMQGE8",
+      "ts": "2026-04-01T09:00:46.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-manage-souls",
+      "species": "flow",
+      "title": "Manage Souls"
+    },
+    {
+      "id": "01KN44C6GR98B5BGJM16S0B757",
+      "ts": "2026-04-01T09:00:47.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-manage-glyphs",
+      "species": "flow",
+      "title": "Manage Glyphs"
+    },
+    {
+      "id": "01KN44C7G02BE6Q2ADKFQZHR5X",
+      "ts": "2026-04-01T09:00:48.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-weekly-wrap",
+      "species": "flow",
+      "title": "Weekly Wrap"
+    },
+    {
+      "id": "01KN44C8F8C53GNTRRBPC83849",
+      "ts": "2026-04-01T09:00:49.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-monthly-wrap",
+      "species": "flow",
+      "title": "Monthly Wrap"
+    },
+    {
+      "id": "01KN44C9EGGD25WBAFRA7WY36A",
+      "ts": "2026-04-01T09:00:50.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-gamification",
+      "species": "flow",
+      "title": "Gamification Hub"
+    },
+    {
+      "id": "01KN44CADRJNAHEMRKR85CVMH1",
+      "ts": "2026-04-01T09:00:51.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-account",
+      "species": "data-model",
+      "title": "Account"
+    },
+    {
+      "id": "01KN44CBD054GGAGM4K4TXSS2K",
+      "ts": "2026-04-01T09:00:52.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-profile",
+      "species": "data-model",
+      "title": "Profile"
+    },
+    {
+      "id": "01KN44CCC8T8JCDSDHE9W01SHQ",
+      "ts": "2026-04-01T09:00:53.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-pebble",
+      "species": "data-model",
+      "title": "Pebble"
+    },
+    {
+      "id": "01KN44CDBGWREFN42JQWTSQ3GJ",
+      "ts": "2026-04-01T09:00:54.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-emotion-pearl",
+      "species": "data-model",
+      "title": "Emotion Pearl"
+    },
+    {
+      "id": "01KN44CEARQDKCV24AKJ68M051",
+      "ts": "2026-04-01T09:00:55.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-soul",
+      "species": "data-model",
+      "title": "Soul"
+    },
+    {
+      "id": "01KN44CFA0YY7MC0YRAC3J93W8",
+      "ts": "2026-04-01T09:00:56.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-domain",
+      "species": "data-model",
+      "title": "Domain"
+    },
+    {
+      "id": "01KN44CG982HN225XHE2E2A5B5",
+      "ts": "2026-04-01T09:00:57.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-card",
+      "species": "data-model",
+      "title": "Card"
+    },
+    {
+      "id": "01KN44CH8GJMP61ZXF20J50PPM",
+      "ts": "2026-04-01T09:00:58.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-thought",
+      "species": "data-model",
+      "title": "Thought"
+    },
+    {
+      "id": "01KN44CJ7RXW5BQZ1JDZXZ91DD",
+      "ts": "2026-04-01T09:00:59.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-collection",
+      "species": "data-model",
+      "title": "Collection"
+    },
+    {
+      "id": "01KN44CK70YN0WQ5W2YV9MAXED",
+      "ts": "2026-04-01T09:01:00.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-bounce",
+      "species": "data-model",
+      "title": "Bounce"
+    },
+    {
+      "id": "01KN44CM68W6D43WXM2K91FHZY",
+      "ts": "2026-04-01T09:01:01.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-cairn",
+      "species": "data-model",
+      "title": "Cairn"
+    },
+    {
+      "id": "01KN44CN5G44DNG2QJA0618WY0",
+      "ts": "2026-04-01T09:01:02.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-achievement",
+      "species": "data-model",
+      "title": "Achievement"
+    },
+    {
+      "id": "01KN44CP4RS92VX9PZBYVMNB0A",
+      "ts": "2026-04-01T09:01:03.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-instant",
+      "species": "data-model",
+      "title": "Instant"
+    },
+    {
+      "id": "01KN44CQ40JWYH0RR9YPNQHMC1",
+      "ts": "2026-04-01T09:01:04.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-mark",
+      "species": "data-model",
+      "title": "Mark"
+    },
+    {
+      "id": "01KN44CR38WYDPFKRANM0M10BP",
+      "ts": "2026-04-01T09:01:05.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-get-marks",
+      "species": "api-endpoint",
+      "title": "GET /marks"
+    },
+    {
+      "id": "01KN44CS2GV1XZSHC3VAQPN0GB",
+      "ts": "2026-04-01T09:01:06.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-create-mark",
+      "species": "api-endpoint",
+      "title": "POST /marks"
+    },
+    {
+      "id": "01KN44CT1RH5068PFWG63NGSJ7",
+      "ts": "2026-04-01T09:01:07.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-delete-mark",
+      "species": "api-endpoint",
+      "title": "DELETE /marks/:id"
+    },
+    {
+      "id": "01KN44CV1048EP109JQEXMRY19",
+      "ts": "2026-04-01T09:01:08.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-create-pebble",
+      "species": "api-endpoint",
+      "title": "POST /pebbles"
+    },
+    {
+      "id": "01KN44CW08APT40KSSR5MQZ6G1",
+      "ts": "2026-04-01T09:01:09.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-get-pebbles",
+      "species": "api-endpoint",
+      "title": "GET /pebbles"
+    },
+    {
+      "id": "01KN44CWZGYTGPGVCZ6HK5TKMK",
+      "ts": "2026-04-01T09:01:10.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-get-pebble",
+      "species": "api-endpoint",
+      "title": "GET /pebbles/:id"
+    },
+    {
+      "id": "01KN44CXYRE145ZEXB0VRPF2MS",
+      "ts": "2026-04-01T09:01:11.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-set-intensity",
+      "species": "api-endpoint",
+      "title": "PATCH /pebbles/:id/intensity"
+    },
+    {
+      "id": "01KN44CYY0M92WJW8FCGSKTD4K",
+      "ts": "2026-04-01T09:01:12.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-create-emotion-pearl",
+      "species": "api-endpoint",
+      "title": "POST /pebbles/:id/pearl"
+    },
+    {
+      "id": "01KN44CZX86KPHH97ZT71JJCHZ",
+      "ts": "2026-04-01T09:01:13.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-link-soul",
+      "species": "api-endpoint",
+      "title": "POST /pebbles/:id/souls"
+    },
+    {
+      "id": "01KN44D0WGVQCTJPB35EZPSADK",
+      "ts": "2026-04-01T09:01:14.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-attach-domain",
+      "species": "api-endpoint",
+      "title": "POST /pebbles/:id/domain"
+    },
+    {
+      "id": "01KN44D1VRFZTE4KNC5JJ2SXPF",
+      "ts": "2026-04-01T09:01:15.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-add-card",
+      "species": "api-endpoint",
+      "title": "POST /pebbles/:id/cards"
+    },
+    {
+      "id": "01KN44D2V0MQPTS90C8QK1Q2QY",
+      "ts": "2026-04-01T09:01:16.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-add-thought",
+      "species": "api-endpoint",
+      "title": "POST /pebbles/:id/thoughts"
+    },
+    {
+      "id": "01KN44D3T8JFRWXVAYS5MDMQYC",
+      "ts": "2026-04-01T09:01:17.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-get-souls",
+      "species": "api-endpoint",
+      "title": "GET /souls"
+    },
+    {
+      "id": "01KN44D4SG05GTF4EBNYB2TNDJ",
+      "ts": "2026-04-01T09:01:18.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-create-soul",
+      "species": "api-endpoint",
+      "title": "POST /souls"
+    },
+    {
+      "id": "01KN44D5RRDCCZF8YN3TBE2AJJ",
+      "ts": "2026-04-01T09:01:19.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-update-soul",
+      "species": "api-endpoint",
+      "title": "PATCH /souls/:id"
+    },
+    {
+      "id": "01KN44D6R0EGN56AMY396C4SJ7",
+      "ts": "2026-04-01T09:01:20.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-delete-soul",
+      "species": "api-endpoint",
+      "title": "DELETE /souls/:id"
+    },
+    {
+      "id": "01KN44D7Q8XSP6D39HJ8AAAM5Q",
+      "ts": "2026-04-01T09:01:21.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-get-collections",
+      "species": "api-endpoint",
+      "title": "GET /collections"
+    },
+    {
+      "id": "01KN44D8PG81570GHBJPFC8JGM",
+      "ts": "2026-04-01T09:01:22.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-create-collection",
+      "species": "api-endpoint",
+      "title": "POST /collections"
+    },
+    {
+      "id": "01KN44D9NR668HN4HJWDYW2F9N",
+      "ts": "2026-04-01T09:01:23.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-get-bounce",
+      "species": "api-endpoint",
+      "title": "GET /bounce"
+    },
+    {
+      "id": "01KN44DAN0W62BHKW1CRTYY8VG",
+      "ts": "2026-04-01T09:01:24.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-get-achievements",
+      "species": "api-endpoint",
+      "title": "GET /achievements"
+    },
+    {
+      "id": "01KN44DBM8B3WD3XJS1D4AY8PM",
+      "ts": "2026-04-01T09:01:25.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-get-weekly-cairn",
+      "species": "api-endpoint",
+      "title": "GET /cairns/weekly"
+    },
+    {
+      "id": "01KN44DCKG3AZFZZ6F1H974EDT",
+      "ts": "2026-04-01T09:01:26.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-get-monthly-cairn",
+      "species": "api-endpoint",
+      "title": "GET /cairns/monthly"
+    },
+    {
+      "id": "01KN44DDJRZCB4XB4MSMQEZYTS",
+      "ts": "2026-04-01T09:01:27.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-register",
+      "species": "api-endpoint",
+      "title": "POST /auth/register"
+    },
+    {
+      "id": "01KN44DEJ0BV8KVKMC9R0TKMMF",
+      "ts": "2026-04-01T09:01:28.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-login",
+      "species": "api-endpoint",
+      "title": "POST /auth/login"
+    },
+    {
+      "id": "01KN44DFH8Q9VSMZV7C07N83MZ",
+      "ts": "2026-04-01T09:01:29.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-logout",
+      "species": "api-endpoint",
+      "title": "POST /auth/logout"
+    },
+    {
+      "id": "01KN44DGGG7426E69Q100VFJB4",
+      "ts": "2026-04-01T09:01:30.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-get-session",
+      "species": "api-endpoint",
+      "title": "GET /auth/session"
+    },
+    {
+      "id": "01KN44DHFR8VD7Q18Q56J8SCPS",
+      "ts": "2026-04-01T09:01:31.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-get-profile",
+      "species": "api-endpoint",
+      "title": "GET /profile"
+    },
+    {
+      "id": "01KN44DJF0NKXX0J1YGKKK1YH4",
+      "ts": "2026-04-01T09:01:32.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-update-profile",
+      "species": "api-endpoint",
+      "title": "PATCH /profile"
+    },
+    {
+      "id": "01KN44DKE83WHTKK69C5QEP9QD",
+      "ts": "2026-04-01T09:01:33.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-get-collection-rise",
+      "species": "api-endpoint",
+      "title": "GET /collections/:id/rise"
+    },
+    {
+      "id": "01KN44DMDG634QBK9P4NKBQYB4",
+      "ts": "2026-04-01T09:01:34.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-mechanic-sheet",
+      "species": "view",
+      "title": "Mechanic Sheet"
+    },
+    {
+      "id": "01KN44DNCRZ0K3QR27GJ5FBN8E",
+      "ts": "2026-04-01T09:01:35.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-pebble-visual",
+      "species": "view",
+      "title": "Pebble Visual"
+    },
+    {
+      "id": "01KN44DPC0132MA558BR9ZG6EP",
+      "ts": "2026-04-01T09:01:36.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-pebble-engine",
+      "species": "data-model",
+      "title": "Pebble Engine"
+    },
+    {
+      "id": "01KN44DQB8F6F7C8EJXT3ANJBX",
+      "ts": "2026-04-01T09:01:37.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-docs-index",
+      "species": "view",
+      "title": "Docs Index"
+    },
+    {
+      "id": "01KN44DRAGE0S04R3TJ4C0RV8H",
+      "ts": "2026-04-01T09:01:38.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-docs-slug",
+      "species": "view",
+      "title": "Docs Page"
+    },
+    {
+      "id": "01KN44DS9RXSG6BGN1KERHQSR6",
+      "ts": "2026-04-01T09:01:39.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-docs-legal-notice",
+      "species": "view",
+      "title": "Legal Notice"
+    },
+    {
+      "id": "01KN44DT90B75W88CG33W2C9HW",
+      "ts": "2026-04-01T09:01:40.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-docs-terms",
+      "species": "view",
+      "title": "Terms of Service"
+    },
+    {
+      "id": "01KN44DV88S2NX85XDEBYFTQPQ",
+      "ts": "2026-04-01T09:01:41.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-docs-privacy",
+      "species": "view",
+      "title": "Privacy Policy"
+    },
+    {
+      "id": "01KN44DW7GWME9TVMMG0ZNH839",
+      "ts": "2026-04-01T09:01:42.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-legal-consent",
+      "species": "flow",
+      "title": "Legal Consent"
+    },
+    {
+      "id": "01KN44DX6R33HRSH8FAPZZ349Q",
+      "ts": "2026-04-01T09:01:43.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-lab",
+      "species": "view",
+      "title": "Lab"
+    },
+    {
+      "id": "01KN44DY60W4MZMPPN0498BWBR",
+      "ts": "2026-04-01T09:01:44.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-admin-analytics",
+      "species": "view",
+      "title": "Admin · Analytics"
+    },
+    {
+      "id": "01KN44DZ58MTF434K1MSXM1VZC",
+      "ts": "2026-04-01T09:01:45.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-admin-glyph-moderation",
+      "species": "view",
+      "title": "Admin · Glyph moderation"
+    },
+    {
+      "id": "01KN44E04GF795227Z1NDFHFQ0",
+      "ts": "2026-04-01T09:01:46.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-admin-glyph-upload",
+      "species": "view",
+      "title": "Admin · Upload glyph"
+    },
+    {
+      "id": "01KN44E13RQKVGHK7AAVRV648G",
+      "ts": "2026-04-01T09:01:47.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-admin-domains",
+      "species": "view",
+      "title": "Admin · Domains"
+    },
+    {
+      "id": "01KN44E230J514SQN1BYJVV6XY",
+      "ts": "2026-04-01T09:01:48.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-admin-list-domains",
+      "species": "api-endpoint",
+      "title": "RPC admin_list_domains"
+    },
+    {
+      "id": "01KN44E328HV88APBB5328YDJH",
+      "ts": "2026-04-01T09:01:49.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-admin-update-domain",
+      "species": "api-endpoint",
+      "title": "RPC admin_update_domain"
+    },
+    {
+      "id": "01KN44E41GCGBW6HQ2W8A4GVS7",
+      "ts": "2026-04-01T09:01:50.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-admin-set-domain-glyph",
+      "species": "api-endpoint",
+      "title": "RPC admin_set_domain_glyph"
+    },
+    {
+      "id": "01KN44E50R9T07R70133JZ9NBW",
+      "ts": "2026-04-01T09:01:51.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-v-domains-with-glyph",
+      "species": "data-model",
+      "title": "v_domains_with_glyph"
+    },
+    {
+      "id": "01KN44E6002ARF46X3NH5XDCA8",
+      "ts": "2026-04-01T09:01:52.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-admin-list-glyph-submissions",
+      "species": "api-endpoint",
+      "title": "RPC admin_list_glyph_submissions"
+    },
+    {
+      "id": "01KN44E6Z84D3GT1GHAH2A6NH6",
+      "ts": "2026-04-01T09:01:53.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-approve-glyph",
+      "species": "api-endpoint",
+      "title": "RPC approve_glyph"
+    },
+    {
+      "id": "01KN44E7YGCS3NGRHSTSE3TG9V",
+      "ts": "2026-04-01T09:01:54.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-reject-glyph",
+      "species": "api-endpoint",
+      "title": "RPC reject_glyph"
+    },
+    {
+      "id": "01KN44E8XRDB4QTEC5RYC7S91K",
+      "ts": "2026-04-01T09:01:55.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-set-glyph-price",
+      "species": "api-endpoint",
+      "title": "RPC set_glyph_price"
+    },
+    {
+      "id": "01KN44E9X0TF949HT22BDABJF1",
+      "ts": "2026-04-01T09:01:56.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-publish-admin-glyph",
+      "species": "api-endpoint",
+      "title": "RPC publish_admin_glyph"
+    },
+    {
+      "id": "01KN44EAW8YKXE25DE3CXF4QMH",
+      "ts": "2026-04-01T09:01:57.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-glyphs",
+      "species": "data-model",
+      "title": "glyphs"
+    },
+    {
+      "id": "01KN44EBVGY57V4F8FDWE53SY4",
+      "ts": "2026-04-01T09:01:58.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-glyph-submissions",
+      "species": "data-model",
+      "title": "glyph_submissions"
+    },
+    {
+      "id": "01KN44ECTR00GS6FS0738S16Z4",
+      "ts": "2026-04-01T09:01:59.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-v-analytics-kpi-daily",
+      "species": "data-model",
+      "title": "v_analytics_kpi_daily"
+    },
+    {
+      "id": "01KN44EDT0FE09178RRVZ3TVMP",
+      "ts": "2026-04-01T09:02:00.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-v-analytics-active-users-daily",
+      "species": "data-model",
+      "title": "v_analytics_active_users_daily"
+    },
+    {
+      "id": "01KN44EES8PKXJAQTPWMXX74KD",
+      "ts": "2026-04-01T09:02:01.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-get-kpi-daily",
+      "species": "api-endpoint",
+      "title": "get_kpi_daily"
+    },
+    {
+      "id": "01KN44EFRGCRED5FGXSFY67A0H",
+      "ts": "2026-04-01T09:02:02.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-get-active-users-series",
+      "species": "api-endpoint",
+      "title": "get_active_users_series"
+    },
+    {
+      "id": "01KN44EGQR4E6W5KRF1GSDQGW4",
+      "ts": "2026-04-01T09:02:03.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-v-analytics-retention-cohorts-weekly",
+      "species": "data-model",
+      "title": "v_analytics_retention_cohorts_weekly"
+    },
+    {
+      "id": "01KN44EHQ0JHA1KH5M82F0E2KG",
+      "ts": "2026-04-01T09:02:04.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-get-retention-cohorts",
+      "species": "api-endpoint",
+      "title": "get_retention_cohorts"
+    },
+    {
+      "id": "01KN44EJP8K7KJYVA4QYKT0MPN",
+      "ts": "2026-04-01T09:02:05.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-v-analytics-emotion-share-weekly",
+      "species": "data-model",
+      "title": "v_analytics_emotion_share_weekly"
+    },
+    {
+      "id": "01KN44EKNGBC7J3X8FZJW2E079",
+      "ts": "2026-04-01T09:02:06.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-v-analytics-domain-share-weekly",
+      "species": "data-model",
+      "title": "v_analytics_domain_share_weekly"
+    },
+    {
+      "id": "01KN44EMMRZ6EF9ZQTA758M7M1",
+      "ts": "2026-04-01T09:02:07.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-get-emotion-share",
+      "species": "api-endpoint",
+      "title": "get_emotion_share"
+    },
+    {
+      "id": "01KN44ENM0A88HTR1KD01JY1GB",
+      "ts": "2026-04-01T09:02:08.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-get-domain-share",
+      "species": "api-endpoint",
+      "title": "get_domain_share"
+    },
+    {
+      "id": "01KN44EPK8PTQ0AQW5K6YHBFBC",
+      "ts": "2026-04-01T09:02:09.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-bounces",
+      "species": "data-model",
+      "title": "bounces"
+    },
+    {
+      "id": "01KN44EQJGGCP8NFYF1Z13DV1C",
+      "ts": "2026-04-01T09:02:10.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-v-analytics-bounce-distribution-today",
+      "species": "data-model",
+      "title": "v_analytics_bounce_distribution_today"
+    },
+    {
+      "id": "01KN44ERHRVJB9EJMYQFDB0DD2",
+      "ts": "2026-04-01T09:02:11.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-get-bounce-distribution-today",
+      "species": "api-endpoint",
+      "title": "get_bounce_distribution_today"
+    },
+    {
+      "id": "01KN44ESH044HQSZVEZK38NKQE",
+      "ts": "2026-04-01T09:02:12.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-v-analytics-quality-signals-today",
+      "species": "data-model",
+      "title": "v_analytics_quality_signals_today"
+    },
+    {
+      "id": "01KN44ETG8DA85SP7DTRPZJQJ8",
+      "ts": "2026-04-01T09:02:13.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-get-quality-signals-today",
+      "species": "api-endpoint",
+      "title": "get_quality_signals_today"
+    },
+    {
+      "id": "01KN44EVFG15JZG4FMRBBXHESN",
+      "ts": "2026-04-01T09:02:14.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-emotion-category",
+      "species": "data-model",
+      "title": "Emotion Category & Palette"
+    },
+    {
+      "id": "01KN44EWERNTTSGZ8981MYFCX1",
+      "ts": "2026-04-01T09:02:15.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-get-emotion-palettes",
+      "species": "api-endpoint",
+      "title": "select v_emotions_with_palette"
+    },
+    {
+      "id": "01KN44EXE0NZ9YBRCSD9Y1KD8M",
+      "ts": "2026-04-01T09:02:16.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-wallet",
+      "species": "view",
+      "title": "Wallet"
+    },
+    {
+      "id": "01KN44EYD8GV4VBQP865KAN0M4",
+      "ts": "2026-04-01T09:02:17.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-karma-events",
+      "species": "data-model",
+      "title": "karma_events"
+    },
+    {
+      "id": "01KN44EZCGBX77H2JZ7YH7039Z",
+      "ts": "2026-04-01T09:02:18.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-wallet-balances",
+      "species": "data-model",
+      "title": "wallet_balances"
+    },
+    {
+      "id": "01KN44F0BRJ9Y7VTND2NDAXC3N",
+      "ts": "2026-04-01T09:02:19.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-spend-karma",
+      "species": "api-endpoint",
+      "title": "spend_karma"
+    },
+    {
+      "id": "01KN44F1B0MSXWVMH3W41EGZBA",
+      "ts": "2026-04-01T09:02:20.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-refund-karma",
+      "species": "api-endpoint",
+      "title": "refund_karma"
+    },
+    {
+      "id": "01KN44F2A8PVS7KHRRDQ38NENC",
+      "ts": "2026-04-01T09:02:21.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-get-wallet-summary",
+      "species": "api-endpoint",
+      "title": "select v_wallet_summary"
+    },
+    {
+      "id": "01KN44F39GZREKQ6022GD0Q6JG",
+      "ts": "2026-04-01T09:02:22.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-karma-flash",
+      "species": "view",
+      "title": "Karma Earned Flash"
+    },
+    {
+      "id": "01KN44F48RWBWFBTSHCWHQJ43C",
+      "ts": "2026-04-01T09:02:23.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-glyph-entitlements",
+      "species": "data-model",
+      "title": "glyph_entitlements"
+    },
+    {
+      "id": "01KN44F580T4X4CT4979J6SQ00",
+      "ts": "2026-04-01T09:02:24.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-buy-glyph",
+      "species": "api-endpoint",
+      "title": "buy_glyph"
+    },
+    {
+      "id": "01KN44F678K2GGBEJENJ1A4B15",
+      "ts": "2026-04-01T09:02:25.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-glyph-swap-drawer",
+      "species": "view",
+      "title": "Glyph Swap Drawer"
+    },
+    {
+      "id": "01KN44F76GQRV494WZSP75C962",
+      "ts": "2026-04-01T09:02:26.000Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-swap-glyph",
+      "species": "flow",
+      "title": "Swap Glyph"
+    },
+    {
+      "id": "01KQ2F1AR05BGMY6H78JD9C2TR",
+      "ts": "2026-04-25T14:00:00.000Z",
+      "actor": "claude-code",
+      "type": "node.status_changed",
+      "node_id": "V-pebble-detail",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "01KQ4G8QM0N1D3X84J7P370N13",
+      "ts": "2026-04-26T09:00:00.000Z",
+      "actor": "claude-code",
+      "type": "node.status_changed",
+      "node_id": "V-pebble-detail",
+      "platform": "ios",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "01KQ9RG180F11T10ZD7RBFJJ32",
+      "ts": "2026-04-28T10:00:00.000Z",
+      "actor": "claude-code",
+      "type": "node.status_changed",
+      "node_id": "V-quick-pebble-editor",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "01KQ9RS6709DE9WHAZBTDHXE14",
+      "ts": "2026-04-28T10:05:00.000Z",
+      "actor": "claude-code",
+      "type": "node.status_changed",
+      "node_id": "F-record-pebble",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "01KQMT3YM0XJ6YR72XKVAX2KS3",
+      "ts": "2026-05-02T17:00:00.000Z",
+      "actor": "alexis",
+      "type": "release.tagged",
+      "version": "0.2.0",
+      "notes": "First public loop: record a pebble end to end."
+    },
+    {
+      "id": "01KS2GNPW0YMXHVXVAF6N7ZYTX",
+      "ts": "2026-05-20T11:00:00.000Z",
+      "actor": "claude-code",
+      "type": "node.status_changed",
+      "node_id": "V-souls-list",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "01KS2GQHF0Y8B4GWJHHRXX993X",
+      "ts": "2026-05-20T11:01:00.000Z",
+      "actor": "claude-code",
+      "type": "node.status_changed",
+      "node_id": "V-soul-detail",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "01KS2GSC20REQMRWQ8XVDG8CNB",
+      "ts": "2026-05-20T11:02:00.000Z",
+      "actor": "claude-code",
+      "type": "node.status_changed",
+      "node_id": "V-soul-create",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "01KS2GV6N0RG7NJRBHSVQ84KM4",
+      "ts": "2026-05-20T11:03:00.000Z",
+      "actor": "claude-code",
+      "type": "node.status_changed",
+      "node_id": "V-soul-edit",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "01KS2H80T02G77NSNSNSYXSHAA",
+      "ts": "2026-05-20T11:10:00.000Z",
+      "actor": "claude-code",
+      "type": "node.status_changed",
+      "node_id": "F-manage-souls",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "01KSFZHHT02YW2BRC7KQP53K0W",
+      "ts": "2026-05-25T16:30:00.000Z",
+      "actor": "alexis",
+      "type": "release.tagged",
+      "version": "0.3.0",
+      "notes": "Souls: relate pebbles to the people they belong with."
+    },
+    {
+      "id": "01KTBHWDE08J8XRDVVC2VZBGC6",
+      "ts": "2026-06-05T09:30:00.000Z",
+      "actor": "claude-code",
+      "type": "node.status_changed",
+      "node_id": "V-pebble-record",
+      "from": "development",
+      "to": "archived"
+    },
+    {
+      "id": "01KTBHY810BSR9ZC91N98KMXY1",
+      "ts": "2026-06-05T09:31:00.000Z",
+      "actor": "claude-code",
+      "type": "node.status_changed",
+      "node_id": "V-pebble-intensity",
+      "from": "development",
+      "to": "archived"
+    },
+    {
+      "id": "01KTBJ02M0DXJETS9WEDPK9P88",
+      "ts": "2026-06-05T09:32:00.000Z",
+      "actor": "claude-code",
+      "type": "node.status_changed",
+      "node_id": "V-emotion-pearl",
+      "from": "development",
+      "to": "archived"
+    },
+    {
+      "id": "01KTRB9KQ0B80Z2S9KTADQBNBC",
+      "ts": "2026-06-10T08:45:00.000Z",
+      "actor": "claude-code",
+      "type": "node.status_changed",
+      "node_id": "V-landing",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "01KVJEDVG06TDYETVMJ5RQ79DS",
+      "ts": "2026-06-20T12:00:00.000Z",
+      "actor": "alexis",
+      "type": "idea.proposed",
+      "title": "Pebble reactions",
+      "description": "Let souls react to a shared pebble with a single glyph."
+    },
+    {
+      "id": "01KW7QBD40H5H3SHQKPX875RF5",
+      "ts": "2026-06-28T18:20:00.000Z",
+      "actor": "alexis",
+      "type": "request.filed",
+      "title": "Offline recording",
+      "description": "Android beta testers ask to record pebbles without a connection.",
+      "source": "beta-feedback"
+    },
+    {
+      "id": "01KWCGPMC0N5EZ1YMV9AHHY20V",
+      "ts": "2026-06-30T15:00:00.000Z",
+      "actor": "claude-code",
+      "type": "ref.added",
+      "node_id": "V-landing",
+      "ref_id": "gh-281",
+      "ref_type": "github-pr",
+      "url": "https://github.com/pebbles-app/pebbles-ios/pull/281"
+    },
+    {
+      "id": "01KWEHY180556JFNS6B459VZV7",
+      "ts": "2026-07-01T10:00:00.000Z",
+      "actor": "alexis",
+      "type": "release.tagged",
+      "version": "0.4.0",
+      "platform": "ios",
+      "notes": "iOS beta: WelcomeView carousel and auth handoff."
+    },
+    {
+      "id": "01KWH1F6J08R3PHHH0P0VPKH2V",
+      "ts": "2026-07-02T09:10:00.000Z",
+      "actor": "alexis",
+      "type": "idea.proposed",
+      "title": "Export a month as a zine",
+      "description": "Print-ready PDF of a monthly wrap, pebbles as pages."
+    },
+    {
+      "id": "01KX3MJ5J05GSF6FCH4GWAK97Y",
+      "ts": "2026-07-09T14:30:00.000Z",
+      "actor": "arkaik-sync",
+      "type": "ref.status_changed",
+      "node_id": "V-landing",
+      "ref_id": "gh-281",
+      "from": "open",
+      "to": "merged",
+      "synced_at": "2026-07-09T14:30:00.000Z"
     }
   ]
 }

--- a/tests/data/seed-import.test.js
+++ b/tests/data/seed-import.test.js
@@ -38,15 +38,25 @@ for (const rel of BUNDLES) {
   assert(parseBundle(bundle).success, `${rel}: parseBundle accepts it as-is`);
   assert(eq(migrateBundle(bundle), bundle), `${rel}: migrateBundle is a no-op (round-trip unchanged)`);
 
-  // With an explicit schema_version: 1 (Conformance Level 1).
-  const versioned = { schema_version: 1, ...bundle };
-  const parsed = parseBundle(versioned);
-  assert(parsed.success, `${rel}: parseBundle accepts it with explicit schema_version: 1`);
-  assert(
-    parsed.success && parsed.data.schema_version === 1,
-    `${rel}: parseBundle preserves schema_version: 1 (not stripped)`,
-  );
-  assert(eq(migrateBundle(versioned), versioned), `${rel}: migrateBundle is a no-op on a declared-v1 bundle`);
+  // With an explicit schema_version: 1 (Conformance Level 1). Only meaningful
+  // for bundles that don't already declare a version of their own — the
+  // pebbles seed is a genuine Level 2 bundle (schema_version: 2 + journal).
+  if (bundle.schema_version === undefined) {
+    const versioned = { schema_version: 1, ...bundle };
+    const parsed = parseBundle(versioned);
+    assert(parsed.success, `${rel}: parseBundle accepts it with explicit schema_version: 1`);
+    assert(
+      parsed.success && parsed.data.schema_version === 1,
+      `${rel}: parseBundle preserves schema_version: 1 (not stripped)`,
+    );
+    assert(eq(migrateBundle(versioned), versioned), `${rel}: migrateBundle is a no-op on a declared-v1 bundle`);
+  } else {
+    const parsed = parseBundle(bundle);
+    assert(
+      parsed.success && parsed.data.schema_version === bundle.schema_version,
+      `${rel}: parseBundle preserves declared schema_version: ${bundle.schema_version} (not stripped)`,
+    );
+  }
 }
 
 fs.rmSync(MIGRATE_BUILD_DIR, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

This PR introduces the maps projection system (one graph, many views) and restructures the app's information architecture to support species-based filtering through the sidebar. It also adds comprehensive journal entries for the Pebbles project and updates documentation to reflect shipped toolchain components.

## Key Changes

### Maps & Projections System
- Added `docs/spec/maps.md` — normative specification for map definitions with journey/system kinds, filtering, and traversal bounds
- Added `docs/spec/mcp.md` — specification for the MCP server (agent plane) for conversational agent access to the graph
- Updated `docs/vision.md` to document the "one graph, many maps" core product principle and reflect shipped status of format/toolchain layers

### Canvas & Compose Closure Refactor
- **`app/project/[id]/canvas/page.tsx`**: Rewrote compose closure logic to properly handle flow vs. view traversal:
  - Views chain the walk onward; flows are surfaced as collapsed cards
  - Implemented BFS discovery order for proper rendering hierarchy
  - Added `useRef` for instance tracking
- **`components/graph/Canvas.tsx`**: Added `useEffect` import for lifecycle management

### Library & Sidebar Restructuring
- **`components/layout/ProjectSidebar.tsx`**: 
  - Replaced inline species filter buttons with sidebar-driven species selection via `?species=` deep links
  - Changed "Navigate" section label to "Maps"
  - Removed `SidebarMenuSub` components; species selection now owned by sidebar navigation
  - Added comment documenting that sidebar is the single species selector (information architecture principle)

- **`components/library/LibraryFilterBar.tsx`**:
  - Removed species filter buttons (now sidebar responsibility)
  - Simplified to search + display-mode toggle only
  - Removed `onSpeciesChange` callback and `species` prop
  - Added clarifying comment about ownership model

- **`app/project/[id]/library/page.tsx`**:
  - Updated to read species from URL search params (`?species=`)
  - Removed unused router/pathname imports
  - Integrated sidebar species selection with library filtering

### Data & Documentation Updates
- **`seed/pebbles.json`**: 
  - Added `schema_version: 2` at root
  - Added project `version: "0.4.0"`
  - Added `maps` array with "recording-loop" journey map definition
  - Added comprehensive 100+ entry journal with node creation events (ULID timestamps)
  - Updated `updated_at` timestamp

- **`docs/data-layer.md`**: Updated to reference canonical definitions in `@arkaik/schema` package
- **`docs/architecture.md`**: Updated canvas description to reference "Journey map" and added changelog route
- **`docs/graph-model.md`**: Renamed "Canvas Visibility" section to "Canvas Visibility (Journey Map)"
- **`docs/spec/bundle-format.md`**, **`docs/spec/journal.md`**, **`docs/spec/toolchain.md`**, **`docs/spec/services.md`**: Updated status markers to reflect implementation progress
- **`README.md`**: Added journal/changelog and Synk backup features to feature list
- **`tests/data/seed-import.test.js`**: Updated migration tests for schema_version handling

## Implementation Details

- **Information Architecture**: The sidebar is now the single source of truth for species filtering, eliminating the filter bar's species buttons. This follows the "one canvas, many maps" principle where different projections (maps) are accessed through navigation rather than inline filtering.

- **Compose Closure**: The canvas now properly distinguishes between views (which continue traversal) and flows (which are rendered as collapsed cards). This prevents double-rendering of flow interiors when expanding playlists.

- **Maps Definition**: The new `MapDefinition` interface supports both "journey" (drill-down navigation) and "system" (architecture diagram) kinds, with configurable filtering, depth bounds, and layout options.

- **Journal Format**: The Pebbles project now includes a complete audit trail of node creation events with ULID identifiers and ISO timestamps, demonstrating the journal as a first-

https://claude.ai/code/session_016iA5XNCVoG4uJoPcKvf3Vx