### PR TITLE
ci: wire arkaik into the Ariko Lab Note pipeline

### DIFF
--- a/.github/workflows/lab-note.yml
+++ b/.github/workflows/lab-note.yml
@@ -1,0 +1,13 @@
+name: lab-note
+on:
+  pull_request:
+    types: [closed]
+permissions:
+  contents: read
+  pull-requests: read
+jobs:
+  lab-note:
+    if: github.event.pull_request.merged == true
+    uses: alexisbohns/ariko/.github/workflows/lab-note.yml@main
+    secrets:
+      inbox_token: ${{ secrets.ARIKO_INBOX_TOKEN }}


### PR DESCRIPTION
## Summary

Wires arkaik into Ariko's Lab Note pipeline (closes #268). Merging a PR
whose body carries a `## Lab Note` section now posts a bilingual changelog
capture to the Ariko inbox automatically — the only human action is merging.

- Adds `.github/workflows/lab-note.yml`, a ~13-line stub that reuses
  `alexisbohns/ariko/.github/workflows/lab-note.yml@main`.
- `ARIKO_INBOX_TOKEN` is already set on this repo; no credential handling.
- Chore PRs without a Lab Note section are silently skipped.

This PR is the bootstrap: the workflow lives on the merge ref, so merging it
fires the pipeline and files the note below — the end-to-end proof.

## Lab Note

```yaml
en:
  title: arkaik's changelog now flows into Ariko
  summary: "Merged arkaik PRs that carry a Lab Note file their own bilingual changelog into the Ariko vault automatically — no manual step beyond merging."
fr:
  title: Le journal d'arkaik alimente désormais Ariko
  summary: "Les PR fusionnées portant une Lab Note déposent d'elles-mêmes leur entrée de changelog bilingue dans le coffre Ariko — sans autre geste que la fusion."
suggested:
  molecule: arkaik
  atom: lab-note-pipeline
  type: feature
  tags: [changelog, ci, ariko]
```

Closes #268.
