### PR TITLE
ci: adopt the Lab Note requirement (CLAUDE.md + PR template + advisory reminder)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+<!-- Summary: what changed and why. Keep it short. -->
+
+## Summary
+
+-
+
+<!--
+  LAB NOTE — required for any change a user, visitor, or listener would notice.
+  Merging this PR posts the note below to the Ariko inbox automatically.
+  Fill in the fields (see CLAUDE.md § Lab Note requirement, or the lab-note skill).
+  Chore / refactor / infra / docs-only change? Delete this whole section — that's
+  the gate. (If the reminder still comments, add the `no-lab-note` label.)
+-->
+## Lab Note
+
+```yaml
+en:
+  title: Short, benefit-first title             # required
+  summary: One or two sentences, user-facing.   # required
+fr:                                             # recommended — adaptation, informal "Tu"
+  title: Titre court, orienté bénéfice
+  summary: Une ou deux phrases, adaptées, pas traduites littéralement.
+suggested:                                      # optional — prefills triage
+  molecule: arkaik
+  type: feature                                 # feature | improvement | fix | announcement
+  tags: [changelog]
+```

--- a/.github/workflows/lab-note-reminder.yml
+++ b/.github/workflows/lab-note-reminder.yml
@@ -1,0 +1,10 @@
+name: lab-note-reminder
+on:
+  pull_request:
+    types: [opened, edited, synchronize, labeled, unlabeled, ready_for_review]
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  lab-note-reminder:
+    uses: alexisbohns/ariko/.github/workflows/lab-note-reminder.yml@main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+# CLAUDE.md — working in the Arkaik repo
+
+Arkaik is a product graph browser built with React Flow on Next.js — a
+local-first, navigable map of a product's anatomy (flows, views, data models,
+API endpoints, acceptances) as an atomic 5-species graph. Orientation lives in
+[`README.md`](README.md).
+
+## Lab Note requirement — read before opening a PR
+
+Arkaik is wired to the Ariko Lab Note pipeline. **When you open a PR that ships
+something a user would notice, you MUST include a Lab Note in the PR body.**
+Merging the PR posts it to the Ariko inbox automatically — no copy-paste.
+
+This section is the always-loaded summary and is **self-sufficient**: you can
+author a valid note from it alone, with no plugin installed. The `lab-note`
+skill (installable via `/plugin install lab-note@ariko`) is the source of truth
+for full tone guidance and the per-repo molecule table.
+
+**The gate.** User-facing change → write a note. Chore, refactor, infra, or
+docs-only change → **no note** (leave the section out; if the advisory reminder
+comments on your PR, add the **`no-lab-note`** label to silence it).
+
+**The contract.** One section whose heading **starts with** `## Lab Note`,
+containing exactly one ` ```yaml ` fence. `en.title` and `en.summary` are
+**required**; `fr.*` is recommended (a real adaptation, not a literal
+translation, using the informal "Tu"); `suggested` is optional. Unknown
+top-level keys are ignored. Skeleton:
+
+```yaml
+en:
+  title: Short, benefit-first title             # required
+  summary: One or two sentences, user-facing.   # required
+fr:                                             # recommended — adaptation, informal "Tu"
+  title: Titre court, orienté bénéfice
+  summary: Une ou deux phrases, adaptées, pas traduites littéralement.
+suggested:                                      # optional — prefills triage in the Ariko admin
+  molecule: arkaik       # THIS repo's molecule slug
+  type: feature          # feature | improvement | fix | announcement
+  tags: [changelog]
+  # atom: <slug>         # ONLY when you know the slug exists — never guess
+```
+
+**Tone.** Lead with the benefit, not the mechanism; keep it short; warm and a
+little playful, never corporate; no engineering jargon, ticket numbers, or
+internal names.
+
+**This repo's molecule slug is `arkaik`.** A malformed note fails the
+post-on-merge job loudly (e.g. `en.title is required`); the advisory reminder
+surfaces the same problems at PR-open time. Fix by editing the PR body —
+posting is idempotent.
+
+Full pipeline docs: [ariko README — "Making it a requirement"](https://github.com/alexisbohns/ariko#lab-note-pipeline-c1--github-connector).


### PR DESCRIPTION
## Summary

- Add `CLAUDE.md` with the Lab Note requirement block (molecule: `arkaik`), self-sufficient so a valid note can be authored without the `lab-note` skill installed
- Add `.github/pull_request_template.md` seeding the `## Lab Note` section
- Add `.github/workflows/lab-note-reminder.yml`, calling ariko's reusable advisory reminder (comments on PRs missing a valid note; opt out with the `no-lab-note` label — never blocks)

Brings arkaik onto the same always-on layers ariko's Lab Note pipeline already ships (alexisbohns/ariko#20), so authoring no longer depends on a discretionary skill being installed in the session that opens the PR.

Closes #274.

## Lab Note

```yaml
en:
  title: Every merged PR now gets logged automatically
  summary: Arkaik's changes now flow through the same behind-the-scenes pipeline as Ariko, so shipped improvements get captured in the changelog without an extra manual step.
fr:
  title: Chaque PR mergée est désormais journalisée automatiquement
  summary: Les évolutions d'Arkaik passent maintenant par le même pipeline qu'Ariko, pour que les améliorations livrées soient capturées dans le changelog sans étape manuelle en plus.
suggested:
  molecule: arkaik
  type: improvement
  tags: [changelog, meta]
```

## Sanity check

- [ ] Open a throwaway PR with no note → `lab-note-reminder` posts one comment
- [ ] Add a valid note (or the `no-lab-note` label) → the comment is removed on the next event


---
_Generated by [Claude Code](https://claude.ai/code/session_01W2Sxow69b9dAt3KPBeLW1g)_