### PR TITLE
Sidebar/library UI polish: docs links, auth in project switcher, list-view default, scrollable sheet body

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -33,7 +33,7 @@ export default function Home() {
 
           <Link
             href="/docs"
-            className="mt-4 inline-block text-sm text-muted-foreground underline underline-offset-4 hover:text-foreground"
+            className="mt-4 block text-sm text-muted-foreground underline underline-offset-4 hover:text-foreground"
           >
             Read the doc
           </Link>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -30,6 +30,13 @@ export default function Home() {
           <Button asChild size="lg" className="mt-10 px-8 text-base">
             <Link href="/projects">Start building</Link>
           </Button>
+
+          <Link
+            href="/docs"
+            className="mt-4 inline-block text-sm text-muted-foreground underline underline-offset-4 hover:text-foreground"
+          >
+            Read the doc
+          </Link>
         </div>
       </main>
 

--- a/app/project/[id]/library/page.tsx
+++ b/app/project/[id]/library/page.tsx
@@ -147,7 +147,7 @@ export default function ProjectLibraryPage() {
   const [panelOpen, setPanelOpen] = useState(false);
   const [newNodeOpen, setNewNodeOpen] = useState(false);
   const [search, setSearch] = useState("");
-  const [displayMode, setDisplayMode] = useState<LibraryDisplayMode>("gallery");
+  const [displayMode, setDisplayMode] = useState<LibraryDisplayMode>("directory");
   const [sort, setSort] = useState<NodeSortState>({
     key: "title",
     direction: "asc",

--- a/components/layout/ProjectSidebar.tsx
+++ b/components/layout/ProjectSidebar.tsx
@@ -6,6 +6,7 @@ import {
   BookOpenIcon,
   ClipboardCheckIcon,
   DatabaseIcon,
+  FileTextIcon,
   GitBranchIcon,
   HistoryIcon,
   LayoutDashboardIcon,
@@ -239,6 +240,14 @@ export function ProjectSidebar({
             <SidebarMenuButton disabled tooltip="Settings coming soon">
               <Settings2Icon />
               <span>Settings</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+          <SidebarMenuItem>
+            <SidebarMenuButton asChild tooltip="Documentation">
+              <a href="/docs" target="_blank" rel="noreferrer">
+                <FileTextIcon />
+                <span>Documentation</span>
+              </a>
             </SidebarMenuButton>
           </SidebarMenuItem>
         </SidebarMenu>

--- a/components/layout/ProjectSwitcher.tsx
+++ b/components/layout/ProjectSwitcher.tsx
@@ -2,7 +2,8 @@
 
 import { useMemo } from "react";
 import { useRouter } from "next/navigation";
-import { CheckIcon, ChevronsUpDownIcon, FolderOpenIcon } from "lucide-react";
+import { CheckIcon, ChevronsUpDownIcon, FolderOpenIcon, GithubIcon, LogOutIcon } from "lucide-react";
+import { signIn, signOut } from "next-auth/react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -18,6 +19,7 @@ import {
   SidebarMenuSkeleton,
   useSidebar,
 } from "@/components/ui/sidebar";
+import { useAuthStatus } from "@/lib/hooks/useAuthStatus";
 import { useProjects } from "@/lib/hooks/useProjects";
 
 interface ProjectSwitcherProps {
@@ -36,6 +38,7 @@ export function ProjectSwitcher({
   const router = useRouter();
   const { isMobile, setOpenMobile } = useSidebar();
   const { projects, loading } = useProjects();
+  const authStatus = useAuthStatus();
 
   const sortedProjects = useMemo(
     () => [...projects].sort((left, right) => left.project.title.localeCompare(right.project.title)),
@@ -116,6 +119,33 @@ export function ProjectSwitcher({
                   </DropdownMenuItem>
                 );
               })
+            )}
+            {authStatus.state === "signed-out" && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  className="cursor-pointer gap-2"
+                  onClick={() => void signIn("github")}
+                >
+                  <GithubIcon className="size-4" />
+                  <span>Sign in with GitHub</span>
+                </DropdownMenuItem>
+              </>
+            )}
+            {authStatus.state === "signed-in" && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuLabel className="text-xs text-muted-foreground">
+                  {authStatus.user.name ?? authStatus.user.email ?? "Account"}
+                </DropdownMenuLabel>
+                <DropdownMenuItem
+                  className="cursor-pointer gap-2"
+                  onClick={() => void signOut()}
+                >
+                  <LogOutIcon className="size-4" />
+                  <span>Sign out</span>
+                </DropdownMenuItem>
+              </>
             )}
           </DropdownMenuContent>
         </DropdownMenu>

--- a/components/panels/NodeDetailPanel.tsx
+++ b/components/panels/NodeDetailPanel.tsx
@@ -5,6 +5,7 @@ import {
   Sheet,
   SheetContent,
   SheetHeader,
+  SheetBody,
   SheetClose,
   SheetTitle,
 } from "@/components/ui/sheet";
@@ -457,7 +458,7 @@ export function NodeDetailPanel({
           </div>
         </SheetHeader>
         {node && (
-          <>
+          <SheetBody className="flex flex-col gap-4 pb-6">
             <NodeFields key={node.id} node={node} onUpdate={onUpdate} />
             <RefsSection key={`refs-${node.id}`} node={node} />
             {(node.species === "view" || node.species === "flow") && allNodes && allEdges && (
@@ -531,7 +532,7 @@ export function NodeDetailPanel({
                 allNodes={allNodes ?? []}
               />
             )}
-          </>
+          </SheetBody>
         )}
       </SheetContent>
     </Sheet>

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -86,6 +86,16 @@ function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
   );
 }
 
+function SheetBody({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-body"
+      className={cn("min-h-0 flex-1 overflow-y-auto", className)}
+      {...props}
+    />
+  );
+}
+
 function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
@@ -128,6 +138,7 @@ export {
   SheetClose,
   SheetContent,
   SheetHeader,
+  SheetBody,
   SheetFooter,
   SheetTitle,
   SheetDescription,


### PR DESCRIPTION
## Summary

- Add a "Documentation" link to the sidebar footer (`components/layout/ProjectSidebar.tsx`), opening `/docs` in a new tab.
- Add sign-in/sign-out to the project switcher dropdown (`components/layout/ProjectSwitcher.tsx`), reusing the existing (optional) NextAuth GitHub auth stack — gated the same way `AuthButton` is (hidden while loading or unconfigured).
- Add a "Read the doc" link below the home page's main CTA (`app/page.tsx`).
- Default library subpages to the list (table) view instead of grid (`app/project/[id]/library/page.tsx`).
- Add a `SheetBody` primitive (`overflow-y-auto`) to `components/ui/sheet.tsx` and use it in `NodeDetailPanel` so long node-detail content scrolls instead of being clipped, while the header stays fixed.

Closes #279

## Test plan

- [x] `npm run lint` — clean (only pre-existing, unrelated warnings)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — succeeds
- [x] Manually verified in a running dev instance with the seeded "Pebbles" example project:
  - Sidebar footer shows a "Documentation" link opening `/docs` in a new tab
  - Home page shows "Read the doc" under "Start building"
  - Library subpages open in table/list view by default (grid still toggle-able)
  - A flow node with lots of content (playlist, platform statuses, connections, history) now scrolls inside the detail sheet, with the header staying fixed and the tail (History) reachable — previously it was clipped
  - Project switcher dropdown renders the sign-in/sign-out gating correctly (renders nothing in this sandbox since GitHub OAuth env vars aren't configured, matching `AuthButton`'s existing graceful-absence behavior)

## Lab Note

```yaml
en:
  title: Faster paths to help, sign-in, and the info you need
  summary: Jump to the docs straight from the sidebar or the home page, sign in without leaving your project, and the library now opens in the tidy list view by default. Long node details scroll properly too — nothing gets cut off anymore.
fr:
  title: Des raccourcis vers l'aide, la connexion et l'essentiel
  summary: Accède à la doc directement depuis la sidebar ou la page d'accueil, connecte-toi sans quitter ton projet, et la bibliothèque s'ouvre maintenant en vue liste par défaut. Les détails d'un nœud défilent aussi correctement, plus rien n'est coupé.
suggested:
  molecule: arkaik
  type: improvement
  tags: [changelog]
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01ADbrk5hPzaku7vSZbrxr6E)_