### PR TITLE
Add animated ASCII ridged-mountains background to the home page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@ import { Gochi_Hand } from "next/font/google";
 import { Button } from "@/components/ui/button";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { ArkaikLogoBoil } from "@/components/branding/ArkaikLogoBoil";
+import { AsciiTerrainBackground } from "@/components/background/AsciiTerrainBackground";
 
 const gochiHand = Gochi_Hand({
   subsets: ["latin"],
@@ -13,6 +14,7 @@ export default function Home() {
 
   return (
     <div className="relative flex min-h-screen flex-col overflow-hidden bg-background font-sans">
+      <AsciiTerrainBackground />
       <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(127,127,127,0.12),transparent_62%)]" />
 
       <header className="relative flex items-center justify-end px-6 py-4">

--- a/components/background/AsciiTerrainBackground.tsx
+++ b/components/background/AsciiTerrainBackground.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+/**
+ * Home page ASCII "ridged mountains" background (issue #280) — a port of
+ * ComputerK's CodePen (https://codepen.io/ComputerK/pen/jENaeKp) from p5.js
+ * to a hand-rolled Canvas2D loop, matching how the rest of the app's
+ * continuous animation (`ArkaikLogoBoil`, the wobble system) avoids
+ * creative-coding/animation library dependencies.
+ *
+ * A grid of monospace ASCII characters is shaded by 4-octave ridged Perlin
+ * noise (see `lib/background/perlin.ts`), which folds/cubes the noise field
+ * into vein-like ridges that read as flowing terrain. The noise field pans
+ * a little every rendered frame for a slow, living drift. Color is the
+ * app's theme `--foreground` at a low, brightness-modulated alpha, so it
+ * reads as a subtle backdrop in both light and dark mode rather than the
+ * pen's stark white-on-black terminal look.
+ */
+
+import { useEffect, useRef } from "react";
+
+import { perlin2 } from "@/lib/background/perlin";
+import {
+  AMP_MULTIPLIER,
+  ASCII_CHARS,
+  BRIGHTNESS_THRESHOLD,
+  CHAR_SIZE,
+  EDGE_DISTANCE,
+  FRAME_RATE,
+  FREQ_MULTIPLIER,
+  MAX_OPACITY,
+  NOISE_PAN_SPEED,
+  NOISE_SCALE,
+  OCTAVE_NUM,
+} from "@/lib/background/constants";
+
+const FREQUENCIES = Array.from({ length: OCTAVE_NUM }, (_, i) => FREQ_MULTIPLIER ** i);
+const AMPLITUDES = Array.from({ length: OCTAVE_NUM }, (_, i) => AMP_MULTIPLIER ** i);
+const MAX_NOISE_VAL = AMPLITUDES.reduce((sum, amp) => sum + amp, 0);
+const FRAME_INTERVAL_MS = 1000 / FRAME_RATE;
+
+function clamp(value: number, lo: number, hi: number): number {
+  return Math.min(hi, Math.max(lo, value));
+}
+
+function mapRange(value: number, inMin: number, inMax: number, outMin: number, outMax: number): number {
+  return outMin + ((value - inMin) * (outMax - outMin)) / (inMax - inMin);
+}
+
+/** Ridged noise: folds/cubes a smooth field into vein-like ridges. */
+function getRidgedNoise(x: number, y: number, offsetX: number, offsetY: number): number {
+  let noiseVal = 0;
+  for (let i = 0; i < OCTAVE_NUM; i++) {
+    const frequency = FREQUENCIES[i];
+    const amplitude = AMPLITUDES[i];
+    const raw = perlin2(
+      x * frequency * NOISE_SCALE + offsetX,
+      y * frequency * NOISE_SCALE + offsetY,
+    );
+    const p01 = clamp((raw + 1) / 2, 0, 1);
+    let n = 1 - Math.abs(p01);
+    n = 1 - Math.abs(n * 2 - 1);
+    n = n * n * n;
+    noiseVal += n * amplitude;
+  }
+  return noiseVal / MAX_NOISE_VAL;
+}
+
+/** Parses this app's `H S% L%` custom-property triples into `[r, g, b]`. */
+function hslTripleToRgb(triple: string): [number, number, number] {
+  const [h, s, l] = triple
+    .trim()
+    .split(/\s+/)
+    .map((part) => parseFloat(part));
+  const sFrac = (s || 0) / 100;
+  const lFrac = (l || 0) / 100;
+
+  if (sFrac === 0) {
+    const gray = Math.round(lFrac * 255);
+    return [gray, gray, gray];
+  }
+
+  const q = lFrac < 0.5 ? lFrac * (1 + sFrac) : lFrac + sFrac - lFrac * sFrac;
+  const p = 2 * lFrac - q;
+  const hueToRgb = (t: number) => {
+    let tt = t;
+    if (tt < 0) tt += 1;
+    if (tt > 1) tt -= 1;
+    if (tt < 1 / 6) return p + (q - p) * 6 * tt;
+    if (tt < 1 / 2) return q;
+    if (tt < 2 / 3) return p + (q - p) * (2 / 3 - tt) * 6;
+    return p;
+  };
+  const hFrac = (h || 0) / 360;
+  return [
+    Math.round(hueToRgb(hFrac + 1 / 3) * 255),
+    Math.round(hueToRgb(hFrac) * 255),
+    Math.round(hueToRgb(hFrac - 1 / 3) * 255),
+  ];
+}
+
+export function AsciiTerrainBackground({ className }: { className?: string }) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const ctx = canvas?.getContext("2d");
+    if (!canvas || !ctx) return;
+
+    const fontFamily = `${getComputedStyle(document.documentElement).getPropertyValue("--font-geist-mono").trim() || "ui-monospace"}, monospace`;
+
+    let cols = 0;
+    let rows = 0;
+    let noiseCache = new Float32Array(0);
+    let fadeCache = new Float32Array(0);
+    let offsetX = 0;
+    let offsetY = 0;
+    let rgb: [number, number, number] = [0, 0, 0];
+    let rafId = 0;
+    let lastFrameTime = 0;
+    let resizePending = false;
+    let reduced = false;
+    let lastCssWidth = -1;
+    let lastCssHeight = -1;
+
+    const readColor = () => {
+      rgb = hslTripleToRgb(getComputedStyle(document.documentElement).getPropertyValue("--foreground"));
+    };
+
+    const setupContext = () => {
+      ctx.font = `${CHAR_SIZE}px ${fontFamily}`;
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+    };
+
+    const updateNoiseCache = () => {
+      for (let col = 0; col < cols; col++) {
+        for (let row = 0; row < rows; row++) {
+          noiseCache[col * rows + row] = getRidgedNoise(col, row, offsetX, offsetY);
+        }
+      }
+    };
+
+    const render = () => {
+      const cssWidth = canvas.clientWidth;
+      const cssHeight = canvas.clientHeight;
+      ctx.clearRect(0, 0, cssWidth, cssHeight);
+
+      const half = CHAR_SIZE / 2;
+      let currentAlpha = -1;
+      const [r, g, b] = rgb;
+
+      for (let col = 0; col < cols; col++) {
+        const x = col * CHAR_SIZE + half;
+        for (let row = 0; row < rows; row++) {
+          const index = col * rows + row;
+          const fadeFactor = fadeCache[index];
+          if (fadeFactor < BRIGHTNESS_THRESHOLD) continue;
+
+          let noiseVal = clamp(mapRange(noiseCache[index], 0, 1, -0.2, 1.2), 0, 1);
+          noiseVal = Math.pow(noiseVal, 1.5);
+          const alpha = Math.pow(noiseVal, 0.8) * MAX_OPACITY * fadeFactor;
+
+          if (Math.abs(alpha - currentAlpha) > 1 / 255) {
+            ctx.fillStyle = `rgba(${r}, ${g}, ${b}, ${alpha.toFixed(3)})`;
+            currentAlpha = alpha;
+          }
+
+          const charIndex = Math.floor(mapRange(noiseVal, 0, 1, 0, ASCII_CHARS.length - 0.01));
+          const y = row * CHAR_SIZE + half;
+          ctx.fillText(ASCII_CHARS[charIndex], x, y);
+        }
+      }
+    };
+
+    const frame = (time: number) => {
+      rafId = requestAnimationFrame(frame);
+      if (time - lastFrameTime < FRAME_INTERVAL_MS) return;
+      lastFrameTime = time;
+
+      updateNoiseCache();
+      render();
+      offsetX += NOISE_PAN_SPEED;
+      offsetY += NOISE_PAN_SPEED;
+    };
+
+    const start = () => {
+      cancelAnimationFrame(rafId);
+      if (reduced) {
+        updateNoiseCache();
+        render();
+      } else {
+        lastFrameTime = 0;
+        rafId = requestAnimationFrame(frame);
+      }
+    };
+
+    // Setting canvas.width/height always clears the bitmap, even to the same
+    // value — guard on an actual size change so the animation loop's own
+    // repaint (or, under reduced motion, an explicit re-render below) is the
+    // only thing that ever touches pixels once sized.
+    const resize = () => {
+      const dpr = window.devicePixelRatio || 1;
+      const cssWidth = Math.max(1, Math.round(canvas.clientWidth));
+      const cssHeight = Math.max(1, Math.round(canvas.clientHeight));
+      if (cssWidth === lastCssWidth && cssHeight === lastCssHeight) return;
+      lastCssWidth = cssWidth;
+      lastCssHeight = cssHeight;
+
+      canvas.width = Math.round(cssWidth * dpr);
+      canvas.height = Math.round(cssHeight * dpr);
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      setupContext();
+
+      cols = Math.floor(cssWidth / CHAR_SIZE);
+      rows = Math.floor(cssHeight / CHAR_SIZE);
+      noiseCache = new Float32Array(cols * rows);
+      fadeCache = new Float32Array(cols * rows);
+
+      const half = CHAR_SIZE / 2;
+      for (let col = 0; col < cols; col++) {
+        const x = col * CHAR_SIZE + half;
+        const fadeX = clamp(Math.min(x, cssWidth - x) / EDGE_DISTANCE, 0, 1);
+        for (let row = 0; row < rows; row++) {
+          const y = row * CHAR_SIZE + half;
+          const fadeY = clamp(Math.min(y, cssHeight - y) / EDGE_DISTANCE, 0, 1);
+          fadeCache[col * rows + row] = fadeX * fadeY;
+        }
+      }
+
+      // The animation loop repaints on its own next tick; under reduced
+      // motion nothing else will, so re-render the static frame now.
+      if (reduced) {
+        updateNoiseCache();
+        render();
+      }
+    };
+
+    const scheduleResize = () => {
+      if (resizePending) return;
+      resizePending = true;
+      requestAnimationFrame(() => {
+        resizePending = false;
+        resize();
+      });
+    };
+
+    readColor();
+    resize();
+
+    const resizeObserver = new ResizeObserver(scheduleResize);
+    resizeObserver.observe(canvas);
+
+    const themeObserver = new MutationObserver(readColor);
+    themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ["class"] });
+
+    const reducedMotionQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const applyReducedMotion = () => {
+      reduced = reducedMotionQuery.matches;
+      start();
+    };
+    applyReducedMotion();
+    reducedMotionQuery.addEventListener("change", applyReducedMotion);
+
+    return () => {
+      cancelAnimationFrame(rafId);
+      resizeObserver.disconnect();
+      themeObserver.disconnect();
+      reducedMotionQuery.removeEventListener("change", applyReducedMotion);
+    };
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-hidden="true"
+      className={className ?? "pointer-events-none absolute inset-0 h-full w-full"}
+    />
+  );
+}

--- a/components/background/AsciiTerrainBackground.tsx
+++ b/components/background/AsciiTerrainBackground.tsx
@@ -27,6 +27,8 @@ import {
   EDGE_DISTANCE,
   FRAME_RATE,
   FREQ_MULTIPLIER,
+  INTRO_DURATION_MS,
+  INTRO_START_FACTOR,
   MAX_OPACITY,
   NOISE_PAN_SPEED,
   NOISE_SCALE,
@@ -44,6 +46,19 @@ function clamp(value: number, lo: number, hi: number): number {
 
 function mapRange(value: number, inMin: number, inMax: number, outMin: number, outMax: number): number {
   return outMin + ((value - inMin) * (outMax - outMin)) / (inMax - inMin);
+}
+
+/** Slow start, slow finish, quicker through the middle — a natural-feeling reveal. */
+function smoothstep(t: number): number {
+  const c = clamp(t, 0, 1);
+  return c * c * (3 - 2 * c);
+}
+
+/** Opacity multiplier for the mount-time intro: soft → full contrast. */
+function introOpacityScale(elapsedMs: number): number {
+  if (elapsedMs >= INTRO_DURATION_MS) return 1;
+  const t = smoothstep(elapsedMs / INTRO_DURATION_MS);
+  return INTRO_START_FACTOR + (1 - INTRO_START_FACTOR) * t;
 }
 
 /** Ridged noise: folds/cubes a smooth field into vein-like ridges. */
@@ -140,7 +155,7 @@ export function AsciiTerrainBackground({ className }: { className?: string }) {
       }
     };
 
-    const render = () => {
+    const render = (opacityScale = 1) => {
       const cssWidth = canvas.clientWidth;
       const cssHeight = canvas.clientHeight;
       ctx.clearRect(0, 0, cssWidth, cssHeight);
@@ -158,7 +173,7 @@ export function AsciiTerrainBackground({ className }: { className?: string }) {
 
           let noiseVal = clamp(mapRange(noiseCache[index], 0, 1, -0.2, 1.2), 0, 1);
           noiseVal = Math.pow(noiseVal, 1.5);
-          const alpha = Math.pow(noiseVal, 0.8) * MAX_OPACITY * fadeFactor;
+          const alpha = Math.pow(noiseVal, 0.8) * MAX_OPACITY * opacityScale * fadeFactor;
 
           if (Math.abs(alpha - currentAlpha) > 1 / 255) {
             ctx.fillStyle = `rgba(${r}, ${g}, ${b}, ${alpha.toFixed(3)})`;
@@ -172,13 +187,15 @@ export function AsciiTerrainBackground({ className }: { className?: string }) {
       }
     };
 
+    const mountTime = performance.now();
+
     const frame = (time: number) => {
       rafId = requestAnimationFrame(frame);
       if (time - lastFrameTime < FRAME_INTERVAL_MS) return;
       lastFrameTime = time;
 
       updateNoiseCache();
-      render();
+      render(introOpacityScale(time - mountTime));
       offsetX += NOISE_PAN_SPEED;
       offsetY += NOISE_PAN_SPEED;
     };

--- a/lib/background/constants.ts
+++ b/lib/background/constants.ts
@@ -1,0 +1,45 @@
+/**
+ * Tuning for the home page's ASCII "ridged mountains" background
+ * (issue #280), ported from ComputerK's CodePen
+ * (https://codepen.io/ComputerK/pen/jENaeKp). Values are a direct port of
+ * the pen's `CONFIG` object except `maxOpacity`, which is new here since
+ * the app paints the theme's foreground color over the page background
+ * instead of the pen's plain white-on-black.
+ */
+
+/** Noise-space scale per pixel. Lower = larger, slower-rolling ridges. */
+export const NOISE_SCALE = 0.004;
+
+/** Grid cell size in CSS px — one ASCII character per cell. */
+export const CHAR_SIZE = 10;
+
+/** Distance in px over which the texture fades in from each canvas edge. */
+export const EDGE_DISTANCE = 100;
+
+/** Cells whose edge-fade factor falls below this are skipped entirely. */
+export const BRIGHTNESS_THRESHOLD = 0.05;
+
+/** Octaves of ridged noise layered together. */
+export const OCTAVE_NUM = 4;
+
+/** Frequency multiplier applied per successive octave. */
+export const FREQ_MULTIPLIER = 2.2;
+
+/** Amplitude multiplier applied per successive octave. */
+export const AMP_MULTIPLIER = 0.45;
+
+/** Animation frame rate cap, in fps. */
+export const FRAME_RATE = 30;
+
+/** Speed the noise field pans per rendered frame, in noise-space units. */
+export const NOISE_PAN_SPEED = 0.001;
+
+/** Brightness ramp, darkest to brightest. */
+export const ASCII_CHARS = [" ", ".", ":", "-", "~", "+", "=", "^", "*", "#", "@", "█"];
+
+/**
+ * Ceiling on the foreground color's alpha, applied on top of each cell's
+ * brightness/edge-fade factor. Keeps the texture a subtle backdrop rather
+ * than the pen's stark full-contrast terminal look.
+ */
+export const MAX_OPACITY = 0.35;

--- a/lib/background/constants.ts
+++ b/lib/background/constants.ts
@@ -43,3 +43,15 @@ export const ASCII_CHARS = [" ", ".", ":", "-", "~", "+", "=", "^", "*", "#", "@
  * than the pen's stark full-contrast terminal look.
  */
 export const MAX_OPACITY = 0.35;
+
+/**
+ * On mount, the texture eases in from `INTRO_START_FACTOR × MAX_OPACITY`
+ * (soft, logo-first) up to the full `MAX_OPACITY` (ridges, contrast) over
+ * `INTRO_DURATION_MS`, instead of appearing at full contrast immediately.
+ * Skipped under `prefers-reduced-motion: reduce`, which renders straight at
+ * full contrast.
+ */
+export const INTRO_DURATION_MS = 6000;
+
+/** Opacity fraction the texture starts at when the intro begins. */
+export const INTRO_START_FACTOR = 0.06;

--- a/lib/background/perlin.ts
+++ b/lib/background/perlin.ts
@@ -1,0 +1,65 @@
+/**
+ * Minimal classic 2D Perlin noise (Ken Perlin's original algorithm),
+ * permutation-table based and deterministic. Stands in for p5.js's
+ * `noise()` without pulling in a creative-coding dependency.
+ */
+
+const PERMUTATION = [
+  151, 160, 137, 91, 90, 15, 131, 13, 201, 95, 96, 53, 194, 233, 7, 225,
+  140, 36, 103, 30, 69, 142, 8, 99, 37, 240, 21, 10, 23, 190, 6, 148,
+  247, 120, 234, 75, 0, 26, 197, 62, 94, 252, 219, 203, 117, 35, 11, 32,
+  57, 177, 33, 88, 237, 149, 56, 87, 174, 20, 125, 136, 171, 168, 68, 175,
+  74, 165, 71, 134, 139, 48, 27, 166, 77, 146, 158, 231, 83, 111, 229, 122,
+  60, 211, 133, 230, 220, 105, 92, 41, 55, 46, 245, 40, 244, 102, 143, 54,
+  65, 25, 63, 161, 1, 216, 80, 73, 209, 76, 132, 187, 208, 89, 18, 169,
+  200, 196, 135, 130, 116, 188, 159, 86, 164, 100, 109, 198, 173, 186, 3, 64,
+  52, 217, 226, 250, 124, 123, 5, 202, 38, 147, 118, 126, 255, 82, 85, 212,
+  207, 206, 59, 227, 47, 16, 58, 17, 182, 189, 28, 42, 223, 183, 170, 213,
+  119, 248, 152, 2, 44, 154, 163, 70, 221, 153, 101, 155, 167, 43, 172, 9,
+  129, 22, 39, 253, 19, 98, 108, 110, 79, 113, 224, 232, 178, 185, 112, 104,
+  218, 246, 97, 228, 251, 34, 242, 193, 238, 210, 144, 12, 191, 179, 162, 241,
+  81, 51, 145, 235, 249, 14, 239, 107, 49, 192, 214, 31, 181, 199, 106, 157,
+  184, 84, 204, 176, 115, 121, 50, 45, 127, 4, 150, 254, 138, 236, 205, 93,
+  222, 114, 67, 29, 24, 72, 243, 141, 128, 195, 78, 66, 215, 61, 156, 180,
+];
+
+const PERM = new Uint8Array(512);
+for (let i = 0; i < 512; i++) {
+  PERM[i] = PERMUTATION[i & 255];
+}
+
+function fade(t: number): number {
+  return t * t * t * (t * (t * 6 - 15) + 10);
+}
+
+function lerp(t: number, a: number, b: number): number {
+  return a + t * (b - a);
+}
+
+function grad(hash: number, x: number, y: number): number {
+  const h = hash & 3;
+  const u = h < 2 ? x : y;
+  const v = h < 2 ? y : x;
+  return ((h & 1) === 0 ? u : -u) + ((h & 2) === 0 ? v : -v);
+}
+
+/** Classic 2D Perlin noise, roughly in the range [-1, 1]. */
+export function perlin2(x: number, y: number): number {
+  const xi = Math.floor(x) & 255;
+  const yi = Math.floor(y) & 255;
+  const xf = x - Math.floor(x);
+  const yf = y - Math.floor(y);
+
+  const u = fade(xf);
+  const v = fade(yf);
+
+  const aa = PERM[PERM[xi] + yi];
+  const ab = PERM[PERM[xi] + yi + 1];
+  const ba = PERM[PERM[xi + 1] + yi];
+  const bb = PERM[PERM[xi + 1] + yi + 1];
+
+  const x1 = lerp(u, grad(aa, xf, yf), grad(ba, xf - 1, yf));
+  const x2 = lerp(u, grad(ab, xf, yf - 1), grad(bb, xf - 1, yf - 1));
+
+  return lerp(v, x1, x2);
+}


### PR DESCRIPTION
## Summary

- Adds `AsciiTerrainBackground`, a full-bleed `<canvas>` that renders a grid of ASCII characters shaded by animated ridged Perlin noise behind the home page's hero content — a native port of ComputerK's ["ridged mountains" CodePen](https://codepen.io/ComputerK/pen/jENaeKp) (p5.js) to a hand-rolled Canvas2D loop, matching the app's existing no-animation-library convention (`ArkaikLogoBoil`, the wobble system).
- New `lib/background/perlin.ts` (deterministic 2D Perlin noise) and `lib/background/constants.ts` (tuning knobs ported from the pen's `CONFIG`).
- Theme-aware: paints the app's `--foreground` custom property at a low, brightness-modulated alpha, re-reading it live when `ThemeToggle` flips the `dark` class.
- Respects `prefers-reduced-motion: reduce` — renders a single static frame instead of animating.
- Wired into `app/page.tsx`, layered behind the existing radial-gradient vignette so hero content stays legible.

Closes #280.

## Test plan

- [x] `npm run lint`
- [x] Verified in a headless browser: renders correctly in light and dark theme, animates smoothly, reflows on resize, and freezes to a static frame under `prefers-reduced-motion: reduce` (confirmed two frames captured 1.5s apart are pixel-identical in reduced motion, and differ in normal mode).
- [x] No console/page errors.

## Lab Note

```yaml
en:
  title: A living background on the home page
  summary: The home page now has a quiet, animated backdrop of drifting ASCII terrain — it adapts to light and dark mode and holds still if you prefer reduced motion.
fr:
  title: Un fond animé sur la page d'accueil
  summary: La page d'accueil a maintenant un fond discret et animé, un relief ASCII qui dérive doucement — il s'adapte au mode clair et sombre, et reste immobile si tu préfères moins d'animations.
suggested:
  molecule: arkaik
  type: feature
  tags: [changelog]
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01VZWExYDE1QhSsz5Z5ofybC)_