### PR TITLE
Add value element descriptions to the Pyramid page and value tooltips

### DIFF
--- a/app/project/[id]/pyramid/page.tsx
+++ b/app/project/[id]/pyramid/page.tsx
@@ -15,6 +15,7 @@ import { useNodes } from "@/lib/hooks/useNodes";
 import { useProject } from "@/lib/hooks/useProject";
 
 const VALUE_LABEL = new Map(VALUES.map((v) => [v.id, v.label]));
+const VALUE_DESCRIPTION = new Map(VALUES.map((v) => [v.id, v.description]));
 const TIER_LABEL = new Map(VALUE_TIERS_CONFIG.map((t) => [t.id, t.label]));
 
 /**
@@ -98,6 +99,7 @@ export default function PyramidPage() {
                         </span>
                         <span className="shrink-0 text-xs text-muted-foreground">{element.acceptanceCount}</span>
                       </div>
+                      <p className="line-clamp-2 text-xs text-muted-foreground">{VALUE_DESCRIPTION.get(element.value)}</p>
                       <PlatformGaugeList rollup={element.rollup} platforms={gaugePlatforms} compact />
                     </Link>
                   );

--- a/components/values/ValueBadge.tsx
+++ b/components/values/ValueBadge.tsx
@@ -3,6 +3,7 @@
 import type { ValueId } from "@arkaik/schema";
 import { VALUES } from "@/lib/config/values";
 import { VALUE_ICON_COMPONENTS } from "@/lib/config/value-icons";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 const VALUE_BY_ID = new Map(VALUES.map((v) => [v.id, v]));
 
@@ -11,17 +12,21 @@ export function ValueIcon({ valueId, className }: { valueId: ValueId; className?
   return <Icon className={className ?? "size-3.5"} aria-hidden="true" />;
 }
 
-/** Icon + label chip for a value element. */
+/** Icon + label chip for a value element, with its definition as a hover tooltip. */
 export function ValueBadge({ valueId }: { valueId: ValueId }) {
   const value = VALUE_BY_ID.get(valueId);
   if (!value) return null;
   return (
-    <span
-      title={value.label}
-      className="inline-flex items-center gap-1 rounded-full border bg-muted/40 px-2 py-0.5 text-[11px] text-muted-foreground"
-    >
-      <ValueIcon valueId={valueId} className="size-3" />
-      <span className="truncate">{value.label}</span>
-    </span>
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="inline-flex items-center gap-1 rounded-full border bg-muted/40 px-2 py-0.5 text-[11px] text-muted-foreground">
+            <ValueIcon valueId={valueId} className="size-3" />
+            <span className="truncate">{value.label}</span>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top">{value.description}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }

--- a/components/values/ValuePicker.tsx
+++ b/components/values/ValuePicker.tsx
@@ -3,6 +3,7 @@
 import type { ValueId } from "@arkaik/schema";
 import { VALUES, VALUE_TIERS_CONFIG } from "@/lib/config/values";
 import { VALUE_ICON_COMPONENTS } from "@/lib/config/value-icons";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 interface ValuePickerProps {
   selected: ValueId[];
@@ -18,31 +19,36 @@ export function ValuePicker({ selected, onChange }: ValuePickerProps) {
     onChange(VALUES.filter((v) => next.has(v.id)).map((v) => v.id));
   }
   return (
-    <div className="flex flex-col gap-3">
-      {VALUE_TIERS_CONFIG.map((tier) => (
-        <div key={tier.id} className="flex flex-col gap-1.5">
-          <span className="text-[11px] uppercase tracking-wide text-muted-foreground">{tier.label}</span>
-          <div className="flex flex-wrap gap-1.5">
-            {VALUES.filter((v) => v.tier === tier.id).map((v) => {
-              const Icon = VALUE_ICON_COMPONENTS[v.id];
-              const on = selectedSet.has(v.id);
-              return (
-                <button
-                  key={v.id}
-                  type="button"
-                  aria-pressed={on}
-                  onClick={() => toggle(v.id)}
-                  title={v.label}
-                  className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] transition-colors ${on ? "border-foreground bg-foreground text-background" : "text-muted-foreground hover:bg-muted/60"}`}
-                >
-                  <Icon className="size-3" />
-                  {v.label}
-                </button>
-              );
-            })}
+    <TooltipProvider delayDuration={300}>
+      <div className="flex flex-col gap-3">
+        {VALUE_TIERS_CONFIG.map((tier) => (
+          <div key={tier.id} className="flex flex-col gap-1.5">
+            <span className="text-[11px] uppercase tracking-wide text-muted-foreground">{tier.label}</span>
+            <div className="flex flex-wrap gap-1.5">
+              {VALUES.filter((v) => v.tier === tier.id).map((v) => {
+                const Icon = VALUE_ICON_COMPONENTS[v.id];
+                const on = selectedSet.has(v.id);
+                return (
+                  <Tooltip key={v.id}>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        aria-pressed={on}
+                        onClick={() => toggle(v.id)}
+                        className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] transition-colors ${on ? "border-foreground bg-foreground text-background" : "text-muted-foreground hover:bg-muted/60"}`}
+                      >
+                        <Icon className="size-3" />
+                        {v.label}
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="top">{v.description}</TooltipContent>
+                  </Tooltip>
+                );
+              })}
+            </div>
           </div>
-        </div>
-      ))}
-    </div>
+        ))}
+      </div>
+    </TooltipProvider>
   );
 }

--- a/lib/config/values.ts
+++ b/lib/config/values.ts
@@ -88,6 +88,48 @@ const VALUE_ICONS: Record<ValueId, string> = {
 };
 
 /**
+ * One-line definition per element, mirroring plugin/skills/arkaik/references/values.md
+ * (the canonical Bain B2C pyramid reference) — shown in the Pyramid page cards
+ * and as tooltips wherever a value item is shown compactly.
+ */
+const VALUE_DESCRIPTIONS: Record<ValueId, string> = {
+  // functional
+  "saves-time": "Completes the user's task in less time.",
+  simplifies: "Reduces steps, choices, or cognitive load.",
+  "makes-money": "Helps the user earn.",
+  "reduces-risk": "Protects against loss, error, or uncertainty.",
+  organizes: "Brings order to the user's things or life.",
+  integrates: "Ties different tools or parts of life together.",
+  connects: "Brings the user together with other people.",
+  "reduces-effort": "Same outcome, less work.",
+  "avoids-hassles": "Prevents friction and annoyance before it happens.",
+  "reduces-cost": "Saves the user money.",
+  quality: "Superior craft or performance the user can feel.",
+  variety: "Meaningful choice and breadth.",
+  "sensory-appeal": "Looks, sounds, or feels good in the moment.",
+  informs: "Tells the user something they want to know.",
+  // emotional
+  "reduces-anxiety": "Calms; makes the user feel safe.",
+  "rewards-me": "Tangible perks for engagement.",
+  nostalgia: "Positive memory of the past.",
+  "design-aesthetics": "Beauty as an experienced value, beyond function.",
+  "badge-value": "Signals identity or status to others.",
+  wellness: "Improves physical or mental well-being.",
+  "therapeutic-value": "Actively supports emotional processing or healing.",
+  "fun-entertainment": "Enjoyable, playful, delightful.",
+  attractiveness: "Makes the user feel attractive.",
+  "provides-access": "Grants entry to something otherwise out of reach.",
+  // life-changing
+  "provides-hope": "Reason to believe things can improve.",
+  "self-actualization": "Helps the user become who they want to be.",
+  motivation: "Energizes the user toward their goals.",
+  heirloom: "Something worth passing on across time.",
+  "affiliation-belonging": "Makes the user part of a group that matters.",
+  // social-impact
+  "self-transcendence": "Helps beyond the user themselves.",
+};
+
+/**
  * UI mirror for the 30 Bain B2C value elements. `tier` derives from the
  * schema's VALUE_TIERS so it can never drift; the Record types above make a
  * missing element a compile error.
@@ -97,6 +139,7 @@ export const VALUES = VALUE_IDS.map((id) => ({
   tier: VALUE_TIERS[id],
   label: VALUE_LABELS[id],
   icon: VALUE_ICONS[id],
+  description: VALUE_DESCRIPTIONS[id],
 }));
 
 export type { ValueId, ValueTierId };


### PR DESCRIPTION
## Summary

- Add a one-line definition for each of the 30 Bain value elements, shown as visible text on the Pyramid page's element cards
- Add the same definitions as hover tooltips on value badges in the Acceptance view and on the value picker in the acceptance sheet overlay

## Lab Note

```yaml
en:
  title: See what each value actually means
  summary: Every value in the Pyramid now shows a short, plain-English description — right on the Pyramid page, and as a tooltip wherever you pick or see a value on an acceptance.
fr:
  title: Comprends ce que veut dire chaque valeur
  summary: Chaque valeur de la Pyramide affiche maintenant une courte description en clair — sur la page Pyramide, et en infobulle partout où tu choisis ou vois une valeur sur une acceptance.
suggested:
  molecule: arkaik
  type: improvement
  tags: [changelog]
```

https://claude.ai/code/session_01M2FpcZwobqbekDUd4xH1Hc