### PR TITLE
Fix StatusIcon className in DeliveryBoard header

### DIFF
--- a/components/delivery/DeliveryBoard.tsx
+++ b/components/delivery/DeliveryBoard.tsx
@@ -22,7 +22,7 @@ export function DeliveryBoard({ columns, speciesLabelById, speciesDescriptionByI
         return (
           <section key={status} className="flex w-72 shrink-0 flex-col rounded-xl border bg-card/50">
             <header className="flex items-center gap-2 border-b px-3 py-2.5">
-              <StatusIcon className={`size-4 ${STATUS_STYLES[status].dot}`} aria-hidden="true" />
+              <StatusIcon className={`size-4 ${STATUS_STYLES[status].badge}`} aria-hidden="true" />
               <h2 className="text-sm font-medium">{label}</h2>
               <span className="ml-auto rounded-full border px-2 py-0.5 text-xs text-muted-foreground">
                 {items.length}


### PR DESCRIPTION
## Summary

Fixed incorrect className reference in the DeliveryBoard component's status header. Changed `STATUS_STYLES[status].dot` to `STATUS_STYLES[status].badge` to use the correct style property.

`.dot` is a `bg-*` class meant for filled circle/swatch indicators; applied to a Lucide icon it just paints an invisible colored box behind the icon while the icon's own stroke (which needs a `text-*` class, since Lucide icons render via `currentColor`) stayed uncolored — the icon appeared black/uncolored while a colored "backfill" sat behind it. Every other call site in the codebase already uses `.badge` for coloring status icons; `DeliveryBoard.tsx` was the one outlier.

https://claude.ai/code/session_01MkyXhgZjpARtF3JfGZgk1w

## Lab Note

```yaml
en:
  title: Delivery board status icons show their true colors
  summary: The status icon on each Delivery column heading now matches that status's color instead of rendering plain black.
fr:
  title: Les icônes de statut retrouvent leurs couleurs
  summary: L'icône de statut de chaque colonne du tableau Delivery reprend maintenant la couleur du statut, au lieu de rester en noir.
suggested:
  molecule: arkaik
  type: fix
  tags: [changelog]
```
