### PR TITLE
Add icons to status and value filter dropdowns

### DIFF
--- a/components/acceptances/AcceptanceFilterBar.tsx
+++ b/components/acceptances/AcceptanceFilterBar.tsx
@@ -10,7 +10,7 @@ import { VALUES } from "@/lib/config/values";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { STATUS_ICONS, STATUS_STYLES } from "@/components/graph/nodes/node-styles";
+import { PLATFORM_ICONS, STATUS_ICONS, STATUS_STYLES } from "@/components/graph/nodes/node-styles";
 import { VALUE_ICON_COMPONENTS } from "@/lib/config/value-icons";
 
 interface AnchorOption {
@@ -80,10 +80,13 @@ export function AcceptanceFilterBar({ filters, onChange, anchorOptions }: Accept
       </div>
 
       <Select value={filters.platform} onValueChange={(v) => onChange({ ...filters, platform: v === ALL ? "all" : (v as AcceptanceFilters["platform"]) })}>
-        <SelectTrigger className="w-[8rem]" aria-label="Platform"><SelectValue placeholder="Platform" /></SelectTrigger>
+        <SelectTrigger className="w-[8rem]" aria-label="Platform"><SelectValue placeholder="Platforms" /></SelectTrigger>
         <SelectContent>
-          <SelectItem value={ALL}>All platforms</SelectItem>
-          {PLATFORMS.map((p) => <SelectItem key={p.id} value={p.id}>{p.label}</SelectItem>)}
+          <SelectItem value={ALL}>Platforms</SelectItem>
+          {PLATFORMS.map((p) => {
+            const Icon = PLATFORM_ICONS[p.id];
+            return <SelectItem key={p.id} value={p.id}><span className="inline-flex items-center gap-2"><Icon className="size-3.5" />{p.label}</span></SelectItem>;
+          })}
         </SelectContent>
       </Select>
 

--- a/components/acceptances/AcceptanceFilterBar.tsx
+++ b/components/acceptances/AcceptanceFilterBar.tsx
@@ -10,6 +10,8 @@ import { VALUES } from "@/lib/config/values";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { STATUS_ICONS, STATUS_STYLES } from "@/components/graph/nodes/node-styles";
+import { VALUE_ICON_COMPONENTS } from "@/lib/config/value-icons";
 
 interface AnchorOption {
   id: string;
@@ -89,7 +91,10 @@ export function AcceptanceFilterBar({ filters, onChange, anchorOptions }: Accept
         <SelectTrigger className="w-[9rem]" aria-label="Status"><SelectValue placeholder="Status" /></SelectTrigger>
         <SelectContent>
           <SelectItem value={ALL}>All statuses</SelectItem>
-          {STATUSES.map((s) => <SelectItem key={s.id} value={s.id}>{s.label}</SelectItem>)}
+          {STATUSES.map((s) => {
+            const Icon = STATUS_ICONS[s.id];
+            return <SelectItem key={s.id} value={s.id}><span className="inline-flex items-center gap-2"><Icon className={`size-3.5 ${STATUS_STYLES[s.id].badge}`} />{s.label}</span></SelectItem>;
+          })}
         </SelectContent>
       </Select>
 
@@ -97,7 +102,10 @@ export function AcceptanceFilterBar({ filters, onChange, anchorOptions }: Accept
         <SelectTrigger className="w-[11rem]" aria-label="Value"><SelectValue placeholder="Value" /></SelectTrigger>
         <SelectContent>
           <SelectItem value={ALL}>All values</SelectItem>
-          {VALUES.map((v) => <SelectItem key={v.id} value={v.id}>{v.label}</SelectItem>)}
+          {VALUES.map((v) => {
+            const Icon = VALUE_ICON_COMPONENTS[v.id];
+            return <SelectItem key={v.id} value={v.id}><span className="inline-flex items-center gap-2"><Icon className="size-3.5" />{v.label}</span></SelectItem>;
+          })}
         </SelectContent>
       </Select>
 


### PR DESCRIPTION
## Summary

Enhanced the AcceptanceFilterBar component to display icons alongside status, value, and platform labels in their respective filter dropdowns. This improves visual consistency with the graph nodes and the Acceptance sheet, and makes filter options more scannable. The platform filter's "All platforms" option is also simplified to "Platforms" now that the trigger already reads as a category label.

## Changes

- Imported `STATUS_ICONS` and `STATUS_STYLES` from node-styles
- Imported `VALUE_ICON_COMPONENTS` from value-icons config
- Imported `PLATFORM_ICONS` from node-styles
- Updated status filter dropdown to render icons with status color
- Updated value filter dropdown to render icons
- Updated platform filter dropdown to render icons and renamed "All platforms" → "Platforms"
- All three dropdowns now display icons inline with labels using consistent spacing

## Lab Note

```yaml
en:
  title: Filters now show icons, not just text
  summary: Status, value, and platform filters now show each option's icon (and status color), so you can scan and pick without reading every label.
fr:
  title: Les filtres affichent maintenant des icônes
  summary: Les filtres de statut, de valeur et de plateforme affichent maintenant l'icône de chaque option (et sa couleur pour le statut), pour repérer et choisir plus vite.
suggested:
  molecule: arkaik
  type: improvement
  tags: [changelog]
```

https://claude.ai/code/session_01FbbyHx4EFmZhbsUP1rNaBk