### PR TITLE
refactor(schema): one shared mutation core for every writer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Acceptance model tests
         run: npm run test:acceptance
 
+      - name: Mutation core tests (applyOps invariants, batch atomicity)
+        run: npm run test:mutate
+
       - name: Deterministic id generator tests
         run: npm run test:id-gen
 

--- a/app/project/[id]/acceptances/page.tsx
+++ b/app/project/[id]/acceptances/page.tsx
@@ -26,8 +26,8 @@ export default function ProjectAcceptancesPage() {
   const [selectedNode, setSelectedNode] = useState<DataNode | null>(null);
   const [panelOpen, setPanelOpen] = useState(false);
 
-  const { nodes: dataNodes, loading: nodesLoading, updateNode, addNode, removeNode } = useNodes(id);
-  const { edges: dataEdges, loading: edgesLoading, addEdge } = useEdges(id);
+  const { nodes: dataNodes, loading: nodesLoading, updateNode, addNode, applyMutations } = useNodes(id);
+  const { edges: dataEdges, loading: edgesLoading, syncEdges } = useEdges(id);
   const { project: projectBundle } = useProject(id);
   const { journal } = useJournal(id);
   const { filters, setFilters } = useAcceptanceFilters();
@@ -78,20 +78,39 @@ export default function ProjectAcceptancesPage() {
     return created;
   }
 
+  /**
+   * An acceptance and the `covers` edge anchoring it are one thing, so they are
+   * written as one atomic batch. This previously created the node, created the
+   * edge, and hand-rolled a rollback of the node when the edge failed — a
+   * compensating delete that could itself fail and leave the orphan behind.
+   */
   async function handleCreateAcceptanceForAnchor(anchor: DataNode, title: string): Promise<DataNode> {
-    const created = await handleCreateAcceptance(title);
-    try {
-      await addEdge({
-        id: `e-${created.id}-${anchor.id}`,
-        project_id: id,
-        source_id: created.id,
-        target_id: anchor.id,
-        edge_type: "covers",
-      });
-    } catch (err) {
-      await removeNode(created.id).catch(() => {}); // roll back the just-created node so no orphan acceptance lingers
-      throw err;
-    }
+    const created: DataNode = {
+      id: generateNodeId("acceptance", title, nodesById.keys()),
+      project_id: id,
+      species: "acceptance",
+      title,
+      status: "idea",
+      platforms: ["web", "ios", "android"],
+      metadata: {},
+    };
+
+    const result = await applyMutations([
+      { op: "create_node", node: created },
+      {
+        op: "create_edge",
+        edge: {
+          id: `e-${created.id}-${anchor.id}`,
+          project_id: id,
+          source_id: created.id,
+          target_id: anchor.id,
+          edge_type: "covers",
+        },
+      },
+    ]);
+    syncEdges(result.edges);
+
+    handleSelectNode(created);
     return created;
   }
 

--- a/lib/data/data-provider.ts
+++ b/lib/data/data-provider.ts
@@ -1,3 +1,5 @@
+import type { MutationOp } from "@arkaik/schema";
+
 import type { Node, Edge, Project, ProjectBundle, JournalEvent } from "./types";
 
 export interface DataProvider {
@@ -23,6 +25,17 @@ export interface DataProvider {
 
   createEdge(edge: Edge): Promise<Edge>;
   deleteEdge(id: string): Promise<void>;
+
+  /**
+   * Apply several mutations atomically — all of them commit, or none do.
+   *
+   * The single-op methods above cannot express "create this node AND this edge
+   * together", which forces callers into a create-then-create sequence with a
+   * hand-rolled rollback when the second half fails. A batch removes that whole
+   * class of half-written state. A remote provider sends one request; the local
+   * one runs a single IndexedDB transaction.
+   */
+  applyMutations(projectId: string, ops: MutationOp[]): Promise<{ nodes: Node[]; edges: Edge[] }>;
 
   exportProject(id: string): Promise<ProjectBundle>;
   importProject(bundle: ProjectBundle): Promise<Project>;

--- a/lib/data/local-provider.ts
+++ b/lib/data/local-provider.ts
@@ -1,8 +1,7 @@
 import type { DataProvider } from "./data-provider";
-import type { Node, Edge, ProjectBundle, PlaylistEntry } from "./types";
+import type { Node, Edge, ProjectBundle } from "./types";
 import { migrateBundle } from "./migrate";
-import { edgeId } from "@arkaik/schema";
-import { wouldCreateCycle } from "@/lib/utils/cycle";
+import { applyOps, type MutationOp } from "@arkaik/schema";
 import {
   appendJournalEvents,
   assembleBundle,
@@ -10,14 +9,7 @@ import {
   splitBundle,
   type ProjectRecord,
 } from "./db";
-import {
-  diffNodeUpdate,
-  edgeAddedInput,
-  edgeRemovedInput,
-  nodeCreatedInput,
-  nodeDeletedInput,
-  toJournalEvents,
-} from "./emit-events";
+import { toJournalEvents } from "./emit-events";
 
 /**
  * The app's `DataProvider`, backed by IndexedDB (Dexie — see `./db.ts`).
@@ -68,31 +60,6 @@ import {
  * list either.
  */
 
-function collectReferencedFlowIds(entries: PlaylistEntry[]): string[] {
-  const result: string[] = [];
-
-  for (const entry of entries) {
-    if (entry.type === "flow") {
-      result.push(entry.flow_id);
-      continue;
-    }
-
-    if (entry.type === "condition") {
-      result.push(...collectReferencedFlowIds(entry.if_true));
-      result.push(...collectReferencedFlowIds(entry.if_false));
-      continue;
-    }
-
-    if (entry.type === "junction") {
-      for (const playlistCase of entry.cases) {
-        result.push(...collectReferencedFlowIds(playlistCase.entries));
-      }
-    }
-  }
-
-  return result;
-}
-
 function isArchived(record: ProjectRecord): boolean {
   return Boolean(record.snapshot.project.archived_at);
 }
@@ -124,6 +91,63 @@ function notifyMutation(projectId: string): void {
   for (const listener of mutationListeners) {
     listener({ projectId });
   }
+}
+
+/** How to find the project a mutation targets. */
+type Locator =
+  | { by: "project"; id: string }
+  | { by: "node"; id: string }
+  | { by: "edge"; id: string };
+
+/**
+ * The single write path: locate the project, run `ops` through the shared
+ * `applyOps`, and persist the resulting graph + derived events in ONE Dexie
+ * transaction so snapshot and journal always commit together.
+ *
+ * Every graph mutation below funnels through here, which is what makes the
+ * app's semantics identical to the MCP server's and (next) the hosted store's —
+ * the cycle guard, the composes synthesis, the edge-id normalization and the
+ * cascade rules all live in `applyOps`, not in this file.
+ *
+ * `notifyMutation` fires exactly once, after the transaction resolves — never
+ * inside it, and never when it throws (issue #243).
+ */
+async function runOps(locator: Locator, ops: MutationOp[], notFoundMessage: string) {
+  const db = await getDb();
+  if (!db) throw new Error(notFoundMessage);
+
+  let nextNodes: Node[] = [];
+  let nextEdges: Edge[] = [];
+  let projectId = "";
+
+  await db.transaction("rw", db.projects, db.journals, async () => {
+    const record =
+      locator.by === "project"
+        ? await db.projects.get(locator.id)
+        : (await db.projects.toArray()).find((candidate) =>
+            locator.by === "node"
+              ? candidate.snapshot.nodes.some((n) => n.id === locator.id)
+              : candidate.snapshot.edges.some((e) => e.id === locator.id),
+          );
+    if (!record) throw new Error(notFoundMessage);
+
+    projectId = record.snapshot.project.id;
+    const outcome = applyOps(
+      { projectId, nodes: record.snapshot.nodes, edges: record.snapshot.edges },
+      ops,
+    );
+
+    record.snapshot.nodes = outcome.nodes;
+    record.snapshot.edges = outcome.edges;
+    nextNodes = outcome.nodes;
+    nextEdges = outcome.edges;
+
+    await db.projects.put(record);
+    await appendJournalEvents(db, projectId, toJournalEvents(outcome.eventInputs));
+  });
+
+  notifyMutation(projectId);
+  return { nodes: nextNodes, edges: nextEdges, projectId };
 }
 
 export const localProvider: DataProvider = {
@@ -203,152 +227,78 @@ export const localProvider: DataProvider = {
   },
 
   async createNode(node: Node) {
-    const db = await getDb();
-    if (!db) throw new Error(`Project ${node.project_id} not found`);
-    await db.transaction("rw", db.projects, db.journals, async () => {
-      const record = await db.projects.get(node.project_id);
-      if (!record) throw new Error(`Project ${node.project_id} not found`);
-      record.snapshot.nodes.push(node);
-      await db.projects.put(record);
-      await appendJournalEvents(db, node.project_id, toJournalEvents([nodeCreatedInput(node)]));
-    });
-    notifyMutation(node.project_id);
+    await runOps({ by: "project", id: node.project_id }, [{ op: "create_node", node }], `Project ${node.project_id} not found`);
     return node;
   },
 
   async updateNode(id: string, patch: Partial<Omit<Node, "id" | "project_id">>) {
-    const db = await getDb();
-    if (!db) throw new Error(`Node ${id} not found`);
-    let updated: Node | undefined;
-    let projectId: string | undefined;
-    await db.transaction("rw", db.projects, db.journals, async () => {
-      const records = await db.projects.toArray();
-      const record = records.find((r) => r.snapshot.nodes.some((n) => n.id === id));
-      if (!record) throw new Error(`Node ${id} not found`);
-      projectId = record.snapshot.project.id;
-
-      const nodes = record.snapshot.nodes;
-      const idx = nodes.findIndex((n) => n.id === id);
-      const current = nodes[idx];
-      const nextNode = { ...current, ...patch };
-
-      if (nextNode.species === "flow") {
-        const entries = nextNode.metadata?.playlist?.entries;
-        if (Array.isArray(entries)) {
-          const nextNodes = [...nodes];
-          nextNodes[idx] = nextNode;
-          const candidateFlowIds = collectReferencedFlowIds(entries);
-
-          for (const candidateFlowId of candidateFlowIds) {
-            if (wouldCreateCycle(nextNode.id, candidateFlowId, nextNodes)) {
-              throw new Error(`Cannot add Flow ${candidateFlowId}: it would create a circular reference.`);
-            }
-          }
-        }
-      }
-
-      // Diff the patch against the pre-update node (per-key for metadata) and
-      // append the derived event(s). Computed only after the cycle validation
-      // above, so a rejected update never emits.
-      const events = toJournalEvents(diffNodeUpdate(current, patch));
-
-      nodes[idx] = nextNode;
-      updated = nextNode;
-      await db.projects.put(record);
-      await appendJournalEvents(db, record.snapshot.project.id, events);
-    });
-    notifyMutation(projectId!);
-    return updated!;
+    const { nodes } = await runOps(
+      { by: "node", id },
+      [{ op: "update_node", node_id: id, patch }],
+      `Node ${id} not found`,
+    );
+    return nodes.find((candidate) => candidate.id === id)!;
   },
 
   async deleteNode(id: string) {
-    const db = await getDb();
-    if (!db) throw new Error(`Node ${id} not found`);
-    let projectId: string | undefined;
-    await db.transaction("rw", db.projects, db.journals, async () => {
-      const records = await db.projects.toArray();
-      const record = records.find((r) => r.snapshot.nodes.some((n) => n.id === id));
-      if (!record) throw new Error(`Node ${id} not found`);
-      projectId = record.snapshot.project.id;
-      record.snapshot.nodes = record.snapshot.nodes.filter((n) => n.id !== id);
-      // Cascade-remove attached edges. The journal's node.deleted IMPLIES this
-      // cascade, so we do NOT emit edge.removed for them (docs/spec/journal.md:71).
-      record.snapshot.edges = record.snapshot.edges.filter(
-        (e) => e.source_id !== id && e.target_id !== id,
-      );
-      await db.projects.put(record);
-      await appendJournalEvents(db, record.snapshot.project.id, toJournalEvents([nodeDeletedInput(id)]));
-    });
-    notifyMutation(projectId!);
+    await runOps({ by: "node", id }, [{ op: "delete_node", node_id: id }], `Node ${id} not found`);
   },
 
+  /**
+   * Deleting across projects is the one mutation `runOps` cannot express: it
+   * targets every project that happens to hold one of the ids, so it runs
+   * `applyOps` once per affected project inside a single transaction, and fires
+   * one notification per project rather than one per node (issue #243).
+   */
   async deleteNodes(ids: string[]) {
     if (ids.length === 0) return;
     const db = await getDb();
     if (!db) return;
     const idSet = new Set(ids);
-    // One notification per affected project, not one per node (issue #243) —
-    // collected during the transaction, fired after it commits.
     const affectedProjectIds: string[] = [];
+
     await db.transaction("rw", db.projects, db.journals, async () => {
-      const records = await db.projects.toArray();
-      for (const record of records) {
-        // Only ids actually present in this project's snapshot are deleted (and
-        // emitted), so a node.deleted never references a node that never existed.
-        const deletedIds = record.snapshot.nodes.filter((n) => idSet.has(n.id)).map((n) => n.id);
-        if (deletedIds.length === 0) continue;
-        record.snapshot.nodes = record.snapshot.nodes.filter((n) => !idSet.has(n.id));
-        // Cascade-remove edges without emitting edge.removed (docs/spec/journal.md:71).
-        record.snapshot.edges = record.snapshot.edges.filter(
-          (e) => !idSet.has(e.source_id) && !idSet.has(e.target_id),
+      for (const record of await db.projects.toArray()) {
+        if (!record.snapshot.nodes.some((n) => idSet.has(n.id))) continue;
+        const projectId = record.snapshot.project.id;
+        const outcome = applyOps(
+          { projectId, nodes: record.snapshot.nodes, edges: record.snapshot.edges },
+          [{ op: "delete_nodes", node_ids: ids }],
         );
+        record.snapshot.nodes = outcome.nodes;
+        record.snapshot.edges = outcome.edges;
         await db.projects.put(record);
-        await appendJournalEvents(
-          db,
-          record.snapshot.project.id,
-          toJournalEvents(deletedIds.map(nodeDeletedInput)),
-        );
-        affectedProjectIds.push(record.snapshot.project.id);
+        await appendJournalEvents(db, projectId, toJournalEvents(outcome.eventInputs));
+        affectedProjectIds.push(projectId);
       }
     });
-    for (const projectId of affectedProjectIds) {
-      notifyMutation(projectId);
-    }
+
+    for (const projectId of affectedProjectIds) notifyMutation(projectId);
   },
 
   async createEdge(edge: Edge) {
-    const db = await getDb();
-    if (!db) throw new Error(`Project ${edge.project_id} not found`);
-    // Enforce the `e-{source}-{target}` convention at the seam so any edge
-    // creation — including a repoint expressed as delete + create — stays
-    // conformant regardless of the id the caller supplied (issue #215,
-    // docs/spec/bundle-format.md § Identifier Conventions).
-    const normalized: Edge = { ...edge, id: edgeId(edge.source_id, edge.target_id) };
-    await db.transaction("rw", db.projects, db.journals, async () => {
-      const record = await db.projects.get(normalized.project_id);
-      if (!record) throw new Error(`Project ${normalized.project_id} not found`);
-      record.snapshot.edges.push(normalized);
-      await db.projects.put(record);
-      await appendJournalEvents(db, normalized.project_id, toJournalEvents([edgeAddedInput(normalized)]));
-    });
-    notifyMutation(normalized.project_id);
-    return normalized;
+    const { edges } = await runOps(
+      { by: "project", id: edge.project_id },
+      [{ op: "create_edge", edge }],
+      `Project ${edge.project_id} not found`,
+    );
+    // applyOps normalizes the id to the `e-{source}-{target}` convention, so the
+    // stored edge is the one to return — not the caller's input.
+    return edges.find((candidate) => candidate.source_id === edge.source_id && candidate.target_id === edge.target_id)!;
   },
 
   async deleteEdge(id: string) {
-    const db = await getDb();
-    if (!db) throw new Error(`Edge ${id} not found`);
-    let projectId: string | undefined;
-    await db.transaction("rw", db.projects, db.journals, async () => {
-      const records = await db.projects.toArray();
-      const record = records.find((r) => r.snapshot.edges.some((e) => e.id === id));
-      if (!record) throw new Error(`Edge ${id} not found`);
-      projectId = record.snapshot.project.id;
-      record.snapshot.edges = record.snapshot.edges.filter((e) => e.id !== id);
-      await db.projects.put(record);
-      await appendJournalEvents(db, record.snapshot.project.id, toJournalEvents([edgeRemovedInput(id)]));
-    });
-    notifyMutation(projectId!);
+    await runOps({ by: "edge", id }, [{ op: "delete_edge", edge_id: id }], `Edge ${id} not found`);
+  },
+
+  /**
+   * Apply several ops as ONE atomic unit — the seam that lets a caller create a
+   * node and its edge together instead of creating the node, creating the edge,
+   * and hand-rolling a rollback when the second call fails.
+   */
+  async applyMutations(projectId: string, ops: MutationOp[]) {
+    const { nodes, edges } = await runOps({ by: "project", id: projectId }, ops, `Project ${projectId} not found`);
+    return { nodes, edges };
   },
 
   async exportProject(id: string) {

--- a/lib/hooks/useEdges.ts
+++ b/lib/hooks/useEdges.ts
@@ -34,5 +34,11 @@ export function useEdges(projectId: string) {
     setEdges((prev) => prev.filter((e) => e.id !== id));
   }, []);
 
-  return { edges, loading, error, addEdge, removeEdge };
+  /**
+   * Adopt an edge list produced by an atomic batch elsewhere (see `useNodes`'s
+   * `applyMutations`). Local state only — the write has already committed.
+   */
+  const syncEdges = useCallback((next: Edge[]) => setEdges(next), []);
+
+  return { edges, loading, error, addEdge, removeEdge, syncEdges };
 }

--- a/lib/hooks/useNodes.ts
+++ b/lib/hooks/useNodes.ts
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import type { Node } from "@/lib/data/types";
+import type { MutationOp } from "@arkaik/schema";
+import type { Edge, Node } from "@/lib/data/types";
 import { getProvider } from "@/lib/data/provider-registry";
 
 export function useNodes(projectId: string) {
@@ -55,5 +56,22 @@ export function useNodes(projectId: string) {
     []
   );
 
-  return { nodes, loading, error, addNode, removeNode, removeNodes, updateNode };
+  /**
+   * Apply several ops as one atomic write and adopt the resulting node list.
+   *
+   * Use this instead of chaining single-op calls whenever a half-applied result
+   * would be wrong — creating a node and the edge that anchors it, say. It
+   * returns the edges too, so a caller holding `useEdges` can sync that half
+   * with `syncEdges`; the write itself already committed as a unit.
+   */
+  const applyMutations = useCallback(
+    async (ops: MutationOp[]): Promise<{ nodes: Node[]; edges: Edge[] }> => {
+      const result = await getProvider().applyMutations(projectId, ops);
+      setNodes(result.nodes);
+      return result;
+    },
+    [projectId],
+  );
+
+  return { nodes, loading, error, addNode, removeNode, removeNodes, updateNode, applyMutations };
 }

--- a/lib/utils/cycle.ts
+++ b/lib/utils/cycle.ts
@@ -1,68 +1,13 @@
-import type { Node, PlaylistEntry } from "@/lib/data/types";
-
-function collectReferencedFlowIds(entries: PlaylistEntry[]): string[] {
-  const result: string[] = [];
-
-  for (const entry of entries) {
-    if (entry.type === "flow") {
-      result.push(entry.flow_id);
-      continue;
-    }
-
-    if (entry.type === "condition") {
-      result.push(...collectReferencedFlowIds(entry.if_true));
-      result.push(...collectReferencedFlowIds(entry.if_false));
-      continue;
-    }
-
-    if (entry.type === "junction") {
-      for (const playlistCase of entry.cases) {
-        result.push(...collectReferencedFlowIds(playlistCase.entries));
-      }
-    }
-  }
-
-  return result;
-}
-
 /**
- * Returns true if adding `candidateId` to `flowId`'s playlist would create a cycle.
+ * Flow-playlist cycle detection.
+ *
+ * The implementation moved to `@arkaik/schema` (`packages/schema/src/mutate.ts`)
+ * so every writer shares it: the app's UI guards call it directly for an
+ * up-front, friendly refusal, and `applyOps` enforces the same rule for the MCP
+ * server and the hosted store, which previously had no equivalent and relied on
+ * `validateBundle` catching the cycle after the fact.
+ *
+ * This module stays as the app-side import path — `@/lib/utils/cycle` is used by
+ * JourneyMap and PlaylistEntryRow — so the move is invisible to call sites.
  */
-export function wouldCreateCycle(
-  flowId: string,
-  candidateId: string,
-  allNodes: Node[],
-): boolean {
-  if (candidateId === flowId) return true;
-
-  const nodesById = new Map(allNodes.map((node) => [node.id, node]));
-  const candidate = nodesById.get(candidateId);
-  if (!candidate || candidate.species !== "flow") return false;
-
-  const visited = new Set<string>();
-  const stack = [candidateId];
-
-  while (stack.length > 0) {
-    const currentFlowId = stack.pop();
-    if (!currentFlowId) continue;
-    if (visited.has(currentFlowId)) continue;
-    visited.add(currentFlowId);
-
-    const currentFlow = nodesById.get(currentFlowId);
-    if (!currentFlow || currentFlow.species !== "flow") continue;
-
-    const entries = currentFlow.metadata?.playlist?.entries;
-    if (!Array.isArray(entries)) continue;
-
-    const referencedFlowIds = collectReferencedFlowIds(entries);
-    if (referencedFlowIds.includes(flowId)) return true;
-
-    for (const referencedFlowId of referencedFlowIds) {
-      if (!visited.has(referencedFlowId)) {
-        stack.push(referencedFlowId);
-      }
-    }
-  }
-
-  return false;
-}
+export { wouldCreateCycle } from "@arkaik/schema";

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:mcp": "npm run build -w arkaik && npm run build -w arkaik-mcp && node tests/mcp/run-mcp-tests.js",
     "test:journal-projections": "node tests/data/journal-projections.test.js",
     "test:emit": "node tests/schema/emit.test.js",
+    "test:mutate": "node tests/schema/mutate.test.js",
     "test:emit-events": "node tests/data/emit-events.test.js",
     "test:screenshot-size": "node tests/schema/screenshot-size.test.js",
     "test:migrate": "node tests/data/migrate.test.js && node tests/data/import-roundtrip.test.js && node tests/data/seed-import.test.js",

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -11,8 +11,9 @@ import {
   SPECIES_IDS,
   STATUS_IDS,
   VALUE_IDS,
+  MutationError,
   acceptancesCovering,
-  collectPlaylistNodeRefs,
+  applyOps,
   computeBacklog,
   computeChangelog,
   computeMapSubgraph,
@@ -26,17 +27,12 @@ import {
   type Edge,
   type EventInput,
   type JournalEvent,
+  type MutationOp,
+  type MutationOutcome,
   type Node,
   type Project,
   type ReleaseTaggedEvent,
   type ValueId,
-} from "@arkaik/schema";
-import {
-  diffNodeUpdate,
-  edgeAddedInput,
-  edgeRemovedInput,
-  nodeCreatedInput,
-  nodeDeletedInput,
 } from "@arkaik/schema";
 import type { BundleValidation } from "arkaik/io";
 import { ToolError, type ToolDefinition, type ToolHandler } from "./protocol";
@@ -109,38 +105,22 @@ function unwrap(result: WriteResult): { warnings: unknown[]; events: JournalEven
 const UPDATABLE_NODE_FIELDS = new Set(["title", "description", "status", "platforms", "metadata"]);
 
 /**
- * The `composes` edges a flow's playlist requires but that don't exist yet
- * (docs/spec/mcp.md § Write Path — Playlist composition). Without this, a flow
- * cannot be created with a populated playlist in a single validated mutation
- * (issue #263): `validateBundle`'s `playlist-composes-coherence` rule demands a
- * `composes` edge for every referenced view/sub-flow, but `add_edge` cannot
- * create those until the flow node exists — a deadlock no call ordering
- * escapes. `create_node`/`update_node` synthesize the missing edges (flow → each
- * referenced view/sub-flow) and fold them into the same gated write, mirroring
- * what the app's playlist editor already does (JourneyMap.tsx). Edges that
- * already exist are left untouched; a duplicate reference yields one edge.
+ * Run ops through the shared mutation core, mapping a refusal onto a ToolError.
+ *
+ * The semantics — composes-edge synthesis, the flow-cycle guard, edge-id
+ * normalization, the delete cascade — moved to `@arkaik/schema`'s `applyOps`
+ * (packages/schema/src/mutate.ts) so this server, the browser app, and the
+ * hosted store cannot drift. This server gained the cycle guard in that move:
+ * it previously let a cycle through to `validateBundle`, which caught it as a
+ * `flow-cycle` finding rather than an up-front refusal.
  */
-function synthesizeComposesEdges(flow: Node, existingEdges: Edge[], projectId: string): Edge[] {
-  if (flow.species !== "flow") return [];
-  const entries = flow.metadata?.playlist?.entries;
-  if (!Array.isArray(entries) || entries.length === 0) return [];
-
-  const existingIds = new Set(existingEdges.map((edge) => edge.id));
-  const seen = new Set<string>();
-  const synthesized: Edge[] = [];
-  for (const refId of collectPlaylistNodeRefs(entries)) {
-    const id = edgeId(flow.id, refId);
-    if (existingIds.has(id) || seen.has(id)) continue;
-    seen.add(id);
-    synthesized.push({
-      id,
-      project_id: projectId,
-      source_id: flow.id,
-      target_id: refId,
-      edge_type: "composes",
-    });
+function mutate(graph: LoadedGraph, ops: MutationOp[]): MutationOutcome {
+  try {
+    return applyOps({ projectId: graph.project.id, nodes: graph.nodes, edges: graph.edges }, ops);
+  } catch (err) {
+    if (err instanceof MutationError) throw new ToolError(err.message);
+    throw err;
   }
-  return synthesized;
 }
 
 /** Release list for `get_changelog` with no version: newest first by each version's latest marker. */
@@ -423,20 +403,17 @@ export function buildCatalog(ctx: ToolContext): { tools: ToolDefinition[]; handl
           : {}),
       };
 
-      // A flow's playlist requires composes edges the validator would otherwise
-      // reject as missing (issue #263) — synthesize them into the same write.
-      const synthesizedEdges = synthesizeComposesEdges(node, graph.edges, graph.project.id);
-      const next =
-        synthesizedEdges.length > 0
-          ? { nodes: [...graph.nodes, node], edges: [...graph.edges, ...synthesizedEdges] }
-          : { nodes: [...graph.nodes, node] };
-
-      const result = persistMutation(ctx.bundlePath, graph.loaded, next, [
-        nodeCreatedInput(node),
-        ...synthesizedEdges.map(edgeAddedInput),
-      ]);
+      // applyOps folds in the composes edges a populated playlist requires, so
+      // a full flow still lands in one validated write (issue #263).
+      const outcome = mutate(graph, [{ op: "create_node", node }]);
+      const result = persistMutation(
+        ctx.bundlePath,
+        graph.loaded,
+        { nodes: outcome.nodes, edges: outcome.edges },
+        outcome.eventInputs,
+      );
       const { warnings, events } = unwrap(result);
-      return { node, edges: synthesizedEdges, events, warnings };
+      return { node, edges: outcome.synthesizedEdges, events, warnings };
     },
   );
 
@@ -479,25 +456,23 @@ export function buildCatalog(ctx: ToolContext): { tools: ToolDefinition[]; handl
 
       const graph = load(ctx);
       const current = findNode(graph.nodes, nodeId);
-      const inputs = diffNodeUpdate(current, patch);
-      if (inputs.length === 0) {
+
+      // applyOps derives no events for a patch that changes nothing, which is
+      // how a no-op stays a no-op: nothing is written and no journal line lands.
+      const outcome = mutate(graph, [{ op: "update_node", node_id: nodeId, patch }]);
+      if (outcome.eventInputs.length === 0) {
         return { node: current, events: [], note: "No-op patch — nothing changed, nothing written." };
       }
 
-      const updated: Node = { ...current, ...patch };
-      const nextNodes = graph.nodes.map((candidate) => (candidate.id === nodeId ? updated : candidate));
-      // Same composes-edge synthesis as create_node (issue #263): a playlist that
-      // now references a view/sub-flow gets its composes edge in this write.
-      const synthesizedEdges = synthesizeComposesEdges(updated, graph.edges, graph.project.id);
-      const next =
-        synthesizedEdges.length > 0 ? { nodes: nextNodes, edges: [...graph.edges, ...synthesizedEdges] } : { nodes: nextNodes };
-
-      const result = persistMutation(ctx.bundlePath, graph.loaded, next, [
-        ...inputs,
-        ...synthesizedEdges.map(edgeAddedInput),
-      ]);
+      const updated = outcome.nodes.find((candidate) => candidate.id === nodeId)!;
+      const result = persistMutation(
+        ctx.bundlePath,
+        graph.loaded,
+        { nodes: outcome.nodes, edges: outcome.edges },
+        outcome.eventInputs,
+      );
       const { warnings, events } = unwrap(result);
-      return { node: updated, edges: synthesizedEdges, events, warnings };
+      return { node: updated, edges: outcome.synthesizedEdges, events, warnings };
     },
   );
 
@@ -517,17 +492,15 @@ export function buildCatalog(ctx: ToolContext): { tools: ToolDefinition[]; handl
       const graph = load(ctx);
       const node = findNode(graph.nodes, nodeId);
 
-      const cascadedEdgeIds = graph.edges
-        .filter((edge) => edge.source_id === nodeId || edge.target_id === nodeId)
-        .map((edge) => edge.id);
-      const nextNodes = graph.nodes.filter((candidate) => candidate.id !== nodeId);
-      const nextEdges = graph.edges.filter((edge) => !cascadedEdgeIds.includes(edge.id));
-
-      const result = persistMutation(ctx.bundlePath, graph.loaded, { nodes: nextNodes, edges: nextEdges }, [
-        nodeDeletedInput(nodeId),
-      ]);
+      const outcome = mutate(graph, [{ op: "delete_node", node_id: nodeId }]);
+      const result = persistMutation(
+        ctx.bundlePath,
+        graph.loaded,
+        { nodes: outcome.nodes, edges: outcome.edges },
+        outcome.eventInputs,
+      );
       const { warnings, events } = unwrap(result);
-      return { removed: node, cascadedEdgeIds, events, warnings };
+      return { removed: node, cascadedEdgeIds: outcome.cascadedEdgeIds, events, warnings };
     },
   );
 
@@ -560,13 +533,20 @@ export function buildCatalog(ctx: ToolContext): { tools: ToolDefinition[]; handl
         target_id: targetId,
         edge_type: edgeType,
       };
+      // applyOps treats re-adding an identical edge as a no-op (synthesis and an
+      // explicit create can legitimately race for the same composes edge). This
+      // tool is the explicit path, so it keeps saying so out loud.
       if (graph.edges.some((candidate) => candidate.id === edge.id)) {
         throw new ToolError(`Edge "${edge.id}" already exists.`);
       }
 
-      const result = persistMutation(ctx.bundlePath, graph.loaded, { edges: [...graph.edges, edge] }, [
-        edgeAddedInput(edge),
-      ]);
+      const outcome = mutate(graph, [{ op: "create_edge", edge }]);
+      const result = persistMutation(
+        ctx.bundlePath,
+        graph.loaded,
+        { nodes: outcome.nodes, edges: outcome.edges },
+        outcome.eventInputs,
+      );
       const { warnings, events } = unwrap(result);
       return { edge, events, warnings };
     },
@@ -589,10 +569,13 @@ export function buildCatalog(ctx: ToolContext): { tools: ToolDefinition[]; handl
       const edge = graph.edges.find((candidate) => candidate.id === edgeIdArg);
       if (!edge) throw new ToolError(`No edge with id "${edgeIdArg}".`);
 
-      const nextEdges = graph.edges.filter((candidate) => candidate.id !== edgeIdArg);
-      const result = persistMutation(ctx.bundlePath, graph.loaded, { edges: nextEdges }, [
-        edgeRemovedInput(edgeIdArg),
-      ]);
+      const outcome = mutate(graph, [{ op: "delete_edge", edge_id: edgeIdArg }]);
+      const result = persistMutation(
+        ctx.bundlePath,
+        graph.loaded,
+        { nodes: outcome.nodes, edges: outcome.edges },
+        outcome.eventInputs,
+      );
       const { warnings, events } = unwrap(result);
       return { removed: edge, events, warnings };
     },

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -12,3 +12,4 @@ export * from "./projections";
 export * from "./maps";
 export * from "./emit";
 export * from "./derive";
+export * from "./mutate";

--- a/packages/schema/src/mutate.ts
+++ b/packages/schema/src/mutate.ts
@@ -1,0 +1,333 @@
+/**
+ * Mutation semantics — what a graph edit *means*, independent of where it is
+ * stored (issue: hosted graph, slice 2).
+ *
+ * Before this module the same semantics existed twice and were about to exist
+ * three times: `lib/data/local-provider.ts` (Dexie), `packages/mcp/src/tools.ts`
+ * (files on disk), and next the hosted Postgres store. They had already drifted
+ * — the app carried a flow-cycle guard the MCP server lacked, and the MCP server
+ * carried composes-edge synthesis the app performed by hand in its playlist
+ * editor. One definition means every writer inherits every invariant.
+ *
+ * SCOPE, deliberately narrow: this computes the next graph and the journal
+ * events that describe the change. It does NOT validate and it does NOT persist.
+ * `validateBundle` stays each writer's own gate — the MCP server and the hosted
+ * store run it before writing; the browser app does not, and this refactor does
+ * not change that. Keeping the two concerns apart is what lets this module stay
+ * pure, browser-safe, and testable without a store.
+ *
+ * Zod-free (type-only imports) like validate.ts / acceptance.ts / derive.ts, so
+ * it bundles into the standalone validator and the CLI without dragging zod in.
+ */
+
+import { edgeId } from "./id-gen";
+import { collectPlaylistNodeRefs, type PlaylistEntry } from "./playlist";
+import {
+  diffNodeUpdate,
+  edgeAddedInput,
+  edgeRemovedInput,
+  nodeCreatedInput,
+  nodeDeletedInput,
+  type EventInput,
+} from "./derive";
+import type { Edge, Node } from "./bundle";
+
+/** The patchable surface of a node: never its identity, never its project. */
+export type NodePatch = Partial<Omit<Node, "id" | "project_id">>;
+
+export type MutationOp =
+  | { op: "create_node"; node: Node }
+  | { op: "update_node"; node_id: string; patch: NodePatch }
+  | { op: "delete_node"; node_id: string }
+  | { op: "delete_nodes"; node_ids: readonly string[] }
+  | { op: "create_edge"; edge: Edge }
+  | { op: "delete_edge"; edge_id: string };
+
+export type MutationErrorCode =
+  | "node_not_found"
+  | "edge_not_found"
+  | "duplicate_node"
+  | "edge_type_conflict"
+  | "playlist_cycle";
+
+/**
+ * A refused mutation. Carries a machine-readable `code` so each writer can map
+ * it onto its own error shape (the MCP server's `ToolError`, an HTTP status)
+ * without string-matching a message.
+ */
+export class MutationError extends Error {
+  readonly code: MutationErrorCode;
+  /** The node or edge id the refusal is about, when there is one. */
+  readonly subjectId?: string;
+
+  constructor(code: MutationErrorCode, message: string, subjectId?: string) {
+    super(message);
+    this.name = "MutationError";
+    this.code = code;
+    this.subjectId = subjectId;
+  }
+}
+
+/** The graph a mutation applies to. */
+export interface MutationInput {
+  projectId: string;
+  nodes: readonly Node[];
+  edges: readonly Edge[];
+}
+
+export interface MutationOutcome {
+  nodes: Node[];
+  edges: Edge[];
+  /** Events describing the change, unstamped — pass to `toJournalEvents(…, actor)`. */
+  eventInputs: EventInput[];
+  /** `composes` edges added to keep a flow's playlist coherent. */
+  synthesizedEdges: Edge[];
+  /** Edge ids removed as a cascade of a node deletion (never separately evented). */
+  cascadedEdgeIds: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Invariant helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether adding `candidateId` to `flowId`'s playlist would close a loop.
+ *
+ * Previously `lib/utils/cycle.ts`, app-only. The MCP server had no equivalent
+ * and relied on `validateBundle`'s `flow-cycle` rule catching it after the fact;
+ * now both refuse the mutation up front, with the same message.
+ */
+export function wouldCreateCycle(
+  flowId: string,
+  candidateId: string,
+  allNodes: readonly Node[],
+): boolean {
+  if (candidateId === flowId) return true;
+
+  const nodesById = new Map(allNodes.map((node) => [node.id, node]));
+  const candidate = nodesById.get(candidateId);
+  if (!candidate || candidate.species !== "flow") return false;
+
+  const visited = new Set<string>();
+  const stack = [candidateId];
+
+  while (stack.length > 0) {
+    const currentFlowId = stack.pop();
+    if (!currentFlowId || visited.has(currentFlowId)) continue;
+    visited.add(currentFlowId);
+
+    const currentFlow = nodesById.get(currentFlowId);
+    if (!currentFlow || currentFlow.species !== "flow") continue;
+
+    const entries = currentFlow.metadata?.playlist?.entries;
+    if (!Array.isArray(entries)) continue;
+
+    const referenced = collectPlaylistNodeRefs(entries as PlaylistEntry[]);
+    if (referenced.includes(flowId)) return true;
+    for (const refId of referenced) {
+      if (!visited.has(refId)) stack.push(refId);
+    }
+  }
+
+  return false;
+}
+
+/**
+ * The `composes` edges a flow's playlist requires but that do not exist yet
+ * (docs/spec/mcp.md § Write Path — Playlist composition).
+ *
+ * Without this, a flow cannot be created with a populated playlist in a single
+ * validated mutation (issue #263): `validateBundle`'s `playlist-composes-
+ * coherence` rule demands a `composes` edge for every referenced view/sub-flow,
+ * but an edge cannot be added before the flow node exists — a deadlock no call
+ * ordering escapes. Edges that already exist are left untouched, and a repeated
+ * reference yields one edge.
+ */
+export function synthesizeComposesEdges(
+  flow: Node,
+  existingEdges: readonly Edge[],
+  projectId: string,
+): Edge[] {
+  if (flow.species !== "flow") return [];
+  const entries = flow.metadata?.playlist?.entries;
+  if (!Array.isArray(entries) || entries.length === 0) return [];
+
+  const existingIds = new Set(existingEdges.map((edge) => edge.id));
+  const seen = new Set<string>();
+  const synthesized: Edge[] = [];
+
+  for (const refId of collectPlaylistNodeRefs(entries as PlaylistEntry[])) {
+    const id = edgeId(flow.id, refId);
+    if (existingIds.has(id) || seen.has(id)) continue;
+    seen.add(id);
+    synthesized.push({
+      id,
+      project_id: projectId,
+      source_id: flow.id,
+      target_id: refId,
+      edge_type: "composes",
+    });
+  }
+  return synthesized;
+}
+
+/** Guard every sub-flow a playlist references against closing a loop. */
+function assertNoPlaylistCycle(flow: Node, nextNodes: readonly Node[]): void {
+  const entries = flow.metadata?.playlist?.entries;
+  if (!Array.isArray(entries)) return;
+  for (const candidateId of collectPlaylistNodeRefs(entries as PlaylistEntry[])) {
+    if (wouldCreateCycle(flow.id, candidateId, nextNodes)) {
+      throw new MutationError(
+        "playlist_cycle",
+        `Cannot add Flow ${candidateId}: it would create a circular reference.`,
+        candidateId,
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// applyOps
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply `ops` in order to a graph, returning the next graph plus the journal
+ * events the change implies. Pure: the inputs are never mutated.
+ *
+ * Ops compose — a later op sees the results of earlier ones — which is what
+ * lets a caller create a node and its edge as ONE atomic unit. That is the
+ * point of batching: today `app/project/[id]/acceptances/page.tsx` creates an
+ * acceptance node, then a `covers` edge, and hand-rolls a rollback of the node
+ * when the edge fails, because it has no way to ask for both at once.
+ *
+ * Throws {@link MutationError} on a refused op, leaving the caller's graph
+ * untouched (nothing is written until the caller persists the result).
+ */
+export function applyOps(input: MutationInput, ops: readonly MutationOp[]): MutationOutcome {
+  let nodes: Node[] = [...input.nodes];
+  let edges: Edge[] = [...input.edges];
+  const eventInputs: EventInput[] = [];
+  const synthesizedEdges: Edge[] = [];
+  const cascadedEdgeIds: string[] = [];
+
+  /** Fold synthesized composes edges for `flow` into the working graph. */
+  const foldSynthesized = (flow: Node): void => {
+    const created = synthesizeComposesEdges(flow, edges, input.projectId);
+    if (created.length === 0) return;
+    edges = [...edges, ...created];
+    synthesizedEdges.push(...created);
+    eventInputs.push(...created.map(edgeAddedInput));
+  };
+
+  for (const op of ops) {
+    switch (op.op) {
+      case "create_node": {
+        if (nodes.some((candidate) => candidate.id === op.node.id)) {
+          throw new MutationError("duplicate_node", `Node "${op.node.id}" already exists.`, op.node.id);
+        }
+        nodes = [...nodes, op.node];
+        assertNoPlaylistCycle(op.node, nodes);
+        eventInputs.push(nodeCreatedInput(op.node));
+        foldSynthesized(op.node);
+        break;
+      }
+
+      case "update_node": {
+        const index = nodes.findIndex((candidate) => candidate.id === op.node_id);
+        if (index === -1) {
+          throw new MutationError("node_not_found", `Node ${op.node_id} not found`, op.node_id);
+        }
+        const current = nodes[index];
+        const updated: Node = { ...current, ...op.patch };
+
+        const nextNodes = [...nodes];
+        nextNodes[index] = updated;
+        // Guarded BEFORE any event is derived, so a refused update emits nothing.
+        if (updated.species === "flow") assertNoPlaylistCycle(updated, nextNodes);
+
+        // A no-op patch produces no events and no synthesis — callers rely on
+        // this to skip a write entirely.
+        const inputs = diffNodeUpdate(current, op.patch);
+        nodes = nextNodes;
+        eventInputs.push(...inputs);
+        if (inputs.length > 0) foldSynthesized(updated);
+        break;
+      }
+
+      case "delete_node": {
+        if (!nodes.some((candidate) => candidate.id === op.node_id)) {
+          throw new MutationError("node_not_found", `Node ${op.node_id} not found`, op.node_id);
+        }
+        nodes = nodes.filter((candidate) => candidate.id !== op.node_id);
+        // The journal's node.deleted IMPLIES the edge cascade, so cascaded edges
+        // get NO edge.removed of their own (docs/spec/journal.md:71).
+        for (const edge of edges) {
+          if (edge.source_id === op.node_id || edge.target_id === op.node_id) {
+            cascadedEdgeIds.push(edge.id);
+          }
+        }
+        edges = edges.filter(
+          (edge) => edge.source_id !== op.node_id && edge.target_id !== op.node_id,
+        );
+        eventInputs.push(nodeDeletedInput(op.node_id));
+        break;
+      }
+
+      case "delete_nodes": {
+        // Only ids actually present are deleted and evented, so a node.deleted
+        // never references a node that was never there.
+        const present = new Set(
+          nodes.filter((candidate) => op.node_ids.includes(candidate.id)).map((n) => n.id),
+        );
+        if (present.size === 0) break;
+        nodes = nodes.filter((candidate) => !present.has(candidate.id));
+        for (const edge of edges) {
+          if (present.has(edge.source_id) || present.has(edge.target_id)) {
+            cascadedEdgeIds.push(edge.id);
+          }
+        }
+        edges = edges.filter(
+          (edge) => !present.has(edge.source_id) && !present.has(edge.target_id),
+        );
+        for (const id of present) eventInputs.push(nodeDeletedInput(id));
+        break;
+      }
+
+      case "create_edge": {
+        // Enforce the `e-{source}-{target}` convention at the seam, so any edge
+        // creation stays conformant regardless of the id the caller supplied
+        // (issue #215, docs/spec/bundle-format.md § Identifier Conventions).
+        const edge: Edge = { ...op.edge, id: edgeId(op.edge.source_id, op.edge.target_id) };
+        const existing = edges.find((candidate) => candidate.id === edge.id);
+        if (existing) {
+          // Idempotent by design: synthesis and an explicit create can race for
+          // the same composes edge (the playlist editor adds the entry and the
+          // edge together). Re-creating an identical edge is a no-op; only a
+          // DIFFERENT edge_type on the same endpoints is a real conflict.
+          if (existing.edge_type !== edge.edge_type) {
+            throw new MutationError(
+              "edge_type_conflict",
+              `Edge "${edge.id}" already exists as "${existing.edge_type}", cannot re-add as "${edge.edge_type}".`,
+              edge.id,
+            );
+          }
+          break;
+        }
+        edges = [...edges, edge];
+        eventInputs.push(edgeAddedInput(edge));
+        break;
+      }
+
+      case "delete_edge": {
+        if (!edges.some((candidate) => candidate.id === op.edge_id)) {
+          throw new MutationError("edge_not_found", `Edge ${op.edge_id} not found`, op.edge_id);
+        }
+        edges = edges.filter((candidate) => candidate.id !== op.edge_id);
+        eventInputs.push(edgeRemovedInput(op.edge_id));
+        break;
+      }
+    }
+  }
+
+  return { nodes, edges, eventInputs, synthesizedEdges, cascadedEdgeIds };
+}

--- a/scripts/generate/load-schema-package.js
+++ b/scripts/generate/load-schema-package.js
@@ -16,12 +16,28 @@ const SCHEMA_DIR = path.join(__dirname, "..", "..", "packages", "schema");
 const SRC_DIR = path.join(SCHEMA_DIR, "src");
 const BUILD_DIR = path.join(SCHEMA_DIR, ".generate-build");
 
-const MODULES = ["ids", "id-gen", "enums", "playlist", "journal", "journal-events", "bundle", "validate", "acceptance", "parse", "serialize", "projections", "maps", "emit", "derive", "index"];
+/**
+ * Every module in packages/schema/src, discovered rather than listed.
+ *
+ * This used to be a hardcoded array, which meant adding a source file to the
+ * schema package silently broke the generators with a `Cannot find module`
+ * from inside the build dir — the list was a third copy of the same knowledge
+ * (tests/schema/load-schema.js holds another). Each file is transpiled
+ * independently and `require` resolves at runtime, so order does not matter.
+ */
+function schemaModules() {
+  return fs
+    .readdirSync(SRC_DIR)
+    .filter((name) => name.endsWith(".ts") && !name.endsWith(".d.ts"))
+    .map((name) => name.slice(0, -3));
+}
 
 function loadSchemaPackage() {
   fs.rmSync(BUILD_DIR, { recursive: true, force: true });
   fs.mkdirSync(BUILD_DIR, { recursive: true });
   fs.writeFileSync(path.join(BUILD_DIR, "package.json"), JSON.stringify({ type: "commonjs" }));
+
+  const MODULES = schemaModules();
 
   for (const name of MODULES) {
     const source = fs.readFileSync(path.join(SRC_DIR, `${name}.ts`), "utf8");

--- a/tests/data/load-local-provider.js
+++ b/tests/data/load-local-provider.js
@@ -132,10 +132,12 @@ function loadLocalProvider() {
   // db.js — hand-written fake (FAKE_DB_SOURCE above).
   fs.writeFileSync(path.join(BUILD_DIR, "db.js"), FAKE_DB_SOURCE);
 
-  // cycle.js — transpiled as-is; only `import type` deps, so no rewrite needed.
+  // cycle.js — now a thin re-export of @arkaik/schema's wouldCreateCycle (the
+  // implementation moved into packages/schema/src/mutate.ts so every writer
+  // shares it), so its schema require needs rewriting like the others.
   fs.writeFileSync(
     path.join(BUILD_DIR, "cycle.js"),
-    transpile(path.join(ROOT, "lib", "utils", "cycle.ts"), "cycle.ts"),
+    rewriteSchemaRequire(transpile(path.join(ROOT, "lib", "utils", "cycle.ts"), "cycle.ts")),
   );
 
   // emit-events.js — transpiled, @arkaik/schema require rewritten to the real build.

--- a/tests/schema/load-schema.js
+++ b/tests/schema/load-schema.js
@@ -14,9 +14,21 @@ const SCHEMA_DIR = path.join(__dirname, "..", "..", "packages", "schema");
 const SRC_DIR = path.join(SCHEMA_DIR, "src");
 const BUILD_DIR = path.join(SCHEMA_DIR, ".test-build");
 
-// Order does not matter for output — CommonJS resolves requires lazily — but we
-// transpile every module the entrypoint depends on.
-const MODULES = ["ids", "id-gen", "enums", "playlist", "journal", "journal-events", "bundle", "validate", "acceptance", "parse", "serialize", "projections", "maps", "emit", "derive", "index"];
+/**
+ * Every module in packages/schema/src, discovered rather than listed. Order does
+ * not matter — CommonJS resolves requires lazily.
+ *
+ * This was a hardcoded array, so adding a source file to the schema package
+ * broke every suite here with a `Cannot find module` raised from inside the
+ * build dir, far from the actual cause. scripts/generate/load-schema-package.js
+ * had the same list and the same failure.
+ */
+function schemaModules() {
+  return fs
+    .readdirSync(SRC_DIR)
+    .filter((name) => name.endsWith(".ts") && !name.endsWith(".d.ts"))
+    .map((name) => name.slice(0, -3));
+}
 
 function loadSchema() {
   fs.rmSync(BUILD_DIR, { recursive: true, force: true });
@@ -25,6 +37,8 @@ function loadSchema() {
   // packages/schema is "type": "module"; mark the CJS output dir accordingly so
   // the transpiled `.js` files are loaded as CommonJS.
   fs.writeFileSync(path.join(BUILD_DIR, "package.json"), JSON.stringify({ type: "commonjs" }));
+
+  const MODULES = schemaModules();
 
   for (const name of MODULES) {
     const source = fs.readFileSync(path.join(SRC_DIR, `${name}.ts`), "utf8");

--- a/tests/schema/mutate.test.js
+++ b/tests/schema/mutate.test.js
@@ -1,0 +1,289 @@
+#!/usr/bin/env node
+
+/**
+ * Unit tests for the shared mutation core (packages/schema/src/mutate.ts).
+ *
+ * `applyOps` is where the app, the MCP server, and the hosted store now agree on
+ * what a graph edit means. These tests pin the invariants that used to live in
+ * only one of them:
+ *   - composes-edge synthesis (was MCP-only)
+ *   - the flow-cycle guard (was app-only)
+ *   - edge-id normalization and the delete cascade
+ *   - batch atomicity: a refusal partway through leaves the caller's graph alone
+ *
+ * Pure functions over plain objects — no store, no IndexedDB, no filesystem.
+ */
+
+const { loadSchema } = require("./load-schema");
+
+let failures = 0;
+function check(name, cond, detail) {
+  if (cond) {
+    console.log(`PASS: ${name}`);
+  } else {
+    failures++;
+    console.log(`FAIL: ${name}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+const PROJECT = "p1";
+
+function node(id, species, extra = {}) {
+  return {
+    id,
+    project_id: PROJECT,
+    species,
+    title: id,
+    status: "idea",
+    platforms: ["web"],
+    ...extra,
+  };
+}
+
+function flowWithPlaylist(id, refIds) {
+  return node(id, "flow", {
+    metadata: {
+      playlist: {
+        entries: refIds.map((refId) =>
+          refId.startsWith("F-") ? { type: "flow", flow_id: refId } : { type: "view", view_id: refId },
+        ),
+      },
+    },
+  });
+}
+
+function graph(nodes = [], edges = []) {
+  return { projectId: PROJECT, nodes, edges };
+}
+
+function main() {
+  const schema = loadSchema();
+  const { applyOps, MutationError, wouldCreateCycle, synthesizeComposesEdges } = schema;
+
+  // --- create_node ---------------------------------------------------------
+  {
+    const out = applyOps(graph(), [{ op: "create_node", node: node("V-a", "view") }]);
+    check("create_node appends the node", out.nodes.length === 1 && out.nodes[0].id === "V-a");
+    check("create_node emits node.created", out.eventInputs.length === 1 && out.eventInputs[0].type === "node.created");
+    check("create_node synthesizes nothing for a view", out.synthesizedEdges.length === 0);
+  }
+  {
+    let threw = null;
+    try {
+      applyOps(graph([node("V-a", "view")]), [{ op: "create_node", node: node("V-a", "view") }]);
+    } catch (err) {
+      threw = err;
+    }
+    check("create_node refuses a duplicate id", threw instanceof MutationError && threw.code === "duplicate_node");
+  }
+
+  // --- composes synthesis (was MCP-only) -----------------------------------
+  {
+    const out = applyOps(graph([node("V-a", "view"), node("V-b", "view")]), [
+      { op: "create_node", node: flowWithPlaylist("F-x", ["V-a", "V-b"]) },
+    ]);
+    check("a populated flow lands in one op", out.nodes.length === 3);
+    check("one composes edge per playlist ref", out.synthesizedEdges.length === 2, String(out.synthesizedEdges.length));
+    check(
+      "synthesized edges are composes flow→ref",
+      out.synthesizedEdges.every((e) => e.edge_type === "composes" && e.source_id === "F-x"),
+    );
+    check(
+      "each synthesized edge emits edge.added",
+      out.eventInputs.filter((e) => e.type === "edge.added").length === 2,
+    );
+  }
+  {
+    // A repeated reference must not produce two identical edges.
+    const out = applyOps(graph([node("V-a", "view")]), [
+      { op: "create_node", node: flowWithPlaylist("F-x", ["V-a", "V-a"]) },
+    ]);
+    check("a repeated playlist ref yields one edge", out.synthesizedEdges.length === 1);
+  }
+  {
+    // An edge that already exists is left alone.
+    const existing = {
+      id: "e-F-x-V-a",
+      project_id: PROJECT,
+      source_id: "F-x",
+      target_id: "V-a",
+      edge_type: "composes",
+    };
+    const out = applyOps(graph([node("V-a", "view"), node("F-x", "flow")], [existing]), [
+      { op: "update_node", node_id: "F-x", patch: flowWithPlaylist("F-x", ["V-a"]).metadata ? { metadata: flowWithPlaylist("F-x", ["V-a"]).metadata } : {} },
+    ]);
+    check("an existing composes edge is not duplicated", out.edges.length === 1, String(out.edges.length));
+  }
+
+  // --- cycle guard (was app-only) ------------------------------------------
+  {
+    check(
+      "wouldCreateCycle catches a direct self-reference",
+      wouldCreateCycle("F-x", "F-x", [node("F-x", "flow")]) === true,
+    );
+    const nodes = [flowWithPlaylist("F-a", ["F-b"]), flowWithPlaylist("F-b", [])];
+    check("wouldCreateCycle catches an indirect loop", wouldCreateCycle("F-b", "F-a", nodes) === true);
+    check("wouldCreateCycle allows an acyclic add", wouldCreateCycle("F-a", "F-b", nodes) === false);
+  }
+  {
+    let threw = null;
+    try {
+      applyOps(graph([flowWithPlaylist("F-a", ["F-b"]), node("F-b", "flow")]), [
+        { op: "update_node", node_id: "F-b", patch: { metadata: { playlist: { entries: [{ type: "flow", flow_id: "F-a" }] } } } },
+      ]);
+    } catch (err) {
+      threw = err;
+    }
+    check(
+      "applyOps refuses a playlist cycle (the MCP server's new guard)",
+      threw instanceof MutationError && threw.code === "playlist_cycle",
+      threw && threw.message,
+    );
+  }
+
+  // --- update_node ---------------------------------------------------------
+  {
+    const out = applyOps(graph([node("V-a", "view")]), [
+      { op: "update_node", node_id: "V-a", patch: { status: "live" } },
+    ]);
+    check("update_node applies the patch", out.nodes[0].status === "live");
+    check(
+      "a status change emits node.status_changed",
+      out.eventInputs.some((e) => e.type === "node.status_changed"),
+    );
+  }
+  {
+    const out = applyOps(graph([node("V-a", "view")]), [
+      { op: "update_node", node_id: "V-a", patch: { status: "idea" } },
+    ]);
+    check("a no-op patch emits nothing", out.eventInputs.length === 0);
+  }
+  {
+    let threw = null;
+    try {
+      applyOps(graph(), [{ op: "update_node", node_id: "V-missing", patch: { status: "live" } }]);
+    } catch (err) {
+      threw = err;
+    }
+    check("update_node refuses an unknown node", threw instanceof MutationError && threw.code === "node_not_found");
+  }
+
+  // --- delete cascade ------------------------------------------------------
+  {
+    const edges = [
+      { id: "e-F-x-V-a", project_id: PROJECT, source_id: "F-x", target_id: "V-a", edge_type: "composes" },
+      { id: "e-V-a-DM-z", project_id: PROJECT, source_id: "V-a", target_id: "DM-z", edge_type: "displays" },
+    ];
+    const out = applyOps(graph([node("V-a", "view"), node("F-x", "flow"), node("DM-z", "data-model")], edges), [
+      { op: "delete_node", node_id: "V-a" },
+    ]);
+    check("delete_node removes the node", out.nodes.every((n) => n.id !== "V-a"));
+    check("delete_node cascades both attached edges", out.edges.length === 0);
+    check("the cascade is reported", out.cascadedEdgeIds.length === 2);
+    check(
+      "the cascade emits node.deleted ONLY (journal.md:71)",
+      out.eventInputs.length === 1 && out.eventInputs[0].type === "node.deleted",
+      JSON.stringify(out.eventInputs.map((e) => e.type)),
+    );
+  }
+  {
+    const out = applyOps(graph([node("V-a", "view"), node("V-b", "view")]), [
+      { op: "delete_nodes", node_ids: ["V-a", "V-missing"] },
+    ]);
+    check("delete_nodes ignores ids that are not present", out.nodes.length === 1 && out.nodes[0].id === "V-b");
+    check("delete_nodes events name only real deletions", out.eventInputs.length === 1);
+  }
+
+  // --- edges ---------------------------------------------------------------
+  {
+    const out = applyOps(graph([node("V-a", "view"), node("DM-z", "data-model")]), [
+      {
+        op: "create_edge",
+        edge: { id: "whatever-the-caller-said", project_id: PROJECT, source_id: "V-a", target_id: "DM-z", edge_type: "displays" },
+      },
+    ]);
+    check("create_edge normalizes the id to e-{source}-{target}", out.edges[0].id === "e-V-a-DM-z", out.edges[0].id);
+  }
+  {
+    const existing = { id: "e-V-a-DM-z", project_id: PROJECT, source_id: "V-a", target_id: "DM-z", edge_type: "displays" };
+    const out = applyOps(graph([node("V-a", "view"), node("DM-z", "data-model")], [existing]), [
+      { op: "create_edge", edge: { ...existing } },
+    ]);
+    check("re-creating an identical edge is a no-op", out.edges.length === 1 && out.eventInputs.length === 0);
+
+    let threw = null;
+    try {
+      applyOps(graph([node("V-a", "view"), node("DM-z", "data-model")], [existing]), [
+        { op: "create_edge", edge: { ...existing, edge_type: "queries" } },
+      ]);
+    } catch (err) {
+      threw = err;
+    }
+    check(
+      "the same endpoints with a different edge_type IS a conflict",
+      threw instanceof MutationError && threw.code === "edge_type_conflict",
+    );
+  }
+  {
+    let threw = null;
+    try {
+      applyOps(graph(), [{ op: "delete_edge", edge_id: "e-nope" }]);
+    } catch (err) {
+      threw = err;
+    }
+    check("delete_edge refuses an unknown edge", threw instanceof MutationError && threw.code === "edge_not_found");
+  }
+
+  // --- batching (the reason applyMutations exists) -------------------------
+  {
+    const before = graph([node("V-anchor", "view")]);
+    const out = applyOps(before, [
+      { op: "create_node", node: node("AC-x", "acceptance") },
+      {
+        op: "create_edge",
+        edge: { id: "", project_id: PROJECT, source_id: "AC-x", target_id: "V-anchor", edge_type: "covers" },
+      },
+    ]);
+    check("a batch sees its own earlier ops", out.nodes.length === 2 && out.edges.length === 1);
+    check("the batch emits both events", out.eventInputs.length === 2);
+  }
+  {
+    // The whole point: a refusal partway through must not leave half applied.
+    const nodes = [node("V-a", "view")];
+    const edges = [];
+    const before = graph(nodes, edges);
+    let threw = null;
+    try {
+      applyOps(before, [
+        { op: "create_node", node: node("V-new", "view") },
+        { op: "delete_edge", edge_id: "e-nope" },
+      ]);
+    } catch (err) {
+      threw = err;
+    }
+    check("a refused batch throws", threw instanceof MutationError);
+    check("the caller's nodes are untouched by a refused batch", nodes.length === 1 && nodes[0].id === "V-a");
+    check("the caller's edges are untouched by a refused batch", edges.length === 0);
+  }
+
+  // --- purity --------------------------------------------------------------
+  {
+    const nodes = [node("V-a", "view")];
+    const edges = [];
+    applyOps(graph(nodes, edges), [{ op: "create_node", node: node("V-b", "view") }]);
+    check("applyOps never mutates the input arrays", nodes.length === 1 && edges.length === 0);
+  }
+  {
+    const flow = flowWithPlaylist("F-x", ["V-a"]);
+    const synthesized = synthesizeComposesEdges(flow, [], PROJECT);
+    check("synthesizeComposesEdges is exported and pure", synthesized.length === 1 && synthesized[0].edge_type === "composes");
+  }
+
+  if (failures > 0) {
+    console.error(`\n${failures} check(s) failed.`);
+    process.exit(1);
+  }
+  console.log("\nAll mutate-core checks passed.");
+}
+
+main();


### PR DESCRIPTION
## Summary

Mutation semantics lived in **two** places and were about to live in **three**: `lib/data/local-provider.ts` (Dexie), `packages/mcp/src/tools.ts` (files on disk), and next the hosted Postgres store.

They had already drifted. Each writer held roughly half the invariants:

| Invariant | App | MCP server |
|---|---|---|
| Flow-cycle guard | ✅ | ❌ (relied on `validateBundle` catching it after the fact) |
| Composes-edge synthesis | ❌ (done by hand in the playlist editor) | ✅ |
| Edge-id normalization | ✅ | ✅ |
| Delete cascade | ✅ | ✅ |

`packages/schema/src/mutate.ts` is now the single definition. `applyOps()` takes a graph plus a list of ops and returns the next graph and the journal events the change implies. Both writers call it, so both now get everything.

### Deliberately out of scope: validation

`applyOps` computes; it does **not** validate and does **not** persist. `validateBundle` stays each writer's own gate — the MCP server runs it before writing, the browser app still does not, and this refactor does not change that. Keeping the two concerns apart is what lets the module stay pure, browser-safe, and testable without a store.

That asymmetry is real and worth naming: today the app validates only on import/export. It closes on its own later, when hosted projects route through the server's validated write path — without changing local-first behavior or needing UI for pathed findings.

### The new capability: batching

Ops compose, so a caller can create a node and its edge as **one atomic unit**.

`app/project/[id]/acceptances/page.tsx` used to create the acceptance node, create the `covers` edge, and hand-roll a rollback of the node when the edge failed — a compensating delete that could itself fail and leave behind exactly the orphan it was meant to prevent. It is now a two-op batch. `DataProvider` gains `applyMutations`; the local provider runs it in one IndexedDB transaction, and a remote provider will send one request.

### Drive-by

`tests/schema/load-schema.js` and `scripts/generate/load-schema-package.js` both hardcoded the list of schema modules. Adding `mutate.ts` broke both with a `Cannot find module` raised from inside a build dir, far from the cause — the same knowledge in three places, and I hit it twice in one change. Both now read the directory.

## Verification

**Every existing suite passes unchanged — that is the refactor's proof:** `schema`, `acceptance`, `serialize`, `id-gen`, `refs`, `journal`, `maps`, `provider`, `sync`, `emit`, `emit-events`, `migrate`, `journal-projections`, `fixtures`, `delivery`, `journey-graph`, `spotlight`, `coverage`, `effective-status`, `pyramid`, `value-icons`, `acceptance-matrix`, `screenshot-size`, `mcp`, `cli`, `validate:seeds`.

Plus `tsc`, `lint` (0 errors), `next build`, and the generated-artifact drift gate.

New: **`tests/schema/mutate.test.js`** — 35 checks pinning each invariant now that it has one home. Notably that a refused batch leaves the caller's graph untouched, that `applyOps` never mutates its inputs, that a delete cascade emits `node.deleted` **only** (docs/spec/journal.md:71), and that re-creating an identical edge is a no-op while the same endpoints with a *different* `edge_type` is a real conflict.

No Lab Note: this is a pure refactor with no user-visible change. Labelled `no-lab-note`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
