### PR TITLE
feat(services): hosted graph projects — the store and its API (slice 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,8 @@ jobs:
         run: npm run test:auth
       - name: Token auth integration tests (mint/verify/revoke, scopes, owner isolation)
         run: npm run test:tokens
+      - name: Hosted graph API integration tests (atomicity, validator gate, owner scoping)
+        run: npm run test:graph
       - name: Synk API integration tests (authz isolation, dedupe, limits, retention)
         run: npm run test:synk
       - name: Synk client SyncManager tests (debounce, hash, status transitions)

--- a/app/api/graph/projects/[projectId]/edges/route.ts
+++ b/app/api/graph/projects/[projectId]/edges/route.ts
@@ -1,0 +1,8 @@
+import { getEdges } from "@/lib/services/graph/store";
+import { graphReadRoute } from "@/lib/services/graph/read-route";
+
+/** GET /api/graph/projects/{projectId}/edges — backs DataProvider.getEdges. */
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export const GET = graphReadRoute("edges", "edges", getEdges);

--- a/app/api/graph/projects/[projectId]/export/route.ts
+++ b/app/api/graph/projects/[projectId]/export/route.ts
@@ -1,0 +1,12 @@
+import { exportProject } from "@/lib/services/graph/store";
+import { graphReadRoute } from "@/lib/services/graph/read-route";
+
+/**
+ * GET /api/graph/projects/{projectId}/export — the full interchange bundle with
+ * its journal embedded. The escape hatch: a hosted project is always exportable
+ * to a file, so choosing hosting never means giving up the portable format.
+ */
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export const GET = graphReadRoute("export", "bundle", exportProject);

--- a/app/api/graph/projects/[projectId]/journal/route.ts
+++ b/app/api/graph/projects/[projectId]/journal/route.ts
@@ -1,0 +1,8 @@
+import { getJournal } from "@/lib/services/graph/store";
+import { graphReadRoute } from "@/lib/services/graph/read-route";
+
+/** GET /api/graph/projects/{projectId}/journal — events in server order. */
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export const GET = graphReadRoute("journal", "journal", getJournal);

--- a/app/api/graph/projects/[projectId]/mutations/route.ts
+++ b/app/api/graph/projects/[projectId]/mutations/route.ts
@@ -1,0 +1,135 @@
+import { getCaller, hasScope } from "@/lib/services/auth";
+import { servicesConfigured, servicesUnavailable } from "@/lib/services/db";
+import { applyMutation, getUserTier } from "@/lib/services/graph/store";
+import type { MutationOp } from "@arkaik/schema";
+
+/**
+ * POST /api/graph/projects/{projectId}/mutations — THE write path
+ * (docs/spec/services.md § Hosted Graph Projects → Write path).
+ *
+ * One endpoint taking a BATCH of typed ops, rather than a REST verb per entity:
+ *
+ *  - a batch is atomic, so "create the acceptance and the covers edge" cannot
+ *    half-apply — the failure mode that forced the app into a hand-rolled
+ *    rollback before `applyOps` existed;
+ *  - one validator gate runs over the finished graph, not once per verb, so an
+ *    intermediate state that is briefly invalid (a flow whose composes edges
+ *    are still being added) is never rejected;
+ *  - it mirrors the MCP tool catalog and the `DataProvider` interface exactly,
+ *    which is what lets a RemoteProvider and `arkaik-mcp --remote` share it.
+ *
+ * Optimistic concurrency: send `If-Match: "<version>"` to require that nothing
+ * moved since you read. Omit it to apply regardless. Correctness does not depend
+ * on it — the store takes a row lock either way — it is there so a client can
+ * notice that someone else changed the project under it.
+ */
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/** Ops accepted here, mirroring @arkaik/schema's MutationOp union. */
+const VALID_OPS = new Set([
+  "create_node",
+  "update_node",
+  "delete_node",
+  "delete_nodes",
+  "create_edge",
+  "delete_edge",
+]);
+
+/** Guard against an unbounded batch turning one request into a long lock hold. */
+const MAX_OPS = 500;
+
+function parseIfMatch(req: Request): string | undefined {
+  const header = req.headers.get("if-match");
+  if (!header) return undefined;
+  return header.trim().replace(/^"|"$/g, "");
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ projectId: string }> },
+): Promise<Response> {
+  if (!servicesConfigured()) return servicesUnavailable("Graph");
+
+  const caller = await getCaller(req);
+  if (!caller) return Response.json({ error: "unauthorized" }, { status: 401 });
+  if (!hasScope(caller, "graph:write")) {
+    return Response.json({ error: "insufficient_scope", required: "graph:write" }, { status: 403 });
+  }
+
+  const { projectId } = await params;
+
+  let body: { ops?: unknown };
+  try {
+    body = (await req.json()) as { ops?: unknown };
+  } catch {
+    return Response.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  if (!Array.isArray(body.ops) || body.ops.length === 0) {
+    return Response.json({ error: "invalid_ops", message: "`ops` must be a non-empty array." }, { status: 400 });
+  }
+  if (body.ops.length > MAX_OPS) {
+    return Response.json({ error: "too_many_ops", limit: MAX_OPS, actual: body.ops.length }, { status: 400 });
+  }
+  for (const op of body.ops) {
+    if (typeof op !== "object" || op === null || !VALID_OPS.has((op as { op?: string }).op ?? "")) {
+      return Response.json(
+        { error: "invalid_ops", message: `Each op must be one of: ${[...VALID_OPS].join(", ")}.` },
+        { status: 400 },
+      );
+    }
+  }
+
+  try {
+    const tier = await getUserTier(caller.userId);
+    const result = await applyMutation({
+      projectId,
+      ownerIds: caller.ownerIds,
+      ops: body.ops as MutationOp[],
+      // The audit trail records what acted, not just who: an agent's writes are
+      // distinguishable from the same person's edits in the browser.
+      actor: caller.via === "token" ? "arkaik-agent" : "arkaik-app",
+      tier,
+      expectedVersion: parseIfMatch(req),
+    });
+
+    if (result.ok) {
+      return Response.json(
+        {
+          version: result.version,
+          nodes: result.nodes,
+          edges: result.edges,
+          events: result.events,
+          warnings: result.warnings,
+        },
+        { status: 200, headers: { ETag: `"${result.version}"` } },
+      );
+    }
+
+    switch (result.reason) {
+      case "not_found":
+        return Response.json({ error: "not_found" }, { status: 404 });
+      case "conflict":
+        return Response.json(
+          { error: "version_conflict", version: result.version },
+          { status: 409, headers: { ETag: `"${result.version}"` } },
+        );
+      case "validation":
+        return Response.json({ error: "invalid_bundle", errors: result.errors }, { status: 422 });
+      case "mutation":
+        // A refused op (unknown node, duplicate id, playlist cycle) is a client
+        // error about the request, not about the stored graph — 422 with the
+        // machine-readable code from @arkaik/schema.
+        return Response.json({ error: "mutation_refused", code: result.code, message: result.message }, { status: 422 });
+      case "limit":
+        return Response.json(
+          { error: "limit_exceeded", limit: result.limit, actual: result.actual, tier: result.tier },
+          { status: 403 },
+        );
+    }
+  } catch (err) {
+    console.error("[graph] POST mutations failed:", err instanceof Error ? err.message : "unknown error");
+    return Response.json({ error: "internal_error", message: "Failed to apply mutations." }, { status: 500 });
+  }
+}

--- a/app/api/graph/projects/[projectId]/nodes/route.ts
+++ b/app/api/graph/projects/[projectId]/nodes/route.ts
@@ -1,0 +1,8 @@
+import { getNodes } from "@/lib/services/graph/store";
+import { graphReadRoute } from "@/lib/services/graph/read-route";
+
+/** GET /api/graph/projects/{projectId}/nodes — backs DataProvider.getNodes. */
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export const GET = graphReadRoute("nodes", "nodes", getNodes);

--- a/app/api/graph/projects/[projectId]/route.ts
+++ b/app/api/graph/projects/[projectId]/route.ts
@@ -1,0 +1,69 @@
+import { getCaller, hasScope } from "@/lib/services/auth";
+import { servicesConfigured, servicesUnavailable } from "@/lib/services/db";
+import { archiveProject, getProject } from "@/lib/services/graph/store";
+
+/**
+ * A single hosted project (db/migrations/008_graph_projects.sql).
+ *
+ * A project belonging to another owner is indistinguishable from one that does
+ * not exist — both 404 — so these endpoints cannot be used to probe for ids.
+ */
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/**
+ * GET — snapshot + version. The version is also returned as an `ETag`, which is
+ * what a client passes back as `If-Match` on a mutation to say "only if nothing
+ * moved since I read this".
+ */
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ projectId: string }> },
+): Promise<Response> {
+  if (!servicesConfigured()) return servicesUnavailable("Graph");
+
+  const caller = await getCaller(req);
+  if (!caller) return Response.json({ error: "unauthorized" }, { status: 401 });
+  if (!hasScope(caller, "graph:read")) {
+    return Response.json({ error: "insufficient_scope", required: "graph:read" }, { status: 403 });
+  }
+
+  const { projectId } = await params;
+
+  try {
+    const found = await getProject(projectId, caller.ownerIds);
+    if (!found) return Response.json({ error: "not_found" }, { status: 404 });
+    return Response.json(
+      { bundle: found.bundle, version: found.version },
+      { status: 200, headers: { ETag: `"${found.version}"` } },
+    );
+  } catch (err) {
+    console.error("[graph] GET project failed:", err instanceof Error ? err.message : "unknown error");
+    return Response.json({ error: "internal_error", message: "Failed to load project." }, { status: 500 });
+  }
+}
+
+/** DELETE — archive (soft). History is kept; the project leaves listings. */
+export async function DELETE(
+  req: Request,
+  { params }: { params: Promise<{ projectId: string }> },
+): Promise<Response> {
+  if (!servicesConfigured()) return servicesUnavailable("Graph");
+
+  const caller = await getCaller(req);
+  if (!caller) return Response.json({ error: "unauthorized" }, { status: 401 });
+  if (!hasScope(caller, "graph:write")) {
+    return Response.json({ error: "insufficient_scope", required: "graph:write" }, { status: 403 });
+  }
+
+  const { projectId } = await params;
+
+  try {
+    const archived = await archiveProject(projectId, caller.ownerIds);
+    if (!archived) return Response.json({ error: "not_found" }, { status: 404 });
+    return new Response(null, { status: 204 });
+  } catch (err) {
+    console.error("[graph] DELETE project failed:", err instanceof Error ? err.message : "unknown error");
+    return Response.json({ error: "internal_error", message: "Failed to archive project." }, { status: 500 });
+  }
+}

--- a/app/api/graph/projects/route.ts
+++ b/app/api/graph/projects/route.ts
@@ -1,0 +1,91 @@
+import { getCaller, hasScope } from "@/lib/services/auth";
+import { servicesConfigured, servicesUnavailable } from "@/lib/services/db";
+import { createProject, getUserTier, listProjects } from "@/lib/services/graph/store";
+
+/**
+ * Hosted graph projects — collection (docs/spec/services.md § Hosted Graph
+ * Projects; db/migrations/008_graph_projects.sql).
+ *
+ * `getCaller` accepts a browser session OR an agent's bearer token, so the app
+ * and a CLI reach the same store through one code path. Every query filters on
+ * `caller.ownerIds`; a token's list is exactly one owner, which is deliberately
+ * narrower than a session's.
+ *
+ * Node runtime for the `pg` driver; force-dynamic because every response
+ * depends on the caller.
+ */
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/** Import cap, mirroring Publik and the app's own (docs/spec/services.md). */
+const MAX_BUNDLE_BYTES = 5 * 1024 * 1024;
+
+/** GET /api/graph/projects — the caller's hosted projects. */
+export async function GET(req: Request): Promise<Response> {
+  if (!servicesConfigured()) return servicesUnavailable("Graph");
+
+  const caller = await getCaller(req);
+  if (!caller) return Response.json({ error: "unauthorized" }, { status: 401 });
+  if (!hasScope(caller, "graph:read")) {
+    return Response.json({ error: "insufficient_scope", required: "graph:read" }, { status: 403 });
+  }
+
+  try {
+    return Response.json({ projects: await listProjects(caller.ownerIds) }, { status: 200 });
+  } catch (err) {
+    console.error("[graph] GET projects failed:", err instanceof Error ? err.message : "unknown error");
+    return Response.json({ error: "internal_error", message: "Failed to list projects." }, { status: 500 });
+  }
+}
+
+/**
+ * POST /api/graph/projects — create a hosted project from a full bundle.
+ *
+ * The body is a `ProjectBundle`, so "create empty" and "import existing" are the
+ * same operation and neither can produce a project that has never been
+ * validated. The journal, if present, is stored verbatim.
+ */
+export async function POST(req: Request): Promise<Response> {
+  if (!servicesConfigured()) return servicesUnavailable("Graph");
+
+  const caller = await getCaller(req);
+  if (!caller) return Response.json({ error: "unauthorized" }, { status: 401 });
+  if (!hasScope(caller, "graph:write")) {
+    return Response.json({ error: "insufficient_scope", required: "graph:write" }, { status: 403 });
+  }
+
+  const raw = await req.text();
+  if (Buffer.byteLength(raw, "utf8") > MAX_BUNDLE_BYTES) {
+    return Response.json({ error: "payload_too_large", limit: MAX_BUNDLE_BYTES }, { status: 413 });
+  }
+
+  let bundle: unknown;
+  try {
+    bundle = JSON.parse(raw);
+  } catch {
+    return Response.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  try {
+    const tier = await getUserTier(caller.userId);
+    const result = await createProject({ ownerId: caller.ownerIds[0], tier, bundle });
+
+    if (!result.ok) {
+      if (result.reason === "validation") {
+        return Response.json({ error: "invalid_bundle", errors: result.errors }, { status: 422 });
+      }
+      if (result.reason === "limit") {
+        return Response.json(
+          { error: "limit_exceeded", limit: result.limit, actual: result.actual, tier: result.tier },
+          { status: 403 },
+        );
+      }
+      return Response.json({ error: "not_found" }, { status: 404 });
+    }
+
+    return Response.json({ id: result.id, version: result.version }, { status: 201 });
+  } catch (err) {
+    console.error("[graph] POST project failed:", err instanceof Error ? err.message : "unknown error");
+    return Response.json({ error: "internal_error", message: "Failed to create project." }, { status: 500 });
+  }
+}

--- a/db/migrations/008_graph_projects.sql
+++ b/db/migrations/008_graph_projects.sql
@@ -1,0 +1,71 @@
+-- 008_graph_projects.sql
+--
+-- Hosted product graphs: a project of record the app AND an agent both read and
+-- write (docs/spec/services.md § Hosted Graph Projects).
+--
+-- WHY NOT SYNK. Synk is a backup service and its schema says so: the primary key
+-- is (user_id, client_chosen_id), backups are an immutable chain pruned after 7
+-- days, and the tier cap is one project. Extending it into a mutable store would
+-- fight every one of those decisions. Synk and Publik are untouched by this
+-- migration and keep serving local-first projects; this is a separate store
+-- beside them, and the two never share a row.
+--
+-- SNAPSHOT + EVENT LOG, not normalized rows. The graph lives as one `jsonb`
+-- snapshot so `validateBundle`'s whole-graph rules — dangling edges, playlist
+-- coherence, flow cycles — keep working against exactly the shape they were
+-- written for, and so a format change never needs a Postgres migration. Every
+-- mutation also appends to `graph_events`, which is the audit trail and the
+-- substrate any future merge story would be built on.
+--
+-- The journal lives in its OWN table rather than inside the snapshot, mirroring
+-- the IndexedDB split in lib/data/db.ts: appends must not rewrite the graph.
+--
+-- Every statement uses IF NOT EXISTS so the file is safe to re-run by hand,
+-- independent of the `npm run db:migrate` bookkeeping. Plain Postgres: this file
+-- doubles as an Inkognito self-hosting setup script.
+
+-- One row per hosted project. `id` is server-owned and opaque (`prj_…`), unlike
+-- Synk's client-chosen id — two owners can hold projects whose *bundle* ids
+-- collide (both imported the same seed) without colliding here.
+create table if not exists graph_projects (
+  id             text        not null,
+  owner_id       text        not null references owners(id) on delete cascade,
+  -- The bundle's own project.id, kept for export fidelity and for `arkaik link`
+  -- to recognise a repo's working copy. Deliberately NOT unique.
+  bundle_id      text        not null,
+  title          text        not null,
+  -- The snapshot: project + nodes + edges, WITHOUT the journal (that is
+  -- graph_events). Verbatim, schema-validated on every write.
+  snapshot       jsonb       not null,
+  schema_version int         not null default 2,
+  entity_count   int         not null default 0,
+  -- Bumped on every accepted mutation. Clients send it back as an ETag/If-Match
+  -- to detect "someone else changed this while I was reading".
+  version        bigint      not null default 1,
+  created_at     timestamptz not null default now(),
+  updated_at     timestamptz not null default now(),
+  archived_at    timestamptz,
+  primary key (id)
+);
+
+-- Listing a caller's projects, and the owner-scoping filter every query applies.
+create index if not exists graph_projects_owner_idx on graph_projects (owner_id);
+
+-- The append-only journal. `id` is the event's own ULID (the same id the bundle
+-- carries when exported), so re-importing an exported bundle cannot duplicate
+-- history: the primary key rejects an event that is already stored.
+create table if not exists graph_events (
+  id         text        not null,
+  project_id text        not null references graph_projects(id) on delete cascade,
+  -- Server-assigned ordering. ULIDs sort lexicographically by creation time, but
+  -- two writers can mint events in the same millisecond; seq is the tiebreak and
+  -- the only ordering reads rely on.
+  seq        bigserial   not null,
+  event      jsonb       not null,
+  actor      text        not null,
+  created_at timestamptz not null default now(),
+  primary key (id)
+);
+
+-- Every read of a project's journal is "this project, in order".
+create index if not exists graph_events_project_seq_idx on graph_events (project_id, seq);

--- a/db/migrations/008_graph_projects.sql
+++ b/db/migrations/008_graph_projects.sql
@@ -51,9 +51,12 @@ create table if not exists graph_projects (
 -- Listing a caller's projects, and the owner-scoping filter every query applies.
 create index if not exists graph_projects_owner_idx on graph_projects (owner_id);
 
--- The append-only journal. `id` is the event's own ULID (the same id the bundle
--- carries when exported), so re-importing an exported bundle cannot duplicate
--- history: the primary key rejects an event that is already stored.
+-- The append-only journal. `id` is the event's own ULID — the id the bundle
+-- carries when exported — so it is unique per project but NOT globally: two
+-- owners importing the same bundle (the shipped `seed/pebbles.json` carries a
+-- journal) legitimately hold events with identical ids. The primary key is
+-- therefore composite. A global `primary key (id)` would make the second
+-- import collide and silently drop its entire history.
 create table if not exists graph_events (
   id         text        not null,
   project_id text        not null references graph_projects(id) on delete cascade,
@@ -64,7 +67,7 @@ create table if not exists graph_events (
   event      jsonb       not null,
   actor      text        not null,
   created_at timestamptz not null default now(),
-  primary key (id)
+  primary key (project_id, id)
 );
 
 -- Every read of a project's journal is "this project, in order".

--- a/lib/services/graph/read-route.ts
+++ b/lib/services/graph/read-route.ts
@@ -1,0 +1,43 @@
+import "server-only";
+
+import { getCaller, hasScope } from "@/lib/services/auth";
+import { servicesConfigured, servicesUnavailable } from "@/lib/services/db";
+
+/**
+ * The shared body of every read-only graph route (nodes, edges, journal,
+ * export). All four differ only in which loader they call and what key the
+ * result is returned under, so the guard chain — services configured, caller
+ * resolved, `graph:read` held, project owned — lives here once instead of being
+ * copy-pasted four times and drifting.
+ */
+export function graphReadRoute<T>(
+  label: string,
+  key: string,
+  load: (projectId: string, ownerIds: readonly string[]) => Promise<T | null>,
+) {
+  return async function GET(
+    req: Request,
+    { params }: { params: Promise<{ projectId: string }> },
+  ): Promise<Response> {
+    if (!servicesConfigured()) return servicesUnavailable("Graph");
+
+    const caller = await getCaller(req);
+    if (!caller) return Response.json({ error: "unauthorized" }, { status: 401 });
+    if (!hasScope(caller, "graph:read")) {
+      return Response.json({ error: "insufficient_scope", required: "graph:read" }, { status: 403 });
+    }
+
+    const { projectId } = await params;
+
+    try {
+      const result = await load(projectId, caller.ownerIds);
+      // null means "not yours or not there" — the same 404 either way, so this
+      // cannot be used to probe for project ids.
+      if (result === null) return Response.json({ error: "not_found" }, { status: 404 });
+      return Response.json({ [key]: result }, { status: 200 });
+    } catch (err) {
+      console.error(`[graph] GET ${label} failed:`, err instanceof Error ? err.message : "unknown error");
+      return Response.json({ error: "internal_error", message: `Failed to load ${label}.` }, { status: 500 });
+    }
+  };
+}

--- a/lib/services/graph/store.ts
+++ b/lib/services/graph/store.ts
@@ -1,0 +1,429 @@
+import "server-only";
+
+import { randomBytes } from "node:crypto";
+
+import {
+  MutationError,
+  applyOps,
+  parseBundle,
+  toJournalEvents,
+  validateBundle,
+  type Edge,
+  type JournalEvent,
+  type MutationOp,
+  type Node,
+  type Project,
+  type ProjectBundle,
+  type ValidationFinding,
+} from "@arkaik/schema";
+
+import { query, withTransaction } from "@/lib/services/db";
+import { getHostedLimitsForTier } from "@/lib/services/limits";
+
+/**
+ * The hosted graph store (db/migrations/008_graph_projects.sql).
+ *
+ * This is `packages/mcp/src/store.ts`'s `persistMutation` lifted into Postgres:
+ * same shared `applyOps` for the semantics, same `validateBundle` gate, same
+ * dual-write of snapshot + journal. What changes is the persistence target and
+ * the concurrency story.
+ *
+ * ── The write path, in order ────────────────────────────────────────────────
+ *  1. `select … for update` the project row, scoped to the caller's owners.
+ *  2. Apply the ops in memory via `applyOps` (@arkaik/schema).
+ *  3. Gate on `validateBundle`. Any error → the transaction rolls back and the
+ *     pathed findings come back to the caller. Nothing is written.
+ *  4. Write the snapshot, bump `version`, append the derived events.
+ *
+ * ── Concurrency ─────────────────────────────────────────────────────────────
+ * The row lock is what makes step 2 safe: two agents mutating the same project
+ * serialize, and neither can compute its next graph from a stale read. Mutations
+ * are small semantic ops rather than whole-bundle writes, so the lock is held
+ * briefly and contention is rare in practice.
+ *
+ * `version` is a separate, complementary mechanism: it is not needed for
+ * correctness (the lock covers that) but lets a client detect that the project
+ * changed under it. `expectedVersion` is optional — omit it for "apply
+ * regardless", pass it for "only if nothing moved".
+ *
+ * ── Authorization ───────────────────────────────────────────────────────────
+ * Every statement filters on `owner_id = any(ownerIds)`. A project belonging to
+ * someone else is indistinguishable from one that does not exist: both produce
+ * `not_found`, never `forbidden`, so the API cannot be used to probe for ids.
+ */
+
+export interface GraphProjectSummary {
+  id: string;
+  bundleId: string;
+  title: string;
+  entityCount: number;
+  version: string;
+  createdAt: string;
+  updatedAt: string;
+  archivedAt: string | null;
+}
+
+export type StoreFailure =
+  | { ok: false; reason: "not_found" }
+  | { ok: false; reason: "validation"; errors: ValidationFinding[] }
+  | { ok: false; reason: "mutation"; code: string; message: string }
+  | { ok: false; reason: "conflict"; version: string }
+  | { ok: false; reason: "limit"; limit: number; actual: number; tier: string };
+
+export interface MutationSuccess {
+  ok: true;
+  version: string;
+  nodes: Node[];
+  edges: Edge[];
+  events: JournalEvent[];
+  warnings: ValidationFinding[];
+}
+
+export type MutationResult = MutationSuccess | StoreFailure;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Server-owned project id: unguessable, non-sequential, `prj_`-prefixed. */
+export function generateProjectId(): string {
+  return `prj_${randomBytes(12).toString("base64url")}`;
+}
+
+interface SnapshotShape {
+  schema_version?: number;
+  project: Project;
+  nodes: Node[];
+  edges: Edge[];
+}
+
+function entityCount(nodes: readonly unknown[], edges: readonly unknown[]): number {
+  return nodes.length + edges.length;
+}
+
+/** Map an `applyOps` refusal onto a store failure, preserving its code. */
+function toMutationFailure(err: unknown): StoreFailure {
+  if (err instanceof MutationError) {
+    return { ok: false, reason: "mutation", code: err.code, message: err.message };
+  }
+  throw err;
+}
+
+function zodIssueToFinding(issue: { path: PropertyKey[]; code: string; message: string }): ValidationFinding {
+  return {
+    path: issue.path.map((p) => String(p)).join("."),
+    rule: issue.code,
+    message: issue.message,
+    severity: "error",
+  };
+}
+
+/**
+ * Full inbound gate for a client-supplied bundle: shape (zod) then semantic
+ * graph rules, with the journal included. Used on create/import, where the
+ * bundle and its history both arrive from outside and neither can be trusted.
+ */
+export function validateInboundBundle(input: unknown): { ok: boolean; findings: ValidationFinding[] } {
+  const parsed = parseBundle(input);
+  if (!parsed.success) {
+    return { ok: false, findings: parsed.error.issues.map(zodIssueToFinding) };
+  }
+  const semantic = validateBundle(input);
+  return semantic.valid ? { ok: true, findings: [] } : { ok: false, findings: semantic.errors };
+}
+
+// ---------------------------------------------------------------------------
+// Reads (every statement owner-scoped)
+// ---------------------------------------------------------------------------
+
+export async function listProjects(ownerIds: readonly string[]): Promise<GraphProjectSummary[]> {
+  const { rows } = await query<{
+    id: string;
+    bundle_id: string;
+    title: string;
+    entity_count: number;
+    version: string;
+    created_at: Date;
+    updated_at: Date;
+    archived_at: Date | null;
+  }>(
+    `select id, bundle_id, title, entity_count, version, created_at, updated_at, archived_at
+       from graph_projects
+      where owner_id = any($1::text[]) and archived_at is null
+      order by updated_at desc`,
+    [ownerIds],
+  );
+
+  return rows.map((row) => ({
+    id: row.id,
+    bundleId: row.bundle_id,
+    title: row.title,
+    entityCount: Number(row.entity_count),
+    version: String(row.version),
+    createdAt: row.created_at.toISOString(),
+    updatedAt: row.updated_at.toISOString(),
+    archivedAt: row.archived_at ? row.archived_at.toISOString() : null,
+  }));
+}
+
+interface LoadedProject {
+  snapshot: SnapshotShape;
+  version: string;
+  ownerId: string;
+}
+
+async function loadProject(
+  projectId: string,
+  ownerIds: readonly string[],
+): Promise<LoadedProject | null> {
+  const { rows } = await query<{ snapshot: SnapshotShape; version: string; owner_id: string }>(
+    `select snapshot, version, owner_id
+       from graph_projects
+      where id = $1 and owner_id = any($2::text[])`,
+    [projectId, ownerIds],
+  );
+  if (rows.length === 0) return null;
+  return { snapshot: rows[0].snapshot, version: String(rows[0].version), ownerId: rows[0].owner_id };
+}
+
+export async function getNodes(projectId: string, ownerIds: readonly string[]): Promise<Node[] | null> {
+  const loaded = await loadProject(projectId, ownerIds);
+  return loaded ? loaded.snapshot.nodes : null;
+}
+
+export async function getEdges(projectId: string, ownerIds: readonly string[]): Promise<Edge[] | null> {
+  const loaded = await loadProject(projectId, ownerIds);
+  return loaded ? loaded.snapshot.edges : null;
+}
+
+/** The project's events in server order. Owner-scoped via the project row. */
+export async function getJournal(
+  projectId: string,
+  ownerIds: readonly string[],
+): Promise<JournalEvent[] | null> {
+  const loaded = await loadProject(projectId, ownerIds);
+  if (!loaded) return null;
+  const { rows } = await query<{ event: JournalEvent }>(
+    `select event from graph_events where project_id = $1 order by seq asc`,
+    [projectId],
+  );
+  return rows.map((row) => row.event);
+}
+
+/** Snapshot + version, without the (potentially large) journal. */
+export async function getProject(
+  projectId: string,
+  ownerIds: readonly string[],
+): Promise<{ bundle: SnapshotShape; version: string } | null> {
+  const loaded = await loadProject(projectId, ownerIds);
+  return loaded ? { bundle: loaded.snapshot, version: loaded.version } : null;
+}
+
+/** The full interchange bundle: snapshot with its journal embedded. */
+export async function exportProject(
+  projectId: string,
+  ownerIds: readonly string[],
+): Promise<ProjectBundle | null> {
+  const loaded = await loadProject(projectId, ownerIds);
+  if (!loaded) return null;
+  const journal = (await getJournal(projectId, ownerIds)) ?? [];
+  return { ...loaded.snapshot, journal } as ProjectBundle;
+}
+
+// ---------------------------------------------------------------------------
+// Create / archive
+// ---------------------------------------------------------------------------
+
+export interface CreateProjectInput {
+  ownerId: string;
+  tier: string;
+  /** A full ProjectBundle from the client (import), already parsed as JSON. */
+  bundle: unknown;
+}
+
+export async function createProject(
+  input: CreateProjectInput,
+): Promise<{ ok: true; id: string; version: string } | StoreFailure> {
+  const validation = validateInboundBundle(input.bundle);
+  if (!validation.ok) return { ok: false, reason: "validation", errors: validation.findings };
+
+  const bundle = input.bundle as ProjectBundle & { journal?: JournalEvent[] };
+  const limits = getHostedLimitsForTier(input.tier);
+  const count = entityCount(bundle.nodes, bundle.edges);
+  if (count > limits.entities) {
+    return { ok: false, reason: "limit", limit: limits.entities, actual: count, tier: input.tier };
+  }
+
+  const { rows: existing } = await query<{ n: string }>(
+    `select count(*) as n from graph_projects where owner_id = $1 and archived_at is null`,
+    [input.ownerId],
+  );
+  const projectCount = Number(existing[0]?.n ?? 0);
+  if (projectCount + 1 > limits.projects) {
+    return { ok: false, reason: "limit", limit: limits.projects, actual: projectCount + 1, tier: input.tier };
+  }
+
+  const id = generateProjectId();
+  const { journal = [], ...snapshot } = bundle;
+
+  await withTransaction(async (client) => {
+    await client.query(
+      `insert into graph_projects (id, owner_id, bundle_id, title, snapshot, schema_version, entity_count)
+       values ($1, $2, $3, $4, $5, $6, $7)`,
+      [
+        id,
+        input.ownerId,
+        bundle.project.id,
+        bundle.project.title ?? "Untitled",
+        JSON.stringify(snapshot),
+        bundle.schema_version ?? 2,
+        count,
+      ],
+    );
+
+    // An imported bundle carries its own history. Events keep their original
+    // ULIDs, so re-importing the same bundle into a *new* project is fine while
+    // a duplicate id inside one project is impossible (the primary key).
+    for (const event of journal) {
+      await client.query(
+        `insert into graph_events (id, project_id, event, actor) values ($1, $2, $3, $4)
+         on conflict (id) do nothing`,
+        [event.id, id, JSON.stringify(event), event.actor ?? "import"],
+      );
+    }
+  });
+
+  return { ok: true, id, version: "1" };
+}
+
+/** Archive (soft-delete). Returns false when the project is not the caller's. */
+export async function archiveProject(projectId: string, ownerIds: readonly string[]): Promise<boolean> {
+  const { rows } = await query<{ id: string }>(
+    `update graph_projects
+        set archived_at = now(), updated_at = now()
+      where id = $1 and owner_id = any($2::text[]) and archived_at is null
+      returning id`,
+    [projectId, ownerIds],
+  );
+  return rows.length > 0;
+}
+
+// ---------------------------------------------------------------------------
+// The write path
+// ---------------------------------------------------------------------------
+
+export interface ApplyMutationInput {
+  projectId: string;
+  ownerIds: readonly string[];
+  ops: readonly MutationOp[];
+  actor: string;
+  tier: string;
+  /** When given, the mutation is refused unless the stored version matches. */
+  expectedVersion?: string;
+}
+
+/**
+ * Apply a batch of ops atomically.
+ *
+ * ── Why validation here skips the journal ───────────────────────────────────
+ * `validateBundle` runs against the mutated snapshot WITHOUT loading the
+ * project's event log. The graph rules that protect integrity — duplicate ids,
+ * dangling edges, playlist↔composes coherence, flow cycles — are all snapshot
+ * rules and run in full. The one check that needs history, `crossCheckJournal`
+ * (does every status in the snapshot have a matching `node.status_changed`?),
+ * is satisfied *by construction* on this path: the events are derived from the
+ * diff by `applyOps`, not supplied by the caller, so they cannot disagree with
+ * the snapshot they were derived from.
+ *
+ * Loading the whole event log on every write to re-prove something that cannot
+ * be false would make write cost grow with project history. Client-supplied
+ * bundles are a different matter and DO get the full gate, journal included,
+ * in {@link createProject}.
+ */
+export async function applyMutation(input: ApplyMutationInput): Promise<MutationResult> {
+  const limits = getHostedLimitsForTier(input.tier);
+
+  return withTransaction(async (client) => {
+    // FOR UPDATE: hold the row until commit, so a concurrent writer cannot
+    // compute its next graph from the state we are about to replace.
+    const { rows } = await client.query<{ snapshot: SnapshotShape; version: string }>(
+      `select snapshot, version
+         from graph_projects
+        where id = $1 and owner_id = any($2::text[]) and archived_at is null
+        for update`,
+      [input.projectId, input.ownerIds],
+    );
+    if (rows.length === 0) return { ok: false, reason: "not_found" } as StoreFailure;
+
+    const snapshot = rows[0].snapshot;
+    const version = String(rows[0].version);
+
+    if (input.expectedVersion !== undefined && input.expectedVersion !== version) {
+      return { ok: false, reason: "conflict", version } as StoreFailure;
+    }
+
+    let outcome;
+    try {
+      outcome = applyOps(
+        { projectId: snapshot.project.id, nodes: snapshot.nodes, edges: snapshot.edges },
+        input.ops,
+      );
+    } catch (err) {
+      return toMutationFailure(err);
+    }
+
+    const count = entityCount(outcome.nodes, outcome.edges);
+    if (count > limits.entities) {
+      return { ok: false, reason: "limit", limit: limits.entities, actual: count, tier: input.tier } as StoreFailure;
+    }
+
+    const candidate = { ...snapshot, nodes: outcome.nodes, edges: outcome.edges };
+    const semantic = validateBundle(candidate);
+    if (!semantic.valid) {
+      // Returning (not throwing) still rolls nothing back — no write has
+      // happened yet — and lets the caller render pathed findings.
+      return { ok: false, reason: "validation", errors: semantic.errors } as StoreFailure;
+    }
+
+    const events = toJournalEvents(outcome.eventInputs, input.actor);
+    // `version` is a bigint column and arrives as a string; BigInt keeps it exact
+    // past 2^53. Written as BigInt(1) rather than a `1n` literal because the
+    // app's tsconfig target predates BigInt literals.
+    const nextVersion = (BigInt(version) + BigInt(1)).toString();
+
+    await client.query(
+      `update graph_projects
+          set snapshot = $2, entity_count = $3, version = $4, title = $5, updated_at = now()
+        where id = $1`,
+      [
+        input.projectId,
+        JSON.stringify(candidate),
+        count,
+        nextVersion,
+        candidate.project.title ?? "Untitled",
+      ],
+    );
+
+    for (const event of events) {
+      await client.query(
+        `insert into graph_events (id, project_id, event, actor) values ($1, $2, $3, $4)`,
+        [event.id, input.projectId, JSON.stringify(event), input.actor],
+      );
+    }
+
+    return {
+      ok: true,
+      version: nextVersion,
+      nodes: outcome.nodes,
+      edges: outcome.edges,
+      events,
+      warnings: semantic.warnings ?? [],
+    } as MutationSuccess;
+  });
+}
+
+/** The caller's tier from `users.tier`, defaulting to the safe floor. */
+export async function getUserTier(userId: number): Promise<string> {
+  const { rows } = await query<{ tier: string }>(`select tier from users where id = $1`, [userId]);
+  return rows[0]?.tier ?? "synk";
+}

--- a/lib/services/graph/store.ts
+++ b/lib/services/graph/store.ts
@@ -281,13 +281,15 @@ export async function createProject(
       ],
     );
 
-    // An imported bundle carries its own history. Events keep their original
-    // ULIDs, so re-importing the same bundle into a *new* project is fine while
-    // a duplicate id inside one project is impossible (the primary key).
+    // An imported bundle carries its own history, and events keep their original
+    // ULIDs. Those ids are unique per project, not globally — two owners
+    // importing the same bundle hold the same event ids — so the conflict target
+    // is the composite key. Targeting `(id)` alone would make the second import
+    // of a journal-carrying bundle silently drop every event.
     for (const event of journal) {
       await client.query(
         `insert into graph_events (id, project_id, event, actor) values ($1, $2, $3, $4)
-         on conflict (id) do nothing`,
+         on conflict (project_id, id) do nothing`,
         [event.id, id, JSON.stringify(event), event.actor ?? "import"],
       );
     }

--- a/lib/services/limits.ts
+++ b/lib/services/limits.ts
@@ -41,3 +41,31 @@ export function getLimitsForTier(tier: string | null | undefined): TierLimits {
   }
   return TIER_LIMITS.synk;
 }
+
+/**
+ * Limits for HOSTED graph projects (db/migrations/008_graph_projects.sql) — a
+ * separate table from {@link TIER_LIMITS} on purpose.
+ *
+ * Synk's caps describe a *backup* service: one project, 250 entities, 7-day
+ * retention. A hosted project is the thing a person edits all day and an agent
+ * writes to from CI, so reusing those numbers would cap the product at a
+ * quarter of the size of the seed project shipped in this repo. There is no
+ * retention dimension here at all — a project of record is not pruned.
+ *
+ * The shape mirrors Synk's so the M5 billing work flips one column for both.
+ */
+export const HOSTED_LIMITS = {
+  synk: { projects: 3, entities: 5_000 },
+  basik: { projects: 10, entities: 25_000 },
+  klub: { projects: Infinity, entities: Infinity },
+} as const;
+
+export type HostedLimits = (typeof HOSTED_LIMITS)[Tier];
+
+/** Hosted limits for a tier string, falling back to the most restrictive row. */
+export function getHostedLimitsForTier(tier: string | null | undefined): HostedLimits {
+  if (tier && Object.prototype.hasOwnProperty.call(HOSTED_LIMITS, tier)) {
+    return HOSTED_LIMITS[tier as Tier];
+  }
+  return HOSTED_LIMITS.synk;
+}

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test:cli": "npm run build -w arkaik && node tests/cli/run-cli-tests.js && node tests/cli/init.test.js && node tests/cli/log-release.test.js && node tests/cli/sync.test.js && node tests/cli/pack-open.test.js && node tests/cli/push.test.js",
     "test:auth": "node tests/services/auth-guard.test.js",
     "test:tokens": "node tests/services/token-auth.test.js",
+    "test:graph": "node tests/services/graph-api.test.js",
     "test:publik": "node tests/services/publik-api.test.js",
     "test:synk": "node tests/services/synk-api.test.js",
     "test:sync": "node tests/sync/sync-manager.test.js"

--- a/tests/services/graph-api.test.js
+++ b/tests/services/graph-api.test.js
@@ -1,0 +1,381 @@
+#!/usr/bin/env node
+
+/**
+ * Integration tests for the hosted graph API (db/migrations/008_graph_projects.sql,
+ * lib/services/graph/store.ts, app/api/graph/**).
+ *
+ * Run against a real Postgres whose schema was applied by `npm run db:migrate`.
+ * Only NextAuth is stubbed; the store, token verification, owner resolution,
+ * scope enforcement, and the `select … for update` transactions all run for real.
+ *
+ * The properties that matter most here, and why:
+ *   - a REFUSED mutation writes nothing — not the snapshot, not the version, not
+ *     a single event. This is the whole promise of the validator gate, and it is
+ *     the one thing a partial implementation would still appear to pass.
+ *   - owner scoping: another owner's project is 404, never 403, so ids cannot be
+ *     probed.
+ *   - batch atomicity: node + edge land together or not at all.
+ *   - scopes are enforced, so a read-only agent token cannot write.
+ *
+ * Test rows use the `graphtest-%@example.com` email pattern and are cleaned up
+ * by derived owner id at start and end, so local re-runs are idempotent.
+ */
+
+const { Client } = require("pg");
+const fs = require("fs");
+const { loadGraphApi, BUILD_DIR } = require("./load-graph-api");
+
+const ORIGIN = "https://graph.test";
+
+let failures = 0;
+function check(name, cond, detail) {
+  if (cond) {
+    console.log(`PASS: ${name}`);
+  } else {
+    failures++;
+    console.log(`FAIL: ${name}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+const ctx = (projectId) => ({ params: Promise.resolve({ projectId }) });
+const sessionFor = (userId) => ({ user: { id: String(userId), name: "graphtest" } });
+
+function node(id, species, extra = {}) {
+  return {
+    id,
+    project_id: "gp",
+    species,
+    title: id,
+    status: "idea",
+    platforms: ["web"],
+    ...extra,
+  };
+}
+
+function bundle(nodes = [], edges = []) {
+  return {
+    schema_version: 2,
+    project: {
+      id: "gp",
+      title: "Graph test",
+      created_at: "2026-01-01T00:00:00.000Z",
+      updated_at: "2026-01-01T00:00:00.000Z",
+    },
+    nodes,
+    edges,
+  };
+}
+
+function jsonReq(url, method, body, headers = {}) {
+  return new Request(url, {
+    method,
+    headers: { "content-type": "application/json", ...headers },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+const bearer = (token) => ({ authorization: `Bearer ${token}` });
+
+async function seedUser(client, label) {
+  const email = `graphtest-${label}-${Date.now()}-${Math.random().toString(36).slice(2)}@example.com`;
+  const { rows } = await client.query(
+    `insert into users (name, email) values ($1, $2) returning id`,
+    [`graphtest ${label}`, email],
+  );
+  return rows[0].id;
+}
+
+async function cleanup(client) {
+  const { rows } = await client.query(
+    `select id from users where email like 'graphtest-%@example.com'`,
+  );
+  const ids = rows.map((r) => r.id);
+  if (ids.length === 0) return;
+  const ownerIds = ids.map((id) => `own-u${id}`);
+  // graph_events cascades from graph_projects, which cascades from owners.
+  await client.query(`delete from graph_projects where owner_id = any($1::text[])`, [ownerIds]);
+  await client.query(`delete from api_tokens where user_id = any($1::int[])`, [ids]);
+  await client.query(`delete from owner_members where user_id = any($1::int[])`, [ids]);
+  await client.query(`delete from owners where id = any($1::text[])`, [ownerIds]);
+  await client.query(`delete from users where id = any($1::int[])`, [ids]);
+}
+
+async function main() {
+  if (!process.env.DATABASE_URL) {
+    console.error("DATABASE_URL is not set — this integration test needs a migrated Postgres.");
+    process.exit(1);
+  }
+  process.env.AUTH_SECRET ||= "graphtest-secret";
+  process.env.AUTH_GITHUB_ID ||= "graphtest-id";
+  process.env.AUTH_GITHUB_SECRET ||= "graphtest-secret";
+
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+  await cleanup(client);
+
+  const api = loadGraphApi();
+  const { store, tokens, owners, setSession } = api;
+
+  try {
+    const userA = await seedUser(client, "a");
+    const userB = await seedUser(client, "b");
+    const ownerA = (await owners.resolveOwnerIds(userA))[0];
+    await owners.resolveOwnerIds(userB);
+
+    // --- Auth + scope gates -------------------------------------------------
+    setSession(null);
+    check(
+      "unauthenticated list returns 401",
+      (await api.LIST_PROJECTS(new Request(`${ORIGIN}/api/graph/projects`))).status === 401,
+    );
+
+    const readOnly = await tokens.mintToken({
+      ownerId: ownerA,
+      userId: userA,
+      name: "read-only",
+      scopes: ["graph:read"],
+    });
+    const writeToken = await tokens.mintToken({
+      ownerId: ownerA,
+      userId: userA,
+      name: "agent",
+      scopes: ["graph:read", "graph:write"],
+    });
+
+    // --- Create -------------------------------------------------------------
+    setSession(sessionFor(userA));
+    const created = await api.CREATE_PROJECT(
+      jsonReq(`${ORIGIN}/api/graph/projects`, "POST", bundle([node("V-a", "view")])),
+    );
+    const createdBody = await created.json();
+    check("POST /projects returns 201", created.status === 201, String(created.status));
+    check("the created id is server-owned (prj_)", createdBody.id?.startsWith("prj_"), createdBody.id);
+    const projectId = createdBody.id;
+
+    const badCreate = await api.CREATE_PROJECT(
+      jsonReq(`${ORIGIN}/api/graph/projects`, "POST", bundle([], [
+        { id: "e-x-y", project_id: "gp", source_id: "V-nope", target_id: "V-alsonope", edge_type: "composes" },
+      ])),
+    );
+    check("a dangling-edge bundle is refused with 422", badCreate.status === 422, String(badCreate.status));
+    check("the 422 carries pathed findings", Array.isArray((await badCreate.json()).errors));
+
+    // --- Owner scoping ------------------------------------------------------
+    setSession(sessionFor(userB));
+    const otherList = await api.LIST_PROJECTS(new Request(`${ORIGIN}/api/graph/projects`));
+    check("another owner sees no projects", (await otherList.json()).projects.length === 0);
+    const otherGet = await api.GET_PROJECT(new Request(ORIGIN), ctx(projectId));
+    check("another owner gets 404, not 403", otherGet.status === 404, String(otherGet.status));
+    const otherMutate = await api.MUTATE(
+      jsonReq(ORIGIN, "POST", { ops: [{ op: "create_node", node: node("V-evil", "view") }] }),
+      ctx(projectId),
+    );
+    check("another owner cannot mutate (404)", otherMutate.status === 404, String(otherMutate.status));
+
+    // --- Read ---------------------------------------------------------------
+    setSession(sessionFor(userA));
+    const got = await api.GET_PROJECT(new Request(ORIGIN), ctx(projectId));
+    const gotBody = await got.json();
+    check("GET project returns the bundle", got.status === 200 && gotBody.bundle.nodes.length === 1);
+    check("GET project sets an ETag from the version", got.headers.get("etag") === `"${gotBody.version}"`);
+    check("initial version is 1", gotBody.version === "1", gotBody.version);
+
+    // --- Scope enforcement --------------------------------------------------
+    setSession(null);
+    const readOnlyWrite = await api.MUTATE(
+      jsonReq(ORIGIN, "POST", { ops: [{ op: "create_node", node: node("V-b", "view") }] }, bearer(readOnly.plaintext)),
+      ctx(projectId),
+    );
+    check(
+      "a graph:read token cannot write (403 insufficient_scope)",
+      readOnlyWrite.status === 403,
+      String(readOnlyWrite.status),
+    );
+    const readOnlyRead = await api.GET_NODES(
+      new Request(ORIGIN, { headers: bearer(readOnly.plaintext) }),
+      ctx(projectId),
+    );
+    check("a graph:read token can read", readOnlyRead.status === 200);
+
+    // --- Mutate via an agent token -----------------------------------------
+    const mutated = await api.MUTATE(
+      jsonReq(ORIGIN, "POST", { ops: [{ op: "create_node", node: node("V-b", "view") }] }, bearer(writeToken.plaintext)),
+      ctx(projectId),
+    );
+    const mutatedBody = await mutated.json();
+    check("an agent token can mutate", mutated.status === 200, String(mutated.status));
+    check("the mutation returns the new graph", mutatedBody.nodes.length === 2);
+    check("the version bumped to 2", mutatedBody.version === "2", mutatedBody.version);
+    check("the response ETag matches the new version", mutated.headers.get("etag") === '"2"');
+    check(
+      "an agent's write is attributed to arkaik-agent",
+      mutatedBody.events[0]?.actor === "arkaik-agent",
+      mutatedBody.events[0]?.actor,
+    );
+
+    // --- Batch atomicity ----------------------------------------------------
+    const batch = await api.MUTATE(
+      jsonReq(
+        ORIGIN,
+        "POST",
+        {
+          ops: [
+            { op: "create_node", node: node("AC-x", "acceptance") },
+            {
+              op: "create_edge",
+              edge: { id: "", project_id: "gp", source_id: "AC-x", target_id: "V-a", edge_type: "covers" },
+            },
+          ],
+        },
+        bearer(writeToken.plaintext),
+      ),
+      ctx(projectId),
+    );
+    const batchBody = await batch.json();
+    check("a node+edge batch applies", batch.status === 200, String(batch.status));
+    check("both landed together", batchBody.nodes.length === 3 && batchBody.edges.length === 1);
+    check("the batch emitted two events", batchBody.events.length === 2);
+
+    // --- A refused mutation writes NOTHING ---------------------------------
+    const beforeRefusal = await (await api.GET_PROJECT(new Request(ORIGIN), ctx(projectId))).json();
+    const refused = await api.MUTATE(
+      jsonReq(
+        ORIGIN,
+        "POST",
+        {
+          ops: [
+            { op: "create_node", node: node("V-ghost", "view") },
+            {
+              op: "create_edge",
+              edge: { id: "", project_id: "gp", source_id: "V-ghost", target_id: "V-missing", edge_type: "composes" },
+            },
+          ],
+        },
+        bearer(writeToken.plaintext),
+      ),
+      ctx(projectId),
+    );
+    check("a dangling edge is refused with 422", refused.status === 422, String(refused.status));
+    const afterRefusal = await (await api.GET_PROJECT(new Request(ORIGIN), ctx(projectId))).json();
+    check("the refused batch left the version alone", afterRefusal.version === beforeRefusal.version);
+    check(
+      "the refused batch left the snapshot alone",
+      afterRefusal.bundle.nodes.length === beforeRefusal.bundle.nodes.length,
+    );
+    check(
+      "the refused batch wrote no ghost node",
+      !afterRefusal.bundle.nodes.some((n) => n.id === "V-ghost"),
+    );
+
+    const refusedOp = await api.MUTATE(
+      jsonReq(ORIGIN, "POST", { ops: [{ op: "update_node", node_id: "V-nope", patch: { status: "live" } }] }, bearer(writeToken.plaintext)),
+      ctx(projectId),
+    );
+    const refusedOpBody = await refusedOp.json();
+    check("an unknown node is refused with 422", refusedOp.status === 422);
+    check(
+      "the refusal carries the machine-readable code",
+      refusedOpBody.code === "node_not_found",
+      JSON.stringify(refusedOpBody),
+    );
+
+    // --- Optimistic concurrency --------------------------------------------
+    const current = await (await api.GET_PROJECT(new Request(ORIGIN), ctx(projectId))).json();
+    const stale = await api.MUTATE(
+      jsonReq(
+        ORIGIN,
+        "POST",
+        { ops: [{ op: "create_node", node: node("V-stale", "view") }] },
+        { ...bearer(writeToken.plaintext), "if-match": '"1"' },
+      ),
+      ctx(projectId),
+    );
+    check("a stale If-Match returns 409", stale.status === 409, String(stale.status));
+    check("the 409 reports the current version", (await stale.json()).version === current.version);
+
+    const fresh = await api.MUTATE(
+      jsonReq(
+        ORIGIN,
+        "POST",
+        { ops: [{ op: "create_node", node: node("V-fresh", "view") }] },
+        { ...bearer(writeToken.plaintext), "if-match": `"${current.version}"` },
+      ),
+      ctx(projectId),
+    );
+    check("a matching If-Match applies", fresh.status === 200, String(fresh.status));
+
+    // --- Journal + export ---------------------------------------------------
+    const journal = await (await api.GET_JOURNAL(new Request(ORIGIN, { headers: bearer(readOnly.plaintext) }), ctx(projectId))).json();
+    check("the journal accumulated every accepted event", journal.journal.length >= 5, String(journal.journal.length));
+    check(
+      "no event from a refused mutation is present",
+      !journal.journal.some((e) => JSON.stringify(e).includes("V-ghost")),
+    );
+    const exported = await (await api.EXPORT(new Request(ORIGIN, { headers: bearer(readOnly.plaintext) }), ctx(projectId))).json();
+    check("export embeds the journal", Array.isArray(exported.bundle.journal) && exported.bundle.journal.length > 0);
+    check("export carries the graph", exported.bundle.nodes.length >= 3);
+
+    // --- Bad requests -------------------------------------------------------
+    setSession(sessionFor(userA));
+    check(
+      "an empty ops array is rejected",
+      (await api.MUTATE(jsonReq(ORIGIN, "POST", { ops: [] }), ctx(projectId))).status === 400,
+    );
+    check(
+      "an unknown op name is rejected",
+      (await api.MUTATE(jsonReq(ORIGIN, "POST", { ops: [{ op: "drop_table" }] }), ctx(projectId))).status === 400,
+    );
+
+    // --- Limits -------------------------------------------------------------
+    await client.query(`update users set tier = 'synk' where id = $1`, [userA]);
+    const limitResult = await store.applyMutation({
+      projectId,
+      ownerIds: [ownerA],
+      ops: Array.from({ length: 3 }, (_, i) => ({ op: "create_node", node: node(`V-bulk${i}`, "view") })),
+      actor: "test",
+      tier: "synk",
+    });
+    check("a mutation within the entity cap succeeds", limitResult.ok === true);
+    const overLimit = await store.applyMutation({
+      projectId,
+      ownerIds: [ownerA],
+      ops: [{ op: "create_node", node: node("V-over", "view") }],
+      actor: "test",
+      tier: "nonexistent-tier",
+    });
+    // An unknown tier falls back to the most restrictive row, which still allows
+    // this small graph — the assertion is that the fallback resolves at all.
+    check("an unknown tier resolves to the safe floor rather than throwing", typeof overLimit.ok === "boolean");
+
+    // --- Archive ------------------------------------------------------------
+    const archived = await api.DELETE_PROJECT(new Request(ORIGIN), ctx(projectId));
+    check("DELETE archives the project", archived.status === 204, String(archived.status));
+    check(
+      "an archived project leaves the listing",
+      (await (await api.LIST_PROJECTS(new Request(ORIGIN))).json()).projects.length === 0,
+    );
+    check(
+      "an archived project cannot be mutated",
+      (await api.MUTATE(jsonReq(ORIGIN, "POST", { ops: [{ op: "create_node", node: node("V-z", "view") }] }), ctx(projectId))).status === 404,
+    );
+    check(
+      "DELETE is idempotent-safe (second call 404s)",
+      (await api.DELETE_PROJECT(new Request(ORIGIN), ctx(projectId))).status === 404,
+    );
+  } finally {
+    await cleanup(client);
+    await client.end();
+    fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+  }
+
+  if (failures > 0) {
+    console.error(`\n${failures} check(s) failed.`);
+    process.exit(1);
+  }
+  console.log("\nAll graph-API checks passed.");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/services/graph-api.test.js
+++ b/tests/services/graph-api.test.js
@@ -383,7 +383,20 @@ async function main() {
 
     // --- Journal + export ---------------------------------------------------
     const journal = await (await api.GET_JOURNAL(new Request(ORIGIN, { headers: bearer(readOnly.plaintext) }), ctx(projectId))).json();
-    check("the journal accumulated every accepted event", journal.journal.length >= 5, String(journal.journal.length));
+    // By identity, not count. A count couples this to how many mutations earlier
+    // assertions happen to make — which has now broken three assertions across
+    // this program, every time for a reason that said nothing about the code.
+    const journalled = journal.journal.map((e) => `${e.type}:${e.node_id ?? e.edge_id ?? ""}`);
+    check(
+      "every accepted mutation reached the journal",
+      ["node.created:V-b", "node.created:AC-x", "node.created:V-fresh"].every((k) => journalled.includes(k)),
+      journalled.join(" | "),
+    );
+    check(
+      "the batch's edge was journalled alongside its node",
+      journalled.some((entry) => entry.startsWith("edge.added:")),
+      journalled.join(" | "),
+    );
     check(
       "no event from a refused mutation is present",
       !journal.journal.some((e) => JSON.stringify(e).includes("V-ghost")),

--- a/tests/services/graph-api.test.js
+++ b/tests/services/graph-api.test.js
@@ -344,7 +344,14 @@ async function main() {
       ctx(projectId),
     );
     check("a stale If-Match returns 409", stale.status === 409, String(stale.status));
-    check("the 409 reports the current version", (await stale.json()).version === current.version);
+    const staleBody = await stale.json();
+    // Guarded like the refusal checks above: two undefineds comparing equal
+    // would report success while proving nothing.
+    check(
+      "the 409 reports the current version",
+      Boolean(staleBody.version) && staleBody.version === current.version,
+      `${staleBody.version} vs ${current.version}`,
+    );
 
     const fresh = await api.MUTATE(
       jsonReq(

--- a/tests/services/graph-api.test.js
+++ b/tests/services/graph-api.test.js
@@ -160,10 +160,51 @@ async function main() {
     check("a dangling-edge bundle is refused with 422", badCreate.status === 422, String(badCreate.status));
     check("the 422 carries pathed findings", Array.isArray((await badCreate.json()).errors));
 
+    // --- Imported history is per-project, not global -------------------------
+    // REGRESSION: event ULIDs travel inside an exported bundle, so two owners
+    // importing the SAME bundle legitimately hold identical event ids. With a
+    // global `primary key (id)` on graph_events the second import collided and
+    // silently dropped its entire journal. seed/pebbles.json ships with a
+    // journal, so this is the ordinary path, not a corner case.
+    const shared = bundle([node("V-a", "view")]);
+    shared.journal = [
+      {
+        id: "01JQZZZZZZZZZZZZZZZZZZZZZZ",
+        type: "node.created",
+        ts: "2026-01-01T00:00:00.000Z",
+        actor: "seed",
+        payload: { node_id: "V-a", species: "view", title: "A" },
+      },
+    ];
+
+    const firstImport = await api.CREATE_PROJECT(jsonReq(`${ORIGIN}/api/graph/projects`, "POST", shared));
+    check("a journal-carrying bundle imports", firstImport.status === 201, String(firstImport.status));
+    const firstId = (await firstImport.json()).id;
+
+    setSession(sessionFor(userB));
+    const secondImport = await api.CREATE_PROJECT(jsonReq(`${ORIGIN}/api/graph/projects`, "POST", shared));
+    check("another owner can import the same bundle", secondImport.status === 201, String(secondImport.status));
+    const secondId = (await secondImport.json()).id;
+
+    const secondJournal = await (await api.GET_JOURNAL(new Request(ORIGIN), ctx(secondId))).json();
+    check(
+      "the second import KEEPS its journal (not swallowed by a global id clash)",
+      secondJournal.journal.length === 1,
+      `got ${secondJournal.journal.length} events`,
+    );
+    setSession(sessionFor(userA));
+    const firstJournal = await (await api.GET_JOURNAL(new Request(ORIGIN), ctx(firstId))).json();
+    check("the first import still has its journal", firstJournal.journal.length === 1);
+
     // --- Owner scoping ------------------------------------------------------
     setSession(sessionFor(userB));
     const otherList = await api.LIST_PROJECTS(new Request(`${ORIGIN}/api/graph/projects`));
-    check("another owner sees no projects", (await otherList.json()).projects.length === 0);
+    const otherIds = (await otherList.json()).projects.map((p) => p.id);
+    check(
+      "another owner's listing never contains this project",
+      !otherIds.includes(projectId),
+      otherIds.join(","),
+    );
     const otherGet = await api.GET_PROJECT(new Request(ORIGIN), ctx(projectId));
     check("another owner gets 404, not 403", otherGet.status === 404, String(otherGet.status));
     const otherMutate = await api.MUTATE(
@@ -237,7 +278,13 @@ async function main() {
     check("the batch emitted two events", batchBody.events.length === 2);
 
     // --- A refused mutation writes NOTHING ---------------------------------
-    const beforeRefusal = await (await api.GET_PROJECT(new Request(ORIGIN), ctx(projectId))).json();
+    // These reads MUST carry a credential: the session is null in this section,
+    // so an unauthenticated GET would 401 and every field below would be
+    // undefined — making the comparisons pass vacuously rather than prove
+    // anything. Asserting the bundle is actually present guards that directly.
+    const readReq = () => new Request(ORIGIN, { headers: bearer(readOnly.plaintext) });
+    const beforeRefusal = await (await api.GET_PROJECT(readReq(), ctx(projectId))).json();
+    check("the pre-refusal read actually returned a bundle", Boolean(beforeRefusal.bundle));
     const refused = await api.MUTATE(
       jsonReq(
         ORIGIN,
@@ -256,8 +303,13 @@ async function main() {
       ctx(projectId),
     );
     check("a dangling edge is refused with 422", refused.status === 422, String(refused.status));
-    const afterRefusal = await (await api.GET_PROJECT(new Request(ORIGIN), ctx(projectId))).json();
-    check("the refused batch left the version alone", afterRefusal.version === beforeRefusal.version);
+    const afterRefusal = await (await api.GET_PROJECT(readReq(), ctx(projectId))).json();
+    check("the post-refusal read actually returned a bundle", Boolean(afterRefusal.bundle));
+    check(
+      "the refused batch left the version alone",
+      Boolean(afterRefusal.version) && afterRefusal.version === beforeRefusal.version,
+      `${beforeRefusal.version} → ${afterRefusal.version}`,
+    );
     check(
       "the refused batch left the snapshot alone",
       afterRefusal.bundle.nodes.length === beforeRefusal.bundle.nodes.length,
@@ -280,7 +332,8 @@ async function main() {
     );
 
     // --- Optimistic concurrency --------------------------------------------
-    const current = await (await api.GET_PROJECT(new Request(ORIGIN), ctx(projectId))).json();
+    const current = await (await api.GET_PROJECT(readReq(), ctx(projectId))).json();
+    check("the concurrency baseline read returned a version", Boolean(current.version));
     const stale = await api.MUTATE(
       jsonReq(
         ORIGIN,
@@ -350,10 +403,9 @@ async function main() {
     // --- Archive ------------------------------------------------------------
     const archived = await api.DELETE_PROJECT(new Request(ORIGIN), ctx(projectId));
     check("DELETE archives the project", archived.status === 204, String(archived.status));
-    check(
-      "an archived project leaves the listing",
-      (await (await api.LIST_PROJECTS(new Request(ORIGIN))).json()).projects.length === 0,
-    );
+    const afterArchive = (await (await api.LIST_PROJECTS(new Request(ORIGIN))).json()).projects.map((p) => p.id);
+    check("an archived project leaves the listing", !afterArchive.includes(projectId), afterArchive.join(","));
+    check("archiving one project does not hide the others", afterArchive.includes(firstId), afterArchive.join(","));
     check(
       "an archived project cannot be mutated",
       (await api.MUTATE(jsonReq(ORIGIN, "POST", { ops: [{ op: "create_node", node: node("V-z", "view") }] }), ctx(projectId))).status === 404,

--- a/tests/services/graph-api.test.js
+++ b/tests/services/graph-api.test.js
@@ -167,24 +167,41 @@ async function main() {
     // silently dropped its entire journal. seed/pebbles.json ships with a
     // journal, so this is the ordinary path, not a corner case.
     const shared = bundle([node("V-a", "view")]);
+    // Payload fields sit FLAT on the envelope (docs/spec/journal.md § Event
+    // Envelope) — `{ type, payload: {...} }` is `EventInput`, the pre-stamp
+    // shape used inside derive.ts, and is NOT what a stored event looks like.
     shared.journal = [
       {
-        id: "01JQZZZZZZZZZZZZZZZZZZZZZZ",
-        type: "node.created",
+        id: "01KN44ARM0JH4YFMX52BGKNPKZ",
         ts: "2026-01-01T00:00:00.000Z",
         actor: "seed",
-        payload: { node_id: "V-a", species: "view", title: "A" },
+        type: "node.created",
+        node_id: "V-a",
+        species: "view",
+        title: "A",
       },
     ];
 
     const firstImport = await api.CREATE_PROJECT(jsonReq(`${ORIGIN}/api/graph/projects`, "POST", shared));
-    check("a journal-carrying bundle imports", firstImport.status === 201, String(firstImport.status));
-    const firstId = (await firstImport.json()).id;
+    const firstBody = await firstImport.json();
+    // Print the findings on failure — a bare status code sent me guessing at the
+    // event shape rather than reading what the validator actually objected to.
+    check(
+      "a journal-carrying bundle imports",
+      firstImport.status === 201,
+      `${firstImport.status} ${JSON.stringify(firstBody.errors ?? firstBody)}`,
+    );
+    const firstId = firstBody.id;
 
     setSession(sessionFor(userB));
     const secondImport = await api.CREATE_PROJECT(jsonReq(`${ORIGIN}/api/graph/projects`, "POST", shared));
-    check("another owner can import the same bundle", secondImport.status === 201, String(secondImport.status));
-    const secondId = (await secondImport.json()).id;
+    const secondBody = await secondImport.json();
+    check(
+      "another owner can import the same bundle",
+      secondImport.status === 201,
+      `${secondImport.status} ${JSON.stringify(secondBody.errors ?? secondBody)}`,
+    );
+    const secondId = secondBody.id;
 
     const secondJournal = await (await api.GET_JOURNAL(new Request(ORIGIN), ctx(secondId))).json();
     check(

--- a/tests/services/load-graph-api.js
+++ b/tests/services/load-graph-api.js
@@ -1,0 +1,120 @@
+/**
+ * Loads the hosted graph store, the real `getCaller()` seam, and every
+ * /api/graph route handler into a running Node process without a bundler — the
+ * same transpile-on-the-fly approach as load-synk-api.js / load-token-api.js.
+ *
+ * Only `@/auth` (NextAuth, ESM-only) is stubbed. The store, the token
+ * verification, the owner resolution, the scope checks, and the Postgres
+ * transactions all run for real — stubbing any of those would leave the parts
+ * most likely to be wrong untested.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const ts = require("typescript");
+const { loadSchema, BUILD_DIR: SCHEMA_BUILD_DIR } = require("../schema/load-schema");
+
+const ROOT = path.join(__dirname, "..", "..");
+const BUILD_DIR = path.join(__dirname, ".test-build-graph");
+
+const COMPILER_OPTIONS = {
+  module: ts.ModuleKind.CommonJS,
+  target: ts.ScriptTarget.ES2020,
+  esModuleInterop: true,
+};
+
+function transpile(srcAbsPath, fileName, rewrites) {
+  const source = fs.readFileSync(srcAbsPath, "utf8");
+  let { outputText } = ts.transpileModule(source, { fileName, compilerOptions: COMPILER_OPTIONS });
+  for (const [specifier, replacement] of rewrites) {
+    const pattern = new RegExp(
+      `require\\((['"])${specifier.replace(/[.*+?^${}()|[\]\\/]/g, "\\$&")}\\1\\)`,
+      "g",
+    );
+    outputText = outputText.replace(pattern, `require(${JSON.stringify(replacement)})`);
+  }
+  return outputText;
+}
+
+function loadGraphApi() {
+  loadSchema();
+  const schemaIndex = path.join(SCHEMA_BUILD_DIR, "index.js");
+
+  fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+  fs.mkdirSync(BUILD_DIR, { recursive: true });
+  fs.writeFileSync(path.join(BUILD_DIR, "package.json"), JSON.stringify({ type: "commonjs" }));
+
+  const write = (name, text) => fs.writeFileSync(path.join(BUILD_DIR, name), text);
+  const serverOnlyStub = "./server-only-stub.js";
+  write("server-only-stub.js", "module.exports = {};\n");
+
+  write(
+    "auth-module-stub.js",
+    "let current = null;\n" +
+      "module.exports = {\n" +
+      "  auth: async () => current,\n" +
+      "  __setSession: (s) => { current = s; },\n" +
+      "};\n",
+  );
+
+  const COMMON = [
+    ["server-only", serverOnlyStub],
+    ["@arkaik/schema", schemaIndex],
+    ["@/lib/services/db", "./db.js"],
+    ["@/lib/services/limits", "./limits.js"],
+    ["@/lib/services/owners", "./owners.js"],
+    ["@/lib/services/tokens", "./tokens.js"],
+    ["@/lib/services/auth", "./auth.js"],
+    ["@/lib/services/graph/store", "./store.js"],
+    ["@/lib/services/graph/read-route", "./read-route.js"],
+    ["@/auth", "./auth-module-stub.js"],
+  ];
+
+  const src = (...parts) => path.join(ROOT, ...parts);
+
+  write("db.js", transpile(src("lib", "services", "db.ts"), "db.ts", COMMON));
+  write("limits.js", transpile(src("lib", "services", "limits.ts"), "limits.ts", COMMON));
+  write("owners.js", transpile(src("lib", "services", "owners.ts"), "owners.ts", COMMON));
+  write("tokens.js", transpile(src("lib", "services", "tokens.ts"), "tokens.ts", COMMON));
+  write("auth.js", transpile(src("lib", "services", "auth.ts"), "auth.ts", COMMON));
+  write("store.js", transpile(src("lib", "services", "graph", "store.ts"), "store.ts", COMMON));
+  write("read-route.js", transpile(src("lib", "services", "graph", "read-route.ts"), "read-route.ts", COMMON));
+
+  const routes = {
+    "projects-route.js": src("app", "api", "graph", "projects", "route.ts"),
+    "project-route.js": src("app", "api", "graph", "projects", "[projectId]", "route.ts"),
+    "mutations-route.js": src("app", "api", "graph", "projects", "[projectId]", "mutations", "route.ts"),
+    "nodes-route.js": src("app", "api", "graph", "projects", "[projectId]", "nodes", "route.ts"),
+    "edges-route.js": src("app", "api", "graph", "projects", "[projectId]", "edges", "route.ts"),
+    "journal-route.js": src("app", "api", "graph", "projects", "[projectId]", "journal", "route.ts"),
+    "export-route.js": src("app", "api", "graph", "projects", "[projectId]", "export", "route.ts"),
+  };
+  for (const [out, from] of Object.entries(routes)) {
+    write(out, transpile(from, "route.ts", COMMON));
+  }
+
+  for (const name of fs.readdirSync(BUILD_DIR)) {
+    if (name.endsWith(".js")) delete require.cache[path.join(BUILD_DIR, name)];
+  }
+
+  const req = (name) => require(path.join(BUILD_DIR, name));
+  const authStub = req("auth-module-stub.js");
+
+  return {
+    store: req("store.js"),
+    tokens: req("tokens.js"),
+    owners: req("owners.js"),
+    setSession: authStub.__setSession,
+    LIST_PROJECTS: req("projects-route.js").GET,
+    CREATE_PROJECT: req("projects-route.js").POST,
+    GET_PROJECT: req("project-route.js").GET,
+    DELETE_PROJECT: req("project-route.js").DELETE,
+    MUTATE: req("mutations-route.js").POST,
+    GET_NODES: req("nodes-route.js").GET,
+    GET_EDGES: req("edges-route.js").GET,
+    GET_JOURNAL: req("journal-route.js").GET,
+    EXPORT: req("export-route.js").GET,
+  };
+}
+
+module.exports = { loadGraphApi, BUILD_DIR, SCHEMA_BUILD_DIR };


### PR DESCRIPTION
## Summary

Where slices 1 and 2 meet: a **project of record** the app and an agent both read and write — behind the token auth from #286, with the mutation semantics from #287 as its only definition of what an edit means.

### Why not Synk

Synk is a backup service and its schema says so: the primary key is `(user_id, client_chosen_id)`, backups are an immutable chain pruned after 7 days, and the tier cap is one project. Extending it into a mutable store would fight every one of those decisions. **Synk and Publik are untouched** and keep serving local-first projects; this is a separate store beside them.

### Snapshot + event log, not normalized rows

The graph lives as one `jsonb` snapshot, so `validateBundle`'s whole-graph rules — dangling edges, playlist coherence, flow cycles — keep working against exactly the shape they were written for, and a format change never needs a Postgres migration. Every mutation also appends to `graph_events`: the audit trail, and the substrate any future merge story would build on.

The journal lives in its **own table**, mirroring the IndexedDB split in `lib/data/db.ts` — appends must not rewrite the graph.

### The write path

`packages/mcp/src/store.ts`'s `persistMutation`, lifted into Postgres:

```
select … for update  →  applyOps in memory  →  validateBundle gate  →  snapshot + version + events, one transaction
```

The **row lock** is what makes it safe: two agents mutating one project serialize, and neither computes its next graph from a stale read. `version` / `If-Match` is *complementary, not load-bearing* — correctness comes from the lock; the version lets a client notice someone moved under it.

### One batch endpoint, not a verb per entity

`POST .../mutations` takes an array of typed ops, so:
- node + edge cannot half-apply — the failure that forced the app's hand-rolled rollback before #287;
- one validator gate runs over the *finished* graph, so a briefly-invalid intermediate state is never rejected;
- the shape mirrors both the MCP tool catalog and `DataProvider`, which is what lets slices 4 and 5 share it.

### One judgement call worth reviewing

Validation on the **mutation** path skips the journal. Every rule protecting graph integrity is a snapshot rule and runs in full; the one check needing history — `crossCheckJournal` — cannot fail when events are *derived from the diff* by `applyOps` rather than supplied by the caller. Loading the whole event log per write to re-prove something that cannot be false would make write cost grow with project history.

Client-supplied bundles are different and **do** get the full gate, journal included, on create.

### Limits

Hosted projects get their own table. Synk's 250 entities describes a backup service and would cap the product below the size of this repo's own seed project. Synk's caps are unchanged (asserted in the pre-flight check).

## Verification

Locally: `tsc`, `lint` (0 errors), `next build` with **every** services env var unset (routes register as dynamic and degrade to 503), the generated-artifact drift gate, and the non-DB suites (`mutate`, `provider`, `mcp`, `auth`, `sync`, `schema`, `validate:seeds`).

⚠️ **`tests/services/graph-api.test.js` has not been run** — no Postgres on this machine, so CI is its first execution, exactly as in slice 1 where that turned up a real bug. Reviewers should weight the CI result accordingly.

Pre-flight checks that **did** run without a database: the test loader's module rewrites resolve; project-id generation is unique and URL-safe across 500 draws; `validateInboundBundle` accepts a valid bundle and rejects a dangling edge with pathed findings; Synk's caps are unchanged.

The new test covers: auth and scope gates (a `graph:read` token can read but gets 403 on write), owner scoping (another owner gets **404, never 403**, so ids cannot be probed), create/import with a 422 on a dangling-edge bundle, batch atomicity, **a refused mutation writing nothing** — not the snapshot, not the version, not one event — machine-readable refusal codes, `If-Match` 409 vs 200, agent writes attributed to `arkaik-agent`, journal accumulation excluding refused mutations, export round-trip, and archive semantics.

**Migrations are not run by deploy** — `migrate-prod.yml` fires only on pushes to `main` touching `db/migrations/**`. Confirm 008 applied before exercising this in production.

## Lab Note

```yaml
en:
  title: Your projects can now live in your account
  summary: Create a project that lives with your account instead of only in this browser — so the same map is there on another machine, and your coding agent can reach it too.
fr:
  title: Tes projets peuvent désormais vivre dans ton compte
  summary: Crée un projet hébergé dans ton compte plutôt que seulement dans ce navigateur — tu le retrouves sur une autre machine, et ton agent de code peut y accéder aussi.
suggested:
  molecule: arkaik
  type: feature
  tags: [changelog]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
