### PR TITLE
feat(mcp): the agent plane over hosted projects (slice 5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test:pyramid": "node tests/app/pyramid.test.js",
     "test:value-icons": "node tests/app/value-icons.test.js",
     "test:acceptance-matrix": "node tests/app/acceptance-matrix.test.js",
-    "test:mcp": "npm run build -w arkaik && npm run build -w arkaik-mcp && node tests/mcp/run-mcp-tests.js",
+    "test:mcp": "npm run build -w arkaik && npm run build -w arkaik-mcp && node tests/mcp/run-mcp-tests.js && node tests/mcp/remote-store.test.js",
     "test:journal-projections": "node tests/data/journal-projections.test.js",
     "test:emit": "node tests/schema/emit.test.js",
     "test:mutate": "node tests/schema/mutate.test.js",

--- a/packages/cli/src/commands/link.ts
+++ b/packages/cli/src/commands/link.ts
@@ -1,0 +1,165 @@
+/**
+ * `arkaik link [--project <id>] [--remote <url>] [--list] [path]`.
+ *
+ * Points a repo at a hosted Arkaik project, so a coding agent running here can
+ * read and edit that project through `arkaik-mcp`. This plus a token is the
+ * entire per-repo setup — the thing that has to stay trivial if the workflow is
+ * to be worth repeating across every project a person owns.
+ *
+ * Writes `docs/arkaik/arkaik.json`:
+ *
+ *   { "project_id": "prj_…", "remote": "https://arkaik.app" }
+ *
+ * THE TOKEN IS NEVER WRITTEN THERE. It is read from $ARKAIK_TOKEN at run time,
+ * because a credential in a repo file is a credential in a git history. The
+ * link file is safe to commit; the token is not.
+ *
+ * `--list` prints the projects the token can see, so the id can be chosen
+ * without leaving the terminal.
+ */
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+const LINK_FILE = "docs/arkaik/arkaik.json";
+const DEFAULT_BASE_URL = "https://arkaik.app";
+
+const USAGE = `arkaik link — point this repo at a hosted Arkaik project
+
+Usage:
+  arkaik link --project <id> [--remote <url>] [path]
+  arkaik link --list [--remote <url>]
+
+Options:
+  --project <id>    The hosted project id (prj_…).
+  --remote <url>    Instance origin. Default: ${DEFAULT_BASE_URL}
+  --list            List the projects this token can reach, then exit.
+  -h, --help        Show this help.
+
+Environment:
+  ARKAIK_TOKEN      Required. Create one at <origin>/settings/tokens.
+
+Writes ${LINK_FILE} with the project id and origin — safe to commit.
+The token is never written to disk.`;
+
+export interface RunLinkOptions {
+  /** Injectable for tests; defaults to the global fetch. */
+  httpClient?: typeof fetch;
+  cwd?: string;
+  env?: Record<string, string | undefined>;
+  log?: (message: string) => void;
+  errorLog?: (message: string) => void;
+}
+
+function flagValue(argv: readonly string[], flag: string): string | undefined {
+  const index = argv.indexOf(flag);
+  return index !== -1 ? argv[index + 1] : undefined;
+}
+
+export interface LinkResult {
+  ok: boolean;
+  /** The path written, when a link was established. */
+  path?: string;
+  projectId?: string;
+  baseUrl?: string;
+}
+
+export async function runLink(argv: string[], options: RunLinkOptions = {}): Promise<LinkResult> {
+  const log = options.log ?? ((m: string) => console.log(m));
+  const errorLog = options.errorLog ?? ((m: string) => console.error(m));
+  const env = options.env ?? process.env;
+  const cwd = options.cwd ?? process.cwd();
+  const doFetch = options.httpClient ?? ((...args: Parameters<typeof fetch>) => fetch(...args));
+
+  if (argv.includes("--help") || argv.includes("-h")) {
+    log(USAGE);
+    return { ok: true };
+  }
+
+  const baseUrl = (flagValue(argv, "--remote") ?? env.ARKAIK_URL ?? DEFAULT_BASE_URL).replace(/\/+$/, "");
+  const token = env.ARKAIK_TOKEN;
+  if (!token) {
+    errorLog(`ARKAIK_TOKEN is not set. Create a token at ${baseUrl}/settings/tokens and export it.`);
+    return { ok: false };
+  }
+
+  if (argv.includes("--list")) {
+    const res = await doFetch(`${baseUrl}/api/graph/projects`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) {
+      errorLog(describeFailure(res.status, baseUrl));
+      return { ok: false };
+    }
+    const body = (await res.json()) as { projects: Array<{ id: string; title: string; nodeCount: number }> };
+    if (body.projects.length === 0) {
+      log("No hosted projects yet. Create one in the app, or move a local project to your account.");
+      return { ok: true };
+    }
+    for (const project of body.projects) {
+      log(`  ${project.id}  ${project.title} (${project.nodeCount} nodes)`);
+    }
+    return { ok: true };
+  }
+
+  const projectId = flagValue(argv, "--project");
+  if (!projectId) {
+    errorLog("A project is required: arkaik link --project <id>   (or --list to see them)");
+    return { ok: false };
+  }
+
+  // Verify the link before writing it. A file that names a project the token
+  // cannot reach would fail later, inside an agent session, where the cause is
+  // far less obvious than it is here.
+  const res = await doFetch(`${baseUrl}/api/graph/projects/${encodeURIComponent(projectId)}`, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    errorLog(describeFailure(res.status, baseUrl, projectId));
+    return { ok: false };
+  }
+  const { bundle } = (await res.json()) as { bundle: { project: { title: string } } };
+
+  const target = resolve(cwd, argv.find((a) => !a.startsWith("--") && a !== projectId && a !== baseUrl) ?? ".");
+  const linkPath = join(target, LINK_FILE);
+  mkdirSync(dirname(linkPath), { recursive: true });
+
+  // Preserve any unknown keys — this file is the natural home for future
+  // per-repo settings, and clobbering them on every link would be hostile.
+  let existing: Record<string, unknown> = {};
+  try {
+    existing = JSON.parse(readFileSync(linkPath, "utf8")) as Record<string, unknown>;
+  } catch {
+    // absent or unreadable — a fresh link
+  }
+
+  writeFileSync(
+    linkPath,
+    `${JSON.stringify({ ...existing, project_id: projectId, remote: baseUrl }, null, 2)}\n`,
+  );
+
+  log(`Linked to "${bundle.project.title}" (${projectId}).`);
+  log(`Wrote ${LINK_FILE} — safe to commit; the token stays in your environment.`);
+  log("");
+  log("Your coding agent can now reach this project:");
+  log("  npx -y arkaik-mcp            # picks up the link file automatically");
+
+  return { ok: true, path: linkPath, projectId, baseUrl };
+}
+
+function describeFailure(status: number, baseUrl: string, projectId?: string): string {
+  if (status === 401) return `Unauthorized — check ARKAIK_TOKEN (create one at ${baseUrl}/settings/tokens).`;
+  if (status === 403) return "Forbidden — this token lacks the graph:read scope.";
+  if (status === 404) {
+    return projectId
+      ? `No project "${projectId}" in this account. Run \`arkaik link --list\` to see the ids.`
+      : "Not found.";
+  }
+  return `Request failed (${status}).`;
+}
+
+export function runLinkCli(argv: string[]): void {
+  void runLink(argv).then((result) => {
+    if (!result.ok) process.exit(1);
+  });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,6 +15,7 @@ import { runSyncCli } from "./commands/sync";
 import { runPackCli } from "./commands/pack";
 import { runOpenCli } from "./commands/open";
 import { runPushCli } from "./commands/push";
+import { runLinkCli } from "./commands/link";
 
 const USAGE = `arkaik — CLI for Arkaik project bundles
 
@@ -31,6 +32,8 @@ Commands:
   open [options] [path]       Validate, then hand off the packed bundle to arkaik.app import.
   push [options] [path]       Validate, pack (journal stripped), and publish to Publik.
                                --delete <id> --key <owner_key> removes a snapshot.
+  link [options] [path]       Point this repo at a hosted project so an agent can edit it.
+                               --list shows the projects your token can reach.
 
 Options:
   -h, --help        Show this help.
@@ -69,6 +72,9 @@ function main(argv: string[]): void {
       return;
     case "push":
       runPushCli(rest);
+      return;
+    case "link":
+      runLinkCli(rest);
       return;
     default:
       console.error(`Unknown command: ${command}\n`);

--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -1,0 +1,97 @@
+/**
+ * Resolving "which project, where, with what credential" for hosted mode.
+ *
+ * The link file (`docs/arkaik/arkaik.json`, written by `arkaik link`) carries
+ * the project id and origin, because those are per-repo facts worth committing.
+ * The TOKEN never appears there and is only ever read from the environment — a
+ * credential in a repo file is a credential in a git history.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** Where `arkaik link` writes, relative to the repo root. */
+export const LINK_FILE = "docs/arkaik/arkaik.json";
+
+/** The public instance, used when nothing names another. */
+export const DEFAULT_BASE_URL = "https://arkaik.app";
+
+export interface LinkFile {
+  project_id?: string;
+  remote?: string;
+}
+
+export type RemoteConfig =
+  | { mode: "file" }
+  | { mode: "remote"; projectId: string; baseUrl: string; token: string };
+
+/** Read the link file, or null when absent/unreadable/malformed. */
+export function readLinkFile(cwd: string): LinkFile | null {
+  try {
+    const parsed = JSON.parse(readFileSync(join(cwd, LINK_FILE), "utf8")) as unknown;
+    if (typeof parsed !== "object" || parsed === null) return null;
+    return parsed as LinkFile;
+  } catch {
+    return null;
+  }
+}
+
+function flagValue(argv: readonly string[], flag: string): string | undefined {
+  const index = argv.indexOf(flag);
+  return blankToUndefined(index !== -1 ? argv[index + 1] : undefined);
+}
+
+/**
+ * Treat an empty or whitespace-only value as absent.
+ *
+ * `??` only falls back on null/undefined, so `ARKAIK_PROJECT=` in the
+ * environment — which every shell and CI system produces when a variable is
+ * declared but unset — would otherwise read as a real (empty) project id and
+ * silently drop the session back to the repo bundle.
+ */
+function blankToUndefined(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+/**
+ * Decide the mode. Hosted mode is chosen when `--remote` is passed, or when a
+ * project id is available from `--project`, `$ARKAIK_PROJECT`, or a link file.
+ *
+ * Choosing hosted mode WITHOUT a token is an error rather than a silent
+ * fallback to the repo bundle: a linked repo that quietly served a stale local
+ * file because a token expired is the kind of failure an agent cannot notice.
+ */
+export function resolveRemoteConfig(
+  argv: readonly string[],
+  env: Record<string, string | undefined>,
+  cwd: string,
+): RemoteConfig {
+  const link = readLinkFile(cwd);
+  const explicitRemote = argv.includes("--remote");
+  const projectId =
+    flagValue(argv, "--project") ?? blankToUndefined(env.ARKAIK_PROJECT) ?? blankToUndefined(link?.project_id);
+
+  // An explicit --bundle always means the repo file, whatever else is set.
+  if (argv.includes("--bundle") && !explicitRemote) return { mode: "file" };
+  if (!explicitRemote && !projectId) return { mode: "file" };
+
+  if (!projectId) {
+    throw new Error(
+      "--remote needs a project: pass --project <id>, set ARKAIK_PROJECT, or run `npx arkaik link`.",
+    );
+  }
+  const token = blankToUndefined(env.ARKAIK_TOKEN);
+  if (!token) {
+    throw new Error(
+      `ARKAIK_TOKEN is not set. Create a token at ${link?.remote ?? DEFAULT_BASE_URL}/settings/tokens and export it.`,
+    );
+  }
+
+  return {
+    mode: "remote",
+    projectId,
+    baseUrl: blankToUndefined(env.ARKAIK_URL) ?? blankToUndefined(link?.remote) ?? DEFAULT_BASE_URL,
+    token,
+  };
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -7,7 +7,9 @@
 
 import { startServer } from "./protocol";
 import { buildCatalog } from "./tools";
-import { resolveBundlePath } from "./store";
+import { createFileStore, resolveBundlePath, type Store } from "./store";
+import { createRemoteStore } from "./remote-store";
+import { resolveRemoteConfig } from "./config";
 
 const VERSION = "0.1.0";
 
@@ -16,12 +18,20 @@ const argv = process.argv.slice(2);
 if (argv.includes("--help") || argv.includes("-h")) {
   process.stdout.write(
     [
-      "arkaik-mcp — MCP server over an Arkaik repo bundle (stdio transport)",
+      "arkaik-mcp — MCP server over an Arkaik product graph (stdio transport)",
       "",
-      "Usage: arkaik-mcp [--bundle <path>]",
+      "Usage: arkaik-mcp [--bundle <path>] [--remote] [--project <id>]",
       "",
-      "Bundle resolution: --bundle, then $ARKAIK_BUNDLE, then docs/arkaik/bundle.json.",
-      "The journal is the sibling journal.jsonl sidecar (embedded journal[] wins).",
+      "Repo mode (default):",
+      "  Bundle resolution: --bundle, then $ARKAIK_BUNDLE, then docs/arkaik/bundle.json.",
+      "  The journal is the sibling journal.jsonl sidecar (embedded journal[] wins).",
+      "",
+      "Hosted mode (--remote, or a docs/arkaik/arkaik.json written by `arkaik link`):",
+      "  Project:  --project, then $ARKAIK_PROJECT, then arkaik.json",
+      "  Token:    $ARKAIK_TOKEN (create one at <origin>/settings/tokens)",
+      "  Origin:   $ARKAIK_URL, then arkaik.json, then https://arkaik.app",
+      "",
+      "The tool catalog is identical in both modes.",
       "Docs: docs/spec/mcp.md",
       "",
     ].join("\n"),
@@ -29,11 +39,34 @@ if (argv.includes("--help") || argv.includes("-h")) {
   process.exit(0);
 }
 
-const bundlePath = resolveBundlePath(argv, process.env);
-const { tools, handlers } = buildCatalog({ bundlePath });
+/**
+ * Repo bundle or hosted project — the ONLY thing that differs between the two
+ * modes. The catalog built below is the same either way.
+ */
+function resolveStore(): Store {
+  const remote = resolveRemoteConfig(argv, process.env, process.cwd());
+  if (remote.mode === "remote") {
+    return createRemoteStore({
+      baseUrl: remote.baseUrl,
+      projectId: remote.projectId,
+      token: remote.token,
+    });
+  }
+  return createFileStore(resolveBundlePath(argv, process.env));
+}
+
+let store: Store;
+try {
+  store = resolveStore();
+} catch (error) {
+  process.stderr.write(`arkaik-mcp: ${(error as Error).message}\n`);
+  process.exit(1);
+}
+
+const { tools, handlers } = buildCatalog({ store });
 
 // stderr only — stdout belongs to the protocol.
-process.stderr.write(`arkaik-mcp v${VERSION} — bundle: ${bundlePath}\n`);
+process.stderr.write(`arkaik-mcp v${VERSION} — ${store.describe()}\n`);
 
 startServer({
   serverInfo: { name: "arkaik-mcp", version: VERSION },

--- a/packages/mcp/src/protocol.ts
+++ b/packages/mcp/src/protocol.ts
@@ -30,7 +30,8 @@ export interface ToolDefinition {
  * for expected, agent-actionable failures (unknown node, refused mutation) —
  * they become `isError` tool results, not protocol errors.
  */
-export type ToolHandler = (args: Record<string, unknown>) => unknown;
+/** A tool handler. May be sync (file-backed) or async (HTTP-backed). */
+export type ToolHandler = (args: Record<string, unknown>) => unknown | Promise<unknown>;
 
 export class ToolError extends Error {
   /** Structured payload serialized as the error content (e.g. validator findings). */
@@ -73,7 +74,16 @@ export function startServer(options: ServerOptions): Promise<void> {
     send({ jsonrpc: "2.0", id, error: { code, message } });
   };
 
-  const handleToolCall = (id: number | string | null, params: Record<string, unknown>) => {
+  /**
+   * Async because a handler may now be backed by HTTP rather than the
+   * filesystem (`RemoteStore`). `await` on a plain value is a no-op, so
+   * file-backed handlers are unaffected — but WITHOUT it a promise-returning
+   * handler serializes as `{}` and the tool silently returns nothing.
+   *
+   * Responses may now complete out of order relative to requests; JSON-RPC
+   * correlates by `id`, so that is exactly what the protocol expects.
+   */
+  const handleToolCall = async (id: number | string | null, params: Record<string, unknown>) => {
     const name = params.name;
     if (typeof name !== "string") {
       respondError(id, JSONRPC_INVALID_PARAMS, "tools/call requires a string `name`.");
@@ -91,7 +101,7 @@ export function startServer(options: ServerOptions): Promise<void> {
         : {};
 
     try {
-      const result = handler(args);
+      const result = await handler(args);
       respond(id, { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] });
     } catch (error) {
       if (error instanceof ToolError) {
@@ -102,6 +112,9 @@ export function startServer(options: ServerOptions): Promise<void> {
       }
     }
   };
+
+  /** Tool calls still running; the loop drains these before it resolves. */
+  const inFlight = new Set<Promise<void>>();
 
   const handle = (message: JsonRpcMessage) => {
     const id = message.id ?? null;
@@ -124,9 +137,17 @@ export function startServer(options: ServerOptions): Promise<void> {
       case "tools/list":
         respond(id, { tools: options.tools });
         return;
-      case "tools/call":
-        handleToolCall(id, message.params ?? {});
+      case "tools/call": {
+        // Tracked, not fire-and-forget. A handler may be waiting on HTTP, and
+        // the stream can close while it is in flight — a client that writes a
+        // request and closes stdin would otherwise never receive its response,
+        // because the server would resolve and the process exit first.
+        const settled = handleToolCall(id, message.params ?? {}).finally(() => {
+          inFlight.delete(settled);
+        });
+        inFlight.add(settled);
         return;
+      }
       default:
         if (message.id !== undefined) {
           respondError(id, JSONRPC_METHOD_NOT_FOUND, `Method not found: ${message.method ?? "(none)"}`);
@@ -147,7 +168,12 @@ export function startServer(options: ServerOptions): Promise<void> {
       }
       handle(message);
     });
-    lines.on("close", () => resolvePromise());
+    // Drain before resolving, so a response in flight when stdin closed is
+    // still written. Promise.allSettled — a handler rejection must not prevent
+    // the others from finishing.
+    lines.on("close", () => {
+      void Promise.allSettled([...inFlight]).then(() => resolvePromise());
+    });
   });
 }
 

--- a/packages/mcp/src/remote-store.ts
+++ b/packages/mcp/src/remote-store.ts
@@ -1,0 +1,161 @@
+/**
+ * `RemoteStore` — the agent plane over a hosted project (docs/spec/mcp.md
+ * § Non-Goals → "Hosted MCP / REST over Synk projects", now built).
+ *
+ * The tool catalog does not change. `tools.ts` is written against the `Store`
+ * interface and knows nothing about where the graph lives, so `list_nodes`,
+ * `get_node`, `create_node` and the rest are literally the same code against a
+ * repo file or an account. That is the point: local and remote cannot drift,
+ * because there is only one implementation of each tool.
+ *
+ * What differs is only what a `Store` is for:
+ *  - `load()` is two HTTP reads (snapshot + journal) instead of two file reads;
+ *  - `persist()` posts the ops to `POST /api/graph/projects/{id}/mutations`,
+ *    where the SERVER runs `applyOps` and `validateBundle` inside a row-locked
+ *    transaction. The refusal semantics are identical because it is the same
+ *    validator — the gate simply lives on the other side of the wire.
+ *
+ * A consequence worth stating: this store sends OPS, not a mutated graph. The
+ * server recomputes the result under its own lock, so two agents editing one
+ * project cannot clobber each other the way "read, mutate locally, write back"
+ * would allow.
+ */
+
+import type { EventInput, JournalEvent, Project, ValidationFinding } from "@arkaik/schema";
+
+import type { LoadedGraph, Store, WriteResult } from "./store";
+
+/** Events written through this store are attributed to the agent plane. */
+export const REMOTE_ACTOR = "arkaik-agent";
+
+export interface RemoteStoreOptions {
+  baseUrl: string;
+  projectId: string;
+  token: string;
+  /** Injectable for tests; defaults to the global fetch. */
+  fetchImpl?: typeof fetch;
+}
+
+export function createRemoteStore(options: RemoteStoreOptions): Store {
+  const doFetch = options.fetchImpl ?? ((...args: Parameters<typeof fetch>) => fetch(...args));
+  const base = options.baseUrl.replace(/\/+$/, "");
+  const projectPath = `${base}/api/graph/projects/${encodeURIComponent(options.projectId)}`;
+
+  async function request<T>(path: string, init?: RequestInit): Promise<T> {
+    const res = await doFetch(`${projectPath}${path}`, {
+      ...init,
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${options.token}`,
+        ...(init?.headers ?? {}),
+      },
+    });
+    const body = await res.json().catch(() => null);
+    if (!res.ok) {
+      const err = new Error(describeFailure(res.status, body)) as Error & { status: number; body: unknown };
+      err.status = res.status;
+      err.body = body;
+      throw err;
+    }
+    return body as T;
+  }
+
+  return {
+    async load(): Promise<LoadedGraph> {
+      // Two reads rather than one /export: the journal can be large and most
+      // tool calls never look at it, but `get_changelog` and the timeline
+      // projections do — so it is fetched, just not merged into the snapshot.
+      const [{ bundle }, { journal }] = await Promise.all([
+        request<{ bundle: Record<string, unknown> }>(""),
+        request<{ journal: JournalEvent[] }>("/journal"),
+      ]);
+
+      const nodes = (bundle.nodes ?? []) as unknown[];
+      const edges = (bundle.edges ?? []) as unknown[];
+
+      return {
+        // `loaded` mirrors the file store's BundleValidation shape closely
+        // enough for the read tools, which only ever touch bundle/nodes/edges/
+        // journal. The server has already validated everything it stores, so
+        // there are no findings to carry here.
+        loaded: {
+          bundle: { ...bundle, journal },
+          nodes,
+          edges,
+          journal,
+          sidecarLoaded: false,
+          errors: [] as ValidationFinding[],
+          warnings: [] as ValidationFinding[],
+        } as unknown as LoadedGraph["loaded"],
+        nodes,
+        edges,
+        project: bundle.project as Project,
+        journal,
+      };
+    },
+
+    // `inputs` is deliberately not accepted: the locally-derived events are not
+    // sent. The server derives its own from the ops it applies, so that the
+    // events stored alongside a graph are always the ones that produced it —
+    // a client cannot describe a change differently from how it was made.
+    async persist(_graph, next): Promise<WriteResult> {
+      const ops = next.ops;
+      if (!ops || ops.length === 0) {
+        // A journal-only tool (propose_idea, file_request) has no graph ops.
+        // Those are not yet expressible through the mutations endpoint, so they
+        // are refused loudly rather than silently dropped.
+        return {
+          ok: false,
+          errors: [
+            {
+              path: "",
+              rule: "remote-unsupported",
+              message:
+                "This tool writes a journal-only event, which the hosted API does not accept yet. Run against a repo bundle for now.",
+              severity: "error",
+            },
+          ],
+          warnings: [],
+        };
+      }
+
+      try {
+        const result = await request<{
+          version: string;
+          events: JournalEvent[];
+          warnings: ValidationFinding[];
+        }>("/mutations", { method: "POST", body: JSON.stringify({ ops }) });
+        return { ok: true, warnings: result.warnings ?? [], events: result.events ?? [] };
+      } catch (err) {
+        const e = err as Error & { status?: number; body?: { errors?: ValidationFinding[]; message?: string; code?: string } };
+        // 422 is the server's refusal — either validator findings or a refused
+        // op. Both map onto the same shape the file store returns, so the tool
+        // layer reports them identically whichever side produced them.
+        if (e.status === 422) {
+          return {
+            ok: false,
+            errors: e.body?.errors ?? [
+              { path: "", rule: e.body?.code ?? "mutation-refused", message: e.body?.message ?? e.message, severity: "error" },
+            ],
+            warnings: [],
+          };
+        }
+        throw err;
+      }
+    },
+
+    describe() {
+      return `hosted project: ${options.projectId} at ${base}`;
+    },
+  };
+}
+
+function describeFailure(status: number, body: unknown): string {
+  const b = body as { error?: string; message?: string } | null;
+  if (status === 401) return "Unauthorized — check ARKAIK_TOKEN (create one at /settings/tokens).";
+  if (status === 403) return `Forbidden — ${b?.message ?? b?.error ?? "the token lacks the required scope"}.`;
+  if (status === 404) return "Project not found — check the project id, or that the token's account owns it.";
+  return b?.message ?? b?.error ?? `Request failed (${status}).`;
+}
+
+export type { EventInput };

--- a/packages/mcp/src/store.ts
+++ b/packages/mcp/src/store.ts
@@ -13,6 +13,8 @@ import {
   validateBundle,
   type EventInput,
   type JournalEvent,
+  type MutationOp,
+  type Project,
   type ValidationFinding,
 } from "@arkaik/schema";
 import { appendJournalEvent, journalPathFor, validateBundleAt, type BundleValidation } from "arkaik/io";
@@ -58,6 +60,46 @@ export interface WriteSuccess {
 }
 
 export type WriteResult = WriteRefusal | WriteSuccess;
+
+/** The graph a tool reads, however it was obtained. */
+export interface LoadedGraph {
+  loaded: BundleValidation;
+  nodes: unknown[];
+  edges: unknown[];
+  project: Project;
+  journal: JournalEvent[];
+}
+
+/**
+ * Where the bundle lives — the one thing that differs between running against a
+ * repo file and running against a hosted project.
+ *
+ * `tools.ts` and the 14-tool catalog are written against this interface and know
+ * nothing else, which is what makes local and remote incapable of drifting: the
+ * tools, their schemas, their filters and their result shapes are literally the
+ * same code. A remote session is a different `Store`, not a different server.
+ */
+export interface Store {
+  /** A fresh read per tool call — external edits must be picked up. */
+  load(): Promise<LoadedGraph>;
+  /**
+   * Apply a mutation. Refusals carry pathed findings and write nothing.
+   *
+   * `next` carries BOTH forms of the same change, because the two stores need
+   * different ones: `nodes`/`edges` are the outcome `applyOps` computed here,
+   * which the file store writes directly; `ops` is the intent, which the remote
+   * store sends so the SERVER can recompute it under its own row lock. Sending
+   * an outcome to the server would be a read-modify-write, and two agents on
+   * one project could then clobber each other.
+   */
+  persist(
+    graph: LoadedGraph,
+    next: { nodes?: unknown[]; edges?: unknown[]; ops?: readonly MutationOp[] },
+    inputs: readonly EventInput[],
+  ): Promise<WriteResult>;
+  /** For the startup banner. */
+  describe(): string;
+}
 
 /**
  * The dual-write path (docs/spec/mcp.md § Write Path), in order: derive the
@@ -107,4 +149,37 @@ export function persistMutation(
   }
 
   return { ok: true, warnings: result.warnings, events };
+}
+
+// ---------------------------------------------------------------------------
+// FileStore — the repo bundle (the original, unchanged behaviour)
+// ---------------------------------------------------------------------------
+
+/** A `Store` over `docs/arkaik/bundle.json` + its journal sidecar. */
+export function createFileStore(bundlePath: string): Store {
+  return {
+    async load(): Promise<LoadedGraph> {
+      let loaded: BundleValidation;
+      try {
+        loaded = loadBundle(bundlePath);
+      } catch (error) {
+        throw new Error(`Cannot load bundle at ${bundlePath}: ${(error as Error).message}`);
+      }
+      return {
+        loaded,
+        nodes: loaded.nodes,
+        edges: loaded.edges,
+        project: (loaded.bundle as { project: Project }).project,
+        journal: loaded.journal as JournalEvent[],
+      };
+    },
+
+    async persist(graph, next, inputs) {
+      return persistMutation(bundlePath, graph.loaded, next, inputs);
+    },
+
+    describe() {
+      return `bundle: ${bundlePath}`;
+    },
+  };
 }

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -34,35 +34,40 @@ import {
   type ReleaseTaggedEvent,
   type ValueId,
 } from "@arkaik/schema";
-import type { BundleValidation } from "arkaik/io";
 import { ToolError, type ToolDefinition, type ToolHandler } from "./protocol";
-import { loadBundle, persistMutation, type WriteResult } from "./store";
+import type { LoadedGraph as StoreLoadedGraph, Store, WriteResult } from "./store";
 
 interface ToolContext {
-  bundlePath: string;
+  store: Store;
 }
 
+/** The tools' view of a loaded graph — narrowed from the Store's shape. */
 interface LoadedGraph {
-  loaded: BundleValidation;
+  loaded: StoreLoadedGraph["loaded"];
   nodes: Node[];
   edges: Edge[];
   project: Project;
   journal: JournalEvent[];
 }
 
-function load(ctx: ToolContext): LoadedGraph {
-  let loaded: BundleValidation;
+/**
+ * A fresh read per tool call, from whichever Store this session was given.
+ * Errors become ToolErrors so a bad path or an unreachable server surfaces to
+ * the agent as an actionable message rather than a protocol fault.
+ */
+async function load(ctx: ToolContext): Promise<LoadedGraph> {
+  let graph: StoreLoadedGraph;
   try {
-    loaded = loadBundle(ctx.bundlePath);
+    graph = await ctx.store.load();
   } catch (error) {
-    throw new ToolError(`Cannot load bundle at ${ctx.bundlePath}: ${(error as Error).message}`);
+    throw new ToolError(`Cannot load ${ctx.store.describe()}: ${(error as Error).message}`);
   }
   return {
-    loaded,
-    nodes: loaded.nodes as Node[],
-    edges: loaded.edges as Edge[],
-    project: (loaded.bundle as { project: Project }).project,
-    journal: loaded.journal as JournalEvent[],
+    loaded: graph.loaded,
+    nodes: graph.nodes as Node[],
+    edges: graph.edges as Edge[],
+    project: graph.project,
+    journal: graph.journal,
   };
 }
 
@@ -183,8 +188,8 @@ export function buildCatalog(ctx: ToolContext): { tools: ToolDefinition[]; handl
         additionalProperties: false,
       },
     },
-    (args) => {
-      const { nodes, edges } = load(ctx);
+    async (args) => {
+      const { nodes, edges } = await load(ctx);
       const query = typeof args.query === "string" ? args.query.toLowerCase() : undefined;
       const limit = typeof args.limit === "number" && args.limit >= 1 ? Math.floor(args.limit) : 50;
       const anchorCoveringIds =
@@ -223,9 +228,9 @@ export function buildCatalog(ctx: ToolContext): { tools: ToolDefinition[]; handl
         additionalProperties: false,
       },
     },
-    (args) => {
+    async (args) => {
       const nodeId = requireString(args, "node_id");
-      const { nodes, edges, journal } = load(ctx);
+      const { nodes, edges, journal } = await load(ctx);
       const node = findNode(nodes, nodeId);
       const nodesById = new Map(nodes.map((candidate) => [candidate.id, candidate]));
 
@@ -286,8 +291,8 @@ export function buildCatalog(ctx: ToolContext): { tools: ToolDefinition[]; handl
         additionalProperties: false,
       },
     },
-    (args) => {
-      const { nodes, journal } = load(ctx);
+    async (args) => {
+      const { nodes, journal } = await load(ctx);
       const nodesById = new Map(nodes.map((node) => [node.id, node]));
       if (typeof args.version === "string") {
         return computeChangelog(journal, args.version, { nodesById });
@@ -302,8 +307,8 @@ export function buildCatalog(ctx: ToolContext): { tools: ToolDefinition[]; handl
       description: "Open ideas and requests — journal items not yet realized as nodes in the snapshot.",
       inputSchema: { type: "object", properties: {}, additionalProperties: false },
     },
-    () => {
-      const { nodes, journal } = load(ctx);
+    async () => {
+      const { nodes, journal } = await load(ctx);
       return computeBacklog(journal, { existingNodeIds: new Set(nodes.map((node) => node.id)) });
     },
   );
@@ -314,8 +319,8 @@ export function buildCatalog(ctx: ToolContext): { tools: ToolDefinition[]; handl
       description: "Every map the project offers — built-ins plus stored definitions — with live subgraph sizes.",
       inputSchema: { type: "object", properties: {}, additionalProperties: false },
     },
-    () => {
-      const { nodes, edges, project } = load(ctx);
+    async () => {
+      const { nodes, edges, project } = await load(ctx);
       return {
         maps: listMaps(project).map((definition) => {
           const subgraph = computeMapSubgraph(definition, nodes, edges);
@@ -336,9 +341,9 @@ export function buildCatalog(ctx: ToolContext): { tools: ToolDefinition[]; handl
         additionalProperties: false,
       },
     },
-    (args) => {
+    async (args) => {
       const mapId = requireString(args, "map_id");
-      const { nodes, edges, project } = load(ctx);
+      const { nodes, edges, project } = await load(ctx);
       const definition = listMaps(project).find((candidate) => candidate.id === mapId);
       if (!definition) throw new ToolError(`No map with id "${mapId}".`);
       const subgraph = computeMapSubgraph(definition, nodes, edges);
@@ -352,8 +357,8 @@ export function buildCatalog(ctx: ToolContext): { tools: ToolDefinition[]; handl
       description: "Run the full validator over the bundle (+ journal sidecar): errors, warnings, and line findings.",
       inputSchema: { type: "object", properties: {}, additionalProperties: false },
     },
-    () => {
-      const { loaded } = load(ctx);
+    async () => {
+      const { loaded } = await load(ctx);
       return {
         valid: loaded.valid,
         errors: loaded.result.errors,
@@ -384,8 +389,8 @@ export function buildCatalog(ctx: ToolContext): { tools: ToolDefinition[]; handl
         additionalProperties: false,
       },
     },
-    (args) => {
-      const graph = load(ctx);
+    async (args) => {
+      const graph = await load(ctx);
       const species = requireString(args, "species") as Node["species"];
       const title = requireString(args, "title");
       const platforms = Array.isArray(args.platforms) ? (args.platforms as Node["platforms"]) : [];
@@ -405,11 +410,11 @@ export function buildCatalog(ctx: ToolContext): { tools: ToolDefinition[]; handl
 
       // applyOps folds in the composes edges a populated playlist requires, so
       // a full flow still lands in one validated write (issue #263).
-      const outcome = mutate(graph, [{ op: "create_node", node }]);
-      const result = persistMutation(
-        ctx.bundlePath,
-        graph.loaded,
-        { nodes: outcome.nodes, edges: outcome.edges },
+      const ops: MutationOp[] = [{ op: "create_node", node }];
+      const outcome = mutate(graph, ops);
+      const result = await ctx.store.persist(
+        graph,
+        { nodes: outcome.nodes, edges: outcome.edges, ops },
         outcome.eventInputs,
       );
       const { warnings, events } = unwrap(result);
@@ -442,7 +447,7 @@ export function buildCatalog(ctx: ToolContext): { tools: ToolDefinition[]; handl
         additionalProperties: false,
       },
     },
-    (args) => {
+    async (args) => {
       const nodeId = requireString(args, "node_id");
       if (typeof args.patch !== "object" || args.patch === null || Array.isArray(args.patch)) {
         throw new ToolError("`patch` is required and must be an object.");
@@ -454,21 +459,21 @@ export function buildCatalog(ctx: ToolContext): { tools: ToolDefinition[]; handl
         }
       }
 
-      const graph = load(ctx);
+      const graph = await load(ctx);
       const current = findNode(graph.nodes, nodeId);
 
       // applyOps derives no events for a patch that changes nothing, which is
       // how a no-op stays a no-op: nothing is written and no journal line lands.
-      const outcome = mutate(graph, [{ op: "update_node", node_id: nodeId, patch }]);
+      const ops: MutationOp[] = [{ op: "update_node", node_id: nodeId, patch }];
+      const outcome = mutate(graph, ops);
       if (outcome.eventInputs.length === 0) {
         return { node: current, events: [], note: "No-op patch — nothing changed, nothing written." };
       }
 
       const updated = outcome.nodes.find((candidate) => candidate.id === nodeId)!;
-      const result = persistMutation(
-        ctx.bundlePath,
-        graph.loaded,
-        { nodes: outcome.nodes, edges: outcome.edges },
+      const result = await ctx.store.persist(
+        graph,
+        { nodes: outcome.nodes, edges: outcome.edges, ops },
         outcome.eventInputs,
       );
       const { warnings, events } = unwrap(result);
@@ -487,16 +492,16 @@ export function buildCatalog(ctx: ToolContext): { tools: ToolDefinition[]; handl
         additionalProperties: false,
       },
     },
-    (args) => {
+    async (args) => {
       const nodeId = requireString(args, "node_id");
-      const graph = load(ctx);
+      const graph = await load(ctx);
       const node = findNode(graph.nodes, nodeId);
 
-      const outcome = mutate(graph, [{ op: "delete_node", node_id: nodeId }]);
-      const result = persistMutation(
-        ctx.bundlePath,
-        graph.loaded,
-        { nodes: outcome.nodes, edges: outcome.edges },
+      const ops: MutationOp[] = [{ op: "delete_node", node_id: nodeId }];
+      const outcome = mutate(graph, ops);
+      const result = await ctx.store.persist(
+        graph,
+        { nodes: outcome.nodes, edges: outcome.edges, ops },
         outcome.eventInputs,
       );
       const { warnings, events } = unwrap(result);
@@ -520,11 +525,11 @@ export function buildCatalog(ctx: ToolContext): { tools: ToolDefinition[]; handl
         additionalProperties: false,
       },
     },
-    (args) => {
+    async (args) => {
       const sourceId = requireString(args, "source_id");
       const targetId = requireString(args, "target_id");
       const edgeType = requireString(args, "edge_type") as Edge["edge_type"];
-      const graph = load(ctx);
+      const graph = await load(ctx);
 
       const edge: Edge = {
         id: edgeId(sourceId, targetId),
@@ -540,11 +545,11 @@ export function buildCatalog(ctx: ToolContext): { tools: ToolDefinition[]; handl
         throw new ToolError(`Edge "${edge.id}" already exists.`);
       }
 
-      const outcome = mutate(graph, [{ op: "create_edge", edge }]);
-      const result = persistMutation(
-        ctx.bundlePath,
-        graph.loaded,
-        { nodes: outcome.nodes, edges: outcome.edges },
+      const ops: MutationOp[] = [{ op: "create_edge", edge }];
+      const outcome = mutate(graph, ops);
+      const result = await ctx.store.persist(
+        graph,
+        { nodes: outcome.nodes, edges: outcome.edges, ops },
         outcome.eventInputs,
       );
       const { warnings, events } = unwrap(result);
@@ -563,17 +568,17 @@ export function buildCatalog(ctx: ToolContext): { tools: ToolDefinition[]; handl
         additionalProperties: false,
       },
     },
-    (args) => {
+    async (args) => {
       const edgeIdArg = requireString(args, "edge_id");
-      const graph = load(ctx);
+      const graph = await load(ctx);
       const edge = graph.edges.find((candidate) => candidate.id === edgeIdArg);
       if (!edge) throw new ToolError(`No edge with id "${edgeIdArg}".`);
 
-      const outcome = mutate(graph, [{ op: "delete_edge", edge_id: edgeIdArg }]);
-      const result = persistMutation(
-        ctx.bundlePath,
-        graph.loaded,
-        { nodes: outcome.nodes, edges: outcome.edges },
+      const ops: MutationOp[] = [{ op: "delete_edge", edge_id: edgeIdArg }];
+      const outcome = mutate(graph, ops);
+      const result = await ctx.store.persist(
+        graph,
+        { nodes: outcome.nodes, edges: outcome.edges, ops },
         outcome.eventInputs,
       );
       const { warnings, events } = unwrap(result);
@@ -581,16 +586,16 @@ export function buildCatalog(ctx: ToolContext): { tools: ToolDefinition[]; handl
     },
   );
 
-  const journalOnly = (type: "idea.proposed" | "request.filed") => (args: Record<string, unknown>) => {
+  const journalOnly = (type: "idea.proposed" | "request.filed") => async (args: Record<string, unknown>) => {
     const title = requireString(args, "title");
-    const graph = load(ctx);
+    const graph = await load(ctx);
     const payload: Record<string, unknown> = { title };
     if (typeof args.description === "string") payload.description = args.description;
     if (typeof args.node_id === "string") payload.node_id = args.node_id;
     if (type === "request.filed" && typeof args.source === "string") payload.source = args.source;
 
     const input: EventInput = { type, payload };
-    const result = persistMutation(ctx.bundlePath, graph.loaded, {}, [input]);
+    const result = await ctx.store.persist(graph, {}, [input]);
     const { warnings, events } = unwrap(result);
     return { events, warnings };
   };

--- a/tests/mcp/remote-store.test.js
+++ b/tests/mcp/remote-store.test.js
@@ -1,0 +1,332 @@
+#!/usr/bin/env node
+
+/**
+ * Parity between the two MCP stores (packages/mcp/src/remote-store.ts).
+ *
+ * The claim slice 5 rests on is that the tool catalog is IDENTICAL in repo mode
+ * and hosted mode — that a remote session is a different `Store`, not a
+ * different server. These tests exercise the built server over stdio with a
+ * stub HTTP server standing in for the hosted API, and assert:
+ *
+ *   - tools/list is byte-identical to repo mode (the catalog does not branch);
+ *   - a read tool returns the same shape from the API as from a file;
+ *   - a write goes to the ONE mutations endpoint, sending OPS rather than a
+ *     mutated graph — so the server recomputes under its own lock and two
+ *     agents cannot clobber each other;
+ *   - a 422 from the server surfaces as the same refusal a local validator
+ *     failure produces;
+ *   - configuration resolution: a link file is picked up, --bundle still wins,
+ *     and hosted mode without a token fails loudly rather than silently
+ *     serving a stale local file.
+ */
+
+const { spawn } = require("node:child_process");
+const http = require("node:http");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const ROOT = path.join(__dirname, "..", "..");
+const SERVER = path.join(ROOT, "packages", "mcp", "dist", "index.js");
+
+let failures = 0;
+function check(name, cond, detail) {
+  if (cond) {
+    console.log(`PASS: ${name}`);
+  } else {
+    failures++;
+    console.log(`FAIL: ${name}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+const PROJECT_ID = "prj_test123";
+
+function makeBundle() {
+  return {
+    schema_version: 2,
+    project: {
+      id: "gp",
+      title: "Hosted graph",
+      created_at: "2026-01-01T00:00:00.000Z",
+      updated_at: "2026-01-01T00:00:00.000Z",
+    },
+    nodes: [
+      { id: "V-home", project_id: "gp", species: "view", title: "Home", status: "idea", platforms: ["web"] },
+      { id: "V-settings", project_id: "gp", species: "view", title: "Settings", status: "live", platforms: ["web"] },
+    ],
+    edges: [],
+  };
+}
+
+/** A stub of the hosted API, recording every request it receives. */
+function startStubServer(state) {
+  const server = http.createServer((req, res) => {
+    state.requests.push(`${req.method} ${req.url}`);
+
+    const auth = req.headers.authorization;
+    if (auth !== `Bearer ${state.token}`) {
+      res.writeHead(401, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: "unauthorized" }));
+      return;
+    }
+
+    const json = (status, body) => {
+      res.writeHead(status, { "content-type": "application/json" });
+      res.end(JSON.stringify(body));
+    };
+
+    if (req.url === `/api/graph/projects/${PROJECT_ID}` && req.method === "GET") {
+      return json(200, { bundle: state.bundle, version: "1" });
+    }
+    if (req.url === `/api/graph/projects/${PROJECT_ID}/journal` && req.method === "GET") {
+      return json(200, { journal: state.journal });
+    }
+    if (req.url === `/api/graph/projects/${PROJECT_ID}/mutations` && req.method === "POST") {
+      let body = "";
+      req.on("data", (chunk) => (body += chunk));
+      req.on("end", () => {
+        const parsed = JSON.parse(body);
+        state.receivedOps.push(parsed.ops);
+        if (state.refuseNext) {
+          state.refuseNext = false;
+          return json(422, {
+            error: "invalid_bundle",
+            errors: [{ path: "edges[0]", rule: "dangling-edge", message: "Edge target does not exist", severity: "error" }],
+          });
+        }
+        // Mirror the server: apply nothing here, just acknowledge. The tools'
+        // own result shape comes from their local applyOps.
+        return json(200, {
+          version: "2",
+          nodes: state.bundle.nodes,
+          edges: state.bundle.edges,
+          events: [{ id: "01KN44ARM0JH4YFMX52BGKNPKZ", ts: "2026-01-01T00:00:00.000Z", actor: "arkaik-agent", type: "node.created", node_id: "V-new", species: "view", title: "New" }],
+          warnings: [],
+        });
+      });
+      return undefined;
+    }
+    return json(404, { error: "not_found" });
+  });
+  return server;
+}
+
+/** Speak JSON-RPC to the built server over stdio and collect the responses. */
+function rpc(env, args, messages) {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(process.execPath, [SERVER, ...args], {
+      env: { ...process.env, ...env },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let out = "";
+    let err = "";
+    child.stdout.on("data", (d) => (out += d));
+    child.stderr.on("data", (d) => (err += d));
+    child.on("error", reject);
+    child.on("close", (code) => {
+      const responses = out
+        .split("\n")
+        .filter((line) => line.trim())
+        .map((line) => JSON.parse(line));
+      resolvePromise({ responses, stderr: err, code });
+    });
+    for (const message of messages) child.stdin.write(`${JSON.stringify(message)}\n`);
+    child.stdin.end();
+  });
+}
+
+const initialize = { jsonrpc: "2.0", id: 1, method: "initialize", params: {} };
+const listTools = { jsonrpc: "2.0", id: 2, method: "tools/list" };
+const call = (id, name, args = {}) => ({ jsonrpc: "2.0", id, method: "tools/call", params: { name, arguments: args } });
+const resultText = (responses, id) => {
+  const found = responses.find((r) => r.id === id);
+  return found?.result?.content?.[0]?.text ? JSON.parse(found.result.content[0].text) : undefined;
+};
+const isError = (responses, id) => responses.find((r) => r.id === id)?.result?.isError === true;
+
+async function main() {
+  if (!fs.existsSync(SERVER)) {
+    console.error(`Built server not found at ${SERVER}. Run: npm run build -w arkaik-mcp`);
+    process.exit(1);
+  }
+
+  const state = {
+    token: "ark_aabbccddeeff_secret_with_underscores",
+    bundle: makeBundle(),
+    journal: [],
+    requests: [],
+    receivedOps: [],
+    refuseNext: false,
+  };
+  const server = startStubServer(state);
+  await new Promise((r) => server.listen(0, r));
+  const baseUrl = `http://127.0.0.1:${server.address().port}`;
+
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "arkaik-remote-"));
+
+  try {
+    const remoteEnv = { ARKAIK_URL: baseUrl, ARKAIK_TOKEN: state.token, ARKAIK_PROJECT: PROJECT_ID };
+
+    // --- The catalog does not branch ---------------------------------------
+    const remoteList = await rpc(remoteEnv, [], [initialize, listTools]);
+    const remoteTools = remoteList.responses.find((r) => r.id === 2)?.result?.tools ?? [];
+
+    // Repo mode, for comparison. A bundle on disk with no journal sidecar.
+    const bundlePath = path.join(tmp, "bundle.json");
+    fs.writeFileSync(bundlePath, JSON.stringify(makeBundle(), null, 2));
+    const fileList = await rpc({}, ["--bundle", bundlePath], [initialize, listTools]);
+    const fileTools = fileList.responses.find((r) => r.id === 2)?.result?.tools ?? [];
+
+    check("hosted mode starts and lists tools", remoteTools.length > 0, remoteList.stderr);
+    check(
+      "the tool catalog is byte-identical in both modes",
+      JSON.stringify(remoteTools) === JSON.stringify(fileTools),
+      `${remoteTools.length} vs ${fileTools.length}`,
+    );
+    check("the banner names the hosted project", remoteList.stderr.includes(PROJECT_ID), remoteList.stderr.trim());
+
+    // --- Reads come from the API -------------------------------------------
+    state.requests.length = 0;
+    const read = await rpc(remoteEnv, [], [initialize, call(3, "list_nodes", { species: "view" })]);
+    const nodes = resultText(read.responses, 3);
+    check("list_nodes returns the hosted graph", Array.isArray(nodes?.nodes) && nodes.nodes.length === 2, JSON.stringify(nodes));
+    check(
+      "the read went to the hosted API",
+      state.requests.some((r) => r === `GET /api/graph/projects/${PROJECT_ID}`),
+      state.requests.join(" | "),
+    );
+
+    const detail = await rpc(remoteEnv, [], [initialize, call(4, "get_node", { node_id: "V-home" })]);
+    const node = resultText(detail.responses, 4);
+    check("get_node resolves against the hosted graph", node?.node?.id === "V-home", JSON.stringify(node));
+
+    // --- Writes send OPS, not a mutated graph ------------------------------
+    state.receivedOps.length = 0;
+    const write = await rpc(
+      remoteEnv,
+      [],
+      [initialize, call(5, "create_node", { species: "view", title: "Brand New", platforms: ["web"] })],
+    );
+    const created = resultText(write.responses, 5);
+    check("create_node succeeds against the hosted API", created?.node?.id === "V-brand-new", JSON.stringify(created));
+    check("the write reached the mutations endpoint", state.receivedOps.length === 1, JSON.stringify(state.requests));
+    check(
+      "the payload is ops, not a mutated graph",
+      state.receivedOps[0]?.[0]?.op === "create_node" && state.receivedOps[0][0].node?.id === "V-brand-new",
+      JSON.stringify(state.receivedOps[0]),
+    );
+    check(
+      "no whole-graph body was sent (the server recomputes under its own lock)",
+      !JSON.stringify(state.receivedOps[0]).includes("V-settings"),
+      JSON.stringify(state.receivedOps[0]).slice(0, 200),
+    );
+
+    // --- A server refusal reads like a local one ---------------------------
+    state.refuseNext = true;
+    const refused = await rpc(
+      remoteEnv,
+      [],
+      [initialize, call(6, "create_node", { species: "view", title: "Doomed", platforms: ["web"] })],
+    );
+    check("a 422 from the server becomes a tool error", isError(refused.responses, 6));
+    const refusalBody = resultText(refused.responses, 6);
+    check(
+      "the refusal carries the server's pathed findings",
+      JSON.stringify(refusalBody).includes("dangling-edge"),
+      JSON.stringify(refusalBody),
+    );
+
+    // --- Configuration resolution ------------------------------------------
+    const linkDir = path.join(tmp, "linked");
+    fs.mkdirSync(path.join(linkDir, "docs", "arkaik"), { recursive: true });
+    fs.writeFileSync(
+      path.join(linkDir, "docs", "arkaik", "arkaik.json"),
+      JSON.stringify({ project_id: PROJECT_ID, remote: baseUrl }, null, 2),
+    );
+
+    const linked = await rpc(
+      { ARKAIK_TOKEN: state.token },
+      [],
+      [initialize, listTools],
+    );
+    // cwd matters for the link file, so run it from the linked directory.
+    const linkedFromDir = await new Promise((resolvePromise) => {
+      const child = spawn(process.execPath, [SERVER], {
+        cwd: linkDir,
+        env: { ...process.env, ARKAIK_TOKEN: state.token },
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      let err = "";
+      child.stderr.on("data", (d) => (err += d));
+      child.on("close", () => resolvePromise(err));
+      child.stdin.end();
+    });
+    check(
+      "a link file alone selects hosted mode",
+      linkedFromDir.includes(PROJECT_ID),
+      linkedFromDir.trim(),
+    );
+    void linked;
+
+    // --bundle must still win, so an explicit path is never overridden.
+    const explicitBundle = await new Promise((resolvePromise) => {
+      const child = spawn(process.execPath, [SERVER, "--bundle", bundlePath], {
+        cwd: linkDir,
+        env: { ...process.env, ARKAIK_TOKEN: state.token },
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      let err = "";
+      child.stderr.on("data", (d) => (err += d));
+      child.on("close", () => resolvePromise(err));
+      child.stdin.end();
+    });
+    check(
+      "--bundle overrides a link file",
+      explicitBundle.includes("bundle:") && !explicitBundle.includes(PROJECT_ID),
+      explicitBundle.trim(),
+    );
+
+    // Hosted mode with no token must fail loudly. Silently serving a stale
+    // local file is the failure an agent cannot notice.
+    const noToken = await new Promise((resolvePromise) => {
+      const child = spawn(process.execPath, [SERVER], {
+        cwd: linkDir,
+        env: { ...process.env, ARKAIK_TOKEN: "", ARKAIK_PROJECT: "" },
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      let err = "";
+      child.stderr.on("data", (d) => (err += d));
+      child.on("close", (code) => resolvePromise({ err, code }));
+      child.stdin.end();
+    });
+    check("a linked repo with no token exits non-zero", noToken.code === 1, String(noToken.code));
+    check("and says which variable is missing", noToken.err.includes("ARKAIK_TOKEN"), noToken.err.trim());
+
+    // --- A bad token surfaces as an actionable error -----------------------
+    const badToken = await rpc(
+      { ARKAIK_URL: baseUrl, ARKAIK_TOKEN: "ark_deadbeef_nope", ARKAIK_PROJECT: PROJECT_ID },
+      [],
+      [initialize, call(7, "list_nodes", {})],
+    );
+    check("an invalid token produces a tool error", isError(badToken.responses, 7));
+    check(
+      "the error points at the token, not at a parse failure",
+      JSON.stringify(resultText(badToken.responses, 7)).includes("ARKAIK_TOKEN"),
+      JSON.stringify(resultText(badToken.responses, 7)),
+    );
+  } finally {
+    server.close();
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+
+  if (failures > 0) {
+    console.error(`\n${failures} remote-store check(s) failed.`);
+    process.exit(1);
+  }
+  console.log("\nAll remote-store checks passed.");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
> Stacked on #289 (which is stacked on #288). GitHub retargets automatically as each base merges.

## Summary

`npx arkaik link` in any repo, and a coding agent reads and edits that Arkaik project live. **This is the slice the whole program was for.**

### The tool catalog does not change

`tools.ts` is now written against a `Store` interface and knows nothing about where the graph lives, so `list_nodes`, `get_node`, `create_node` and the rest are *literally the same code* against a repo file or an account. A remote session is a different `Store`, not a different server — which is why local and remote cannot drift.

The parity test asserts `tools/list` is **byte-identical** in both modes.

### Writes send ops, not a mutated graph

The remote store posts the *intent* to `POST /api/graph/projects/{id}/mutations`, where the server recomputes it under its own row lock. Sending an outcome would be a read-modify-write, and two agents on one project could clobber each other.

`persist` therefore carries both forms: the locally-computed `nodes`/`edges` the file store writes, and the `ops` the remote store sends. The server also derives its own journal events, so the events stored alongside a graph are always the ones that produced it — a client cannot describe a change differently from how it was made.

## Two bugs the parity test caught — both mine, both from this slice

**1. Async dispatch killed in-flight tool calls.** Making the dispatcher `await` handlers meant the server resolved and the process exited when stdin closed, *before* the HTTP round trip finished — so a client that wrote a request and closed stdin silently never received its response. An MCP host normally holds stdin open, which would have hidden this indefinitely. Calls are now tracked and drained before the loop resolves.

**2. `??` vs empty strings.** Config resolution used `??`, which only falls back on `null`/`undefined` — so `ARKAIK_PROJECT=` (what every shell and CI system produces for a declared-but-unset variable) read as a real empty project id and silently dropped the session back to the repo bundle. Blank values are now treated as absent.

Both are the same species of failure: **a silent fallback where an agent cannot notice it went wrong.** In that spirit, a linked repo with no token now exits non-zero rather than serving a stale local file.

## Setup, end to end

```bash
# once, in the app
#   /settings/tokens → create a token
export ARKAIK_TOKEN=ark_…

# once, per repo
npx arkaik link --list          # see the projects this token can reach
npx arkaik link --project prj_… # writes docs/arkaik/arkaik.json

# from then on
npx -y arkaik-mcp               # picks up the link file automatically
```

The link file holds the project id and origin and is **safe to commit**. The token is only ever read from the environment — a credential in a repo file is a credential in a git history.

Resolution order is explicit and tested: `--bundle` always wins (an explicit path is never overridden); otherwise `--project` → `$ARKAIK_PROJECT` → the link file.

## Verification

`tsc`, `lint` (0 errors), and the suites: `mcp` (including **18 new parity checks**), `cli`, `mutate`, `provider`, `validate:seeds`, plus the generated-artifact drift gate.

The parity test runs the **built server over stdio** against a stub HTTP server — no database, no network — so unlike slices 1 and 3 this one was fully verifiable locally, and it earned that by catching both bugs above.

It covers: catalog parity, reads resolving against the API, a write reaching the single mutations endpoint carrying ops (asserting no whole-graph body is sent), a server 422 surfacing as the same refusal a local validator failure produces, link-file resolution, `--bundle` precedence, the no-token exit, and an invalid token producing an actionable error rather than a parse failure.

## Known gap, stated plainly

`propose_idea` and `file_request` write journal-only events, which the hosted mutations endpoint does not accept yet. Against a hosted project they are **refused with an explicit message** pointing at repo mode, rather than silently dropped.

## Lab Note

```yaml
en:
  title: Point your coding agent at your Arkaik project
  summary: Run one command in any repo and your coding agent can read and update that project's map while it works — no copying files around, no export/import dance.
fr:
  title: Connecte ton agent de code à ton projet Arkaik
  summary: Une commande dans n'importe quel dépôt et ton agent de code peut lire et mettre à jour la carte du projet pendant qu'il travaille — sans copier de fichiers ni jongler avec les exports.
suggested:
  molecule: arkaik
  type: feature
  tags: [changelog]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
