### PR TITLE
feat: PR-driven acceptance transitions (slice 6)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,22 @@ DATABASE_URL=
 AUTH_SECRET=
 AUTH_GITHUB_ID=
 AUTH_GITHUB_SECRET=
+
+# --- GitHub App (PR-driven acceptance transitions) ----------------------------
+# Optional. Without these, /api/github/webhook refuses every delivery and the
+# rest of the app is unaffected — PR automation simply does not run.
+#
+# GITHUB_WEBHOOK_SECRET is the shared secret configured on the GitHub App. Every
+# delivery is HMAC-verified against it; a deployment that leaves it unset
+# rejects webhooks rather than accepting unauthenticated writes.
+# GITHUB_APP_ID / GITHUB_APP_PRIVATE_KEY identify the App when calling back to
+# the GitHub API (reserved; the webhook path itself needs only the secret).
+GITHUB_WEBHOOK_SECRET=
+GITHUB_APP_ID=
+GITHUB_APP_PRIVATE_KEY=
+
+# --- Rate limiting ------------------------------------------------------------
+# Optional. Keys the HMAC used to hash client IPs for Publik rate limiting
+# (lib/services/publik.ts). Falls back to AUTH_SECRET, then a constant — the
+# stored value is never a raw address either way.
+RATE_LIMIT_SALT=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Mutation core tests (applyOps invariants, batch atomicity)
         run: npm run test:mutate
 
+      - name: Ref promotion policy tests (opt-in, per-platform, guards)
+        run: npm run test:promote
+
       - name: Deterministic id generator tests
         run: npm run test:id-gen
 
@@ -161,6 +164,8 @@ jobs:
         run: npm run test:tokens
       - name: Hosted graph API integration tests (atomicity, validator gate, owner scoping)
         run: npm run test:graph
+      - name: GitHub webhook integration tests (signature, replay guard, promotion)
+        run: npm run test:github
       - name: Synk API integration tests (authz isolation, dedupe, limits, retention)
         run: npm run test:synk
       - name: Synk client SyncManager tests (debounce, hash, status transitions)

--- a/app/api/github/webhook/route.ts
+++ b/app/api/github/webhook/route.ts
@@ -1,0 +1,117 @@
+import { servicesConfigured, servicesUnavailable } from "@/lib/services/db";
+import {
+  DELIVERY_HEADER,
+  EVENT_HEADER,
+  SIGNATURE_HEADER,
+  verifySignature,
+} from "@/lib/services/github/verify";
+import {
+  applyPullRequestEvent,
+  claimDelivery,
+  releaseDelivery,
+  type PullRequestEvent,
+} from "@/lib/services/github/pull-request";
+
+/**
+ * POST /api/github/webhook — GitHub App deliveries.
+ *
+ * The only endpoint in the app that accepts a signed request from a third
+ * party. Its guards, in the order they must happen:
+ *
+ *   1. read the RAW body — the signature covers bytes, and re-serializing
+ *      parsed JSON does not round-trip;
+ *   2. verify the HMAC before parsing anything;
+ *   3. claim the delivery id, so a retry or a manual redeliver cannot re-apply
+ *      transitions;
+ *   4. only then interpret the payload.
+ *
+ * Unrecognised events are acknowledged with 202 rather than 4xx: GitHub retries
+ * on failure, and an event this deployment does not care about is not a failure.
+ */
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+/** Bodies above this are rejected unread — GitHub's are far smaller. */
+const MAX_BODY_BYTES = 2 * 1024 * 1024;
+
+/** Actions that can change a PR's open/closed/merged state. */
+const HANDLED_ACTIONS = new Set(["opened", "reopened", "closed", "edited", "synchronize", "ready_for_review"]);
+
+export async function POST(req: Request): Promise<Response> {
+  if (!servicesConfigured()) return servicesUnavailable("GitHub");
+
+  const raw = await req.text();
+  if (Buffer.byteLength(raw, "utf8") > MAX_BODY_BYTES) {
+    return Response.json({ error: "payload_too_large" }, { status: 413 });
+  }
+
+  // Verify BEFORE parsing. Nothing derived from an unverified body is trusted,
+  // including the decision about what kind of event it is.
+  const verified = verifySignature(raw, req.headers.get(SIGNATURE_HEADER));
+  if (!verified.ok) {
+    if (verified.reason === "unconfigured") {
+      // A deployment without a secret refuses everything rather than accepting
+      // unauthenticated writes — 503, because this is a server-side gap.
+      console.error("[github] webhook received but GITHUB_WEBHOOK_SECRET is unset");
+      return Response.json({ error: "webhook_not_configured" }, { status: 503 });
+    }
+    return Response.json({ error: "invalid_signature" }, { status: 401 });
+  }
+
+  const deliveryId = req.headers.get(DELIVERY_HEADER);
+  if (!deliveryId) return Response.json({ error: "missing_delivery_id" }, { status: 400 });
+
+  const event = req.headers.get(EVENT_HEADER);
+  if (event !== "pull_request") {
+    // ping, installation, everything else: acknowledged, not acted on.
+    return Response.json({ status: "ignored", event }, { status: 202 });
+  }
+
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return Response.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  const action = typeof payload.action === "string" ? payload.action : "";
+  if (!HANDLED_ACTIONS.has(action)) {
+    return Response.json({ status: "ignored", action }, { status: 202 });
+  }
+
+  const pr = payload.pull_request as Record<string, unknown> | undefined;
+  const repo = payload.repository as Record<string, unknown> | undefined;
+  if (!pr || !repo || typeof repo.full_name !== "string" || typeof pr.number !== "number") {
+    return Response.json({ error: "unexpected_payload" }, { status: 400 });
+  }
+
+  // Claimed only once the event is one we will act on, so an ignored delivery
+  // does not consume an id that a later retry of a handled event might reuse.
+  if (!(await claimDelivery(deliveryId))) {
+    return Response.json({ status: "duplicate", delivery: deliveryId }, { status: 202 });
+  }
+
+  const prEvent: PullRequestEvent = {
+    action,
+    repoFullName: repo.full_name,
+    number: pr.number,
+    url: typeof pr.html_url === "string" ? pr.html_url : "",
+    title: typeof pr.title === "string" ? pr.title : "",
+    body: typeof pr.body === "string" ? pr.body : "",
+    merged: pr.merged === true,
+    state: typeof pr.state === "string" ? pr.state : "open",
+  };
+
+  try {
+    const outcomes = await applyPullRequestEvent(prEvent);
+    return Response.json({ status: "ok", outcomes }, { status: 200 });
+  } catch (err) {
+    console.error("[github] webhook failed:", err instanceof Error ? err.message : "unknown error");
+    // Release the claim so GitHub's retry can redo this. Holding it would turn
+    // a transient failure into a permanently lost transition — the retry would
+    // arrive, see the claim, and skip. Re-applying is a no-op by construction
+    // (see releaseDelivery), so at-least-once is the right posture here.
+    await releaseDelivery(deliveryId).catch(() => {});
+    return Response.json({ error: "internal_error" }, { status: 500 });
+  }
+}

--- a/app/api/graph/projects/[projectId]/repos/route.ts
+++ b/app/api/graph/projects/[projectId]/repos/route.ts
@@ -1,0 +1,121 @@
+import { getCaller, hasScope } from "@/lib/services/auth";
+import { servicesConfigured, servicesUnavailable } from "@/lib/services/db";
+import { linkRepo, listRepoLinks, unlinkRepo } from "@/lib/services/graph/repos";
+
+/**
+ * Repository links for a hosted project (db/migrations/009_project_repos.sql).
+ *
+ * These rows are what the GitHub webhook resolves a delivery against, so
+ * without this endpoint the PR-transition feature has no reachable state and
+ * silently does nothing.
+ *
+ * DELETE takes the repo as a QUERY parameter rather than a path segment: a
+ * repository name contains a slash, and encoding one into a dynamic segment is
+ * the kind of detail that works until some proxy normalises it.
+ */
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ projectId: string }> },
+): Promise<Response> {
+  if (!servicesConfigured()) return servicesUnavailable("Graph");
+
+  const caller = await getCaller(req);
+  if (!caller) return Response.json({ error: "unauthorized" }, { status: 401 });
+  if (!hasScope(caller, "graph:read")) {
+    return Response.json({ error: "insufficient_scope", required: "graph:read" }, { status: 403 });
+  }
+
+  const { projectId } = await params;
+  try {
+    const links = await listRepoLinks(projectId, caller.ownerIds);
+    if (links === null) return Response.json({ error: "not_found" }, { status: 404 });
+    return Response.json({ repos: links }, { status: 200 });
+  } catch (err) {
+    console.error("[graph] GET repos failed:", err instanceof Error ? err.message : "unknown error");
+    return Response.json({ error: "internal_error" }, { status: 500 });
+  }
+}
+
+/** POST — link a repo, or change the platform of an existing link. */
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ projectId: string }> },
+): Promise<Response> {
+  if (!servicesConfigured()) return servicesUnavailable("Graph");
+
+  const caller = await getCaller(req);
+  if (!caller) return Response.json({ error: "unauthorized" }, { status: 401 });
+  if (!hasScope(caller, "graph:write")) {
+    return Response.json({ error: "insufficient_scope", required: "graph:write" }, { status: 403 });
+  }
+
+  const { projectId } = await params;
+
+  let body: { repo_full_name?: unknown; platform?: unknown };
+  try {
+    body = (await req.json()) as typeof body;
+  } catch {
+    return Response.json({ error: "invalid_json" }, { status: 400 });
+  }
+  if (typeof body.repo_full_name !== "string") {
+    return Response.json({ error: "invalid_repo", message: "`repo_full_name` must be \"owner/name\"." }, { status: 400 });
+  }
+  const platform =
+    body.platform === undefined || body.platform === null || body.platform === ""
+      ? null
+      : String(body.platform);
+
+  try {
+    const result = await linkRepo(projectId, caller.ownerIds, {
+      repoFullName: body.repo_full_name,
+      platform,
+    });
+    if (!result.ok) {
+      if (result.reason === "not_found") return Response.json({ error: "not_found" }, { status: 404 });
+      return Response.json(
+        {
+          error: result.reason,
+          message:
+            result.reason === "invalid_repo"
+              ? 'Expected "owner/name".'
+              : "Platform must be web, ios, android, or omitted.",
+        },
+        { status: 400 },
+      );
+    }
+    return Response.json({ repo: result.link }, { status: 201 });
+  } catch (err) {
+    console.error("[graph] POST repos failed:", err instanceof Error ? err.message : "unknown error");
+    return Response.json({ error: "internal_error" }, { status: 500 });
+  }
+}
+
+/** DELETE ?repo=owner/name — remove a link. */
+export async function DELETE(
+  req: Request,
+  { params }: { params: Promise<{ projectId: string }> },
+): Promise<Response> {
+  if (!servicesConfigured()) return servicesUnavailable("Graph");
+
+  const caller = await getCaller(req);
+  if (!caller) return Response.json({ error: "unauthorized" }, { status: 401 });
+  if (!hasScope(caller, "graph:write")) {
+    return Response.json({ error: "insufficient_scope", required: "graph:write" }, { status: 403 });
+  }
+
+  const { projectId } = await params;
+  const repo = new URL(req.url).searchParams.get("repo");
+  if (!repo) return Response.json({ error: "invalid_repo", message: "`?repo=owner/name` is required." }, { status: 400 });
+
+  try {
+    const removed = await unlinkRepo(projectId, caller.ownerIds, repo);
+    if (!removed) return Response.json({ error: "not_found" }, { status: 404 });
+    return new Response(null, { status: 204 });
+  } catch (err) {
+    console.error("[graph] DELETE repos failed:", err instanceof Error ? err.message : "unknown error");
+    return Response.json({ error: "internal_error" }, { status: 500 });
+  }
+}

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -19,6 +19,7 @@ import { getProvider } from "@/lib/data/provider-registry";
 import type { Project, ProjectBundle } from "@/lib/data/types";
 import type { ProjectSummary } from "@/lib/data/data-provider";
 import { Badge } from "@/components/ui/badge";
+import { RepoLinksDialog } from "@/components/settings/RepoLinksDialog";
 import { exportProject as exportProjectBundle } from "@/lib/utils/export";
 import { createRemoteProvider } from "@/lib/data/remote-provider";
 import { archiveProject, importProjectFromFile } from "@/lib/utils/export";
@@ -28,7 +29,7 @@ import { PublishDialog } from "@/components/publik/PublishDialog";
 import { ProjectSyncControl } from "@/components/sync/ProjectSyncControl";
 import { RestoreDialog } from "@/components/sync/RestoreDialog";
 import { SynkOnboardingBanner } from "@/components/sync/SynkOnboardingBanner";
-import { CloudIcon, CloudUploadIcon, HistoryIcon, Share2Icon } from "lucide-react";
+import { CloudIcon, CloudUploadIcon, GithubIcon, HistoryIcon, Share2Icon } from "lucide-react";
 import { toast } from "sonner";
 import {
   Select,
@@ -61,6 +62,7 @@ export default function ProjectsPage() {
   const [importing, setImporting] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [moving, setMoving] = useState<string | null>(null);
+  const [repoTarget, setRepoTarget] = useState<ProjectSummary | null>(null);
   const authStatus = useAuthStatus();
   /** Hosting a project needs somewhere to put it — i.e. a signed-in account. */
   const canHost = authStatus.state === "signed-in";
@@ -303,6 +305,12 @@ export default function ProjectsPage() {
                     <Share2Icon />
                     Publish
                   </Button>
+                  {bundle.hosted ? (
+                    <Button size="sm" variant="outline" onClick={() => setRepoTarget(bundle)}>
+                      <GithubIcon />
+                      Repos
+                    </Button>
+                  ) : null}
                   {!bundle.hosted && canHost ? (
                     <Button
                       size="sm"
@@ -336,6 +344,14 @@ export default function ProjectsPage() {
         onConfirm={handleArchiveProject}
       />
 
+      <RepoLinksDialog
+        projectId={repoTarget?.project.id ?? ""}
+        projectTitle={repoTarget?.project.title ?? "this project"}
+        open={Boolean(repoTarget)}
+        onOpenChange={(next) => {
+          if (!next) setRepoTarget(null);
+        }}
+      />
       <PublishDialog
         open={Boolean(publishTarget)}
         onOpenChange={(open) => {

--- a/components/settings/RepoLinksDialog.tsx
+++ b/components/settings/RepoLinksDialog.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { GithubIcon, Loader2Icon, PlusIcon, Trash2Icon } from "lucide-react";
+import { toast } from "sonner";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { PLATFORMS } from "@/lib/config/platforms";
+
+/**
+ * Linking a hosted project to the repositories that implement it.
+ *
+ * These links are what the GitHub webhook resolves a delivery against — without
+ * one, a PR in that repo finds no project and nothing happens. So this dialog is
+ * the difference between the PR-transition feature existing and being reachable.
+ *
+ * THE PLATFORM CHOICE IS THE POINT. Recording which platform a repository builds
+ * for means a PR merged there marks only that platform shipped, with no per-PR
+ * annotation and no way to forget — and the remaining platforms then show up as
+ * a genuine parity gap rather than false parity.
+ */
+
+interface RepoLink {
+  repoFullName: string;
+  platform: string | null;
+  createdAt: string;
+}
+
+/** The value the Select uses for "this repo builds every platform". */
+const ALL_PLATFORMS = "__all__";
+
+export interface RepoLinksDialogProps {
+  projectId: string;
+  projectTitle: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function RepoLinksDialog({ projectId, projectTitle, open, onOpenChange }: RepoLinksDialogProps) {
+  const [links, setLinks] = useState<RepoLink[] | null>(null);
+  const [repo, setRepo] = useState("");
+  const [platform, setPlatform] = useState<string>(ALL_PLATFORMS);
+  const [saving, setSaving] = useState(false);
+
+  const refresh = useCallback(async () => {
+    const res = await fetch(`/api/graph/projects/${encodeURIComponent(projectId)}/repos`, {
+      cache: "no-store",
+    });
+    if (!res.ok) {
+      setLinks([]);
+      return;
+    }
+    setLinks(((await res.json()) as { repos: RepoLink[] }).repos);
+  }, [projectId]);
+
+  useEffect(() => {
+    if (open) void refresh();
+  }, [open, refresh]);
+
+  async function link() {
+    const name = repo.trim();
+    if (!name) return;
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/graph/projects/${encodeURIComponent(projectId)}/repos`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          repo_full_name: name,
+          platform: platform === ALL_PLATFORMS ? null : platform,
+        }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { message?: string; error?: string };
+        toast.error(body.message ?? body.error ?? "Could not link that repository.");
+        return;
+      }
+      setRepo("");
+      setPlatform(ALL_PLATFORMS);
+      await refresh();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function unlink(name: string) {
+    const res = await fetch(
+      `/api/graph/projects/${encodeURIComponent(projectId)}/repos?repo=${encodeURIComponent(name)}`,
+      { method: "DELETE" },
+    );
+    if (!res.ok && res.status !== 404) {
+      toast.error("Could not remove that link.");
+      return;
+    }
+    await refresh();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Linked repositories</DialogTitle>
+          <DialogDescription>
+            Pull requests in these repositories can move {projectTitle}&rsquo;s acceptances. Naming the
+            platform a repository builds for means a merge there marks only that platform shipped.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <Input
+              placeholder="owner/repository"
+              value={repo}
+              onChange={(e) => setRepo(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") void link();
+              }}
+              className="flex-1"
+            />
+            <Select value={platform} onValueChange={setPlatform}>
+              <SelectTrigger className="sm:w-40">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={ALL_PLATFORMS}>All platforms</SelectItem>
+                {PLATFORMS.map((p) => (
+                  <SelectItem key={p.id} value={p.id}>
+                    {p.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button onClick={() => void link()} disabled={saving || !repo.trim()}>
+              {saving ? <Loader2Icon className="animate-spin" /> : <PlusIcon />}
+              <span>Link</span>
+            </Button>
+          </div>
+
+          {links === null ? (
+            <p className="text-sm text-muted-foreground">Loading…</p>
+          ) : links.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No repositories linked yet. Until one is, pull requests cannot move this project&rsquo;s
+              acceptances.
+            </p>
+          ) : (
+            <ul className="flex flex-col divide-y rounded-md border">
+              {links.map((entry) => (
+                <li key={entry.repoFullName} className="flex items-center gap-2 px-3 py-2">
+                  <GithubIcon className="size-4 shrink-0 text-muted-foreground" />
+                  <code className="min-w-0 flex-1 truncate font-mono text-sm">{entry.repoFullName}</code>
+                  <Badge variant="outline" className="shrink-0 font-normal">
+                    {entry.platform
+                      ? (PLATFORMS.find((p) => p.id === entry.platform)?.label ?? entry.platform)
+                      : "All platforms"}
+                  </Badge>
+                  <Button variant="ghost" size="sm" onClick={() => void unlink(entry.repoFullName)}>
+                    <Trash2Icon />
+                    <span className="sr-only">Unlink {entry.repoFullName}</span>
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          <p className="text-xs text-muted-foreground">
+            A pull request moves an acceptance when its title or body mentions the acceptance id (for
+            example <code className="font-mono">AC-guest-checkout</code>), and the project has opted in
+            with <code className="font-mono">ref_policy</code>.
+          </p>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/db/migrations/009_project_repos.sql
+++ b/db/migrations/009_project_repos.sql
@@ -1,0 +1,51 @@
+-- 009_project_repos.sql
+--
+-- Linking a hosted project to the repositories that implement it, so a PR can
+-- find the acceptance it delivers (docs/spec/bundle-format.md § References).
+--
+-- THE PLATFORM COLUMN is the interesting one. Acceptances carry per-platform
+-- statuses, and a product's platforms usually live in different repositories.
+-- Recording the platform on the LINK means a PR merged in the iOS repo marks
+-- only iOS shipped — with no per-PR annotation, and no way for someone to
+-- forget. Web and Android then show up as a real parity gap, which is what the
+-- gap projection is for. A repo that serves every platform leaves it null.
+--
+-- `installation_id` is the GitHub App installation that delivers the webhook.
+-- It is stored per link rather than per owner because one account can install
+-- the App on several organisations.
+--
+-- Deliveries are recorded so a redelivered webhook — GitHub retries, and its
+-- "Redeliver" button is one click — cannot apply the same transition twice.
+--
+-- Every statement uses IF NOT EXISTS so the file is safe to re-run by hand.
+
+create table if not exists project_repos (
+  project_id      text        not null references graph_projects(id) on delete cascade,
+  provider        text        not null default 'github',
+  -- "owner/name", lowercased on write: GitHub treats these case-insensitively
+  -- and webhook payloads do not promise a particular case.
+  repo_full_name  text        not null,
+  platform        text,
+  installation_id text,
+  created_at      timestamptz not null default now(),
+  primary key (project_id, provider, repo_full_name),
+  constraint project_repos_platform_check
+    check (platform is null or platform in ('web', 'ios', 'android'))
+);
+
+-- The webhook's lookup: given a repo, which projects care about it? A repo can
+-- legitimately serve more than one project (a monorepo), so this is not unique.
+create index if not exists project_repos_lookup_idx on project_repos (provider, repo_full_name);
+
+-- Webhook delivery ledger, for replay protection. GitHub retries failed
+-- deliveries and offers a manual redeliver button; without this, a retry after
+-- a partially-successful run would re-apply transitions.
+create table if not exists github_deliveries (
+  delivery_id text        not null,
+  received_at timestamptz not null default now(),
+  primary key (delivery_id)
+);
+
+-- Deliveries older than a day cannot be replayed by GitHub any more, so the
+-- ledger is pruned opportunistically on write rather than kept forever.
+create index if not exists github_deliveries_received_idx on github_deliveries (received_at);

--- a/docs/spec/bundle-format.md
+++ b/docs/spec/bundle-format.md
@@ -71,7 +71,8 @@ interface Ref {
 | Rule | Detail |
 |---|---|
 | Mirroring | `external_status` is a *mirror*, never authoritative. Sync tooling (`arkaik sync`, server-side integrations) updates it and records `ref.status_changed` journal events |
-| Mapping | `status_mapped` never overwrites `node.status` automatically; it is advisory display data. Promoting it to the node's status is a deliberate (human or agent) act that produces a normal `node.status_changed` event |
+| Mapping | `status_mapped` never overwrites `node.status` automatically; it is advisory display data. Promoting it to the node's status is a deliberate act that produces a normal `node.status_changed` event |
+| Promotion policy | A project MAY opt in to automatic promotion by declaring `project.metadata.ref_policy` — a map of ref type → external status → `StatusId` (or `null` for "recognised, moves nothing"). `ref_policy: true` selects the defaults (`github-pr`: open → `development`, merged → `live`, closed → nothing). **Absent `ref_policy`, nothing is promoted** — the advisory rule above is unchanged for every bundle that predates this. A promotion is scoped to `ref.platform` when the ref carries one, moving `metadata.platformStatuses[platform]` rather than `node.status`, so shipping on one platform never claims parity across all of them. Archived nodes are never promoted; a node already at the target is skipped, making re-runs no-ops. Implemented once in `computeRefPromotions` (`@arkaik/schema`) and shared by `arkaik sync --promote` and the hosted GitHub App |
 | Unknown types | Consumers MUST preserve refs with unrecognized `type` values and SHOULD render them as generic links |
 
 ## Asset Values

--- a/lib/services/github/pull-request.ts
+++ b/lib/services/github/pull-request.ts
@@ -1,0 +1,263 @@
+import "server-only";
+
+import { applyOps, computeRefPromotions, promotionPatch, type MutationOp, type Node, type Ref } from "@arkaik/schema";
+
+import { query } from "@/lib/services/db";
+import { applyMutation, getProject } from "@/lib/services/graph/store";
+
+/**
+ * Turning a `pull_request` webhook into acceptance status changes.
+ *
+ * The shape of the work, in order:
+ *   1. resolve the repo to the projects that linked it (and the platform each
+ *      link declares);
+ *   2. find the nodes whose refs point at this PR — attaching one if the PR
+ *      body names an acceptance and no ref exists yet;
+ *   3. mirror the PR's state onto those refs;
+ *   4. compute promotions under the project's opted-in policy and apply them.
+ *
+ * Every write goes through `applyMutation`, so a webhook-driven change is
+ * subject to the same validator gate and lands the same journal events as a
+ * human edit — with `github-app` as the actor, so the history says what acted.
+ */
+
+/** `AC-…` mentioned in a PR body or title. Bounded to the id charset. */
+const ACCEPTANCE_MENTION = /\bAC-[a-z0-9][a-z0-9-]*/gi;
+
+export interface PullRequestEvent {
+  action: string;
+  repoFullName: string;
+  number: number;
+  url: string;
+  title: string;
+  body: string;
+  merged: boolean;
+  state: string;
+}
+
+export interface LinkedRepo {
+  projectId: string;
+  platform: string | null;
+}
+
+/**
+ * The external status a PR is in, matching what `arkaik sync` computes from the
+ * REST API — so the webhook and the CLI can never disagree about what "merged"
+ * means for the same PR.
+ */
+export function prExternalStatus(event: Pick<PullRequestEvent, "merged" | "state">): string {
+  if (event.merged) return "merged";
+  return event.state === "closed" ? "closed" : "open";
+}
+
+/** Projects that linked this repo. Lowercased: GitHub is case-insensitive here. */
+export async function linkedProjects(repoFullName: string): Promise<LinkedRepo[]> {
+  const { rows } = await query<{ project_id: string; platform: string | null }>(
+    `select project_id, platform
+       from project_repos
+      where provider = 'github' and repo_full_name = $1`,
+    [repoFullName.toLowerCase()],
+  );
+  return rows.map((row) => ({ projectId: row.project_id, platform: row.platform }));
+}
+
+/**
+ * Record a delivery, returning false if it was already seen.
+ *
+ * GitHub retries failed deliveries and offers a manual redeliver button, so
+ * without this a retry after a partially-successful run would re-apply
+ * transitions. Insert-first (rather than check-then-insert) makes the guard
+ * atomic under concurrent deliveries.
+ */
+export async function claimDelivery(deliveryId: string): Promise<boolean> {
+  const { rows } = await query<{ delivery_id: string }>(
+    `insert into github_deliveries (delivery_id) values ($1)
+     on conflict (delivery_id) do nothing
+     returning delivery_id`,
+    [deliveryId],
+  );
+  if (rows.length === 0) return false;
+
+  // Opportunistic prune — GitHub cannot replay a delivery older than a day.
+  await query(`delete from github_deliveries where received_at < now() - interval '2 days'`);
+  return true;
+}
+
+/**
+ * Give a claimed delivery back after a failed apply, so GitHub's retry can
+ * redo it. Without this, claiming before applying would turn any transient
+ * failure into a permanently lost transition: the retry would arrive, see the
+ * claim, and skip.
+ *
+ * Releasing is safe because applying twice is a no-op by construction —
+ * re-writing an identical ref derives no events (`diffNodeUpdate`), and a
+ * promotion to a status the node already holds is skipped as `already-there`.
+ * The ledger prevents wasted work, not incorrectness.
+ */
+export async function releaseDelivery(deliveryId: string): Promise<void> {
+  await query(`delete from github_deliveries where delivery_id = $1`, [deliveryId]);
+}
+
+/** A stable, readable ref id for a PR: `gh-pr-<number>`. */
+export function refIdFor(number: number): string {
+  return `gh-pr-${number}`;
+}
+
+/** Acceptance ids named in a PR's title or body, deduped and upper-cased. */
+export function mentionedAcceptances(event: Pick<PullRequestEvent, "title" | "body">): string[] {
+  const found = new Set<string>();
+  for (const text of [event.title, event.body]) {
+    if (!text) continue;
+    for (const match of text.matchAll(ACCEPTANCE_MENTION)) {
+      // Node ids are case-sensitive; `AC-` is the canonical prefix, and the rest
+      // is kebab-case by `deriveNodeId`, so normalise the prefix only.
+      found.add(`AC-${match[0].slice(3)}`);
+    }
+  }
+  return [...found];
+}
+
+interface NodeWithRefs extends Node {
+  metadata?: Node["metadata"] & { refs?: Ref[] };
+}
+
+/**
+ * The ops that bring one project in line with a PR event: attach the ref where
+ * a mention names an uncovered acceptance, mirror the PR's state onto matching
+ * refs, then promote under the project's policy.
+ *
+ * Returns an empty list when nothing applies, which is the common case — most
+ * PRs in a linked repo mention no acceptance at all.
+ */
+export function planForProject(
+  bundle: { project: { metadata?: Record<string, unknown> }; nodes: Node[]; edges: unknown[] },
+  event: PullRequestEvent,
+  platform: string | null,
+): MutationOp[] {
+  const ops: MutationOp[] = [];
+  const refId = refIdFor(event.number);
+  const externalStatus = prExternalStatus(event);
+  const now = new Date().toISOString();
+
+  const nodes = bundle.nodes as NodeWithRefs[];
+  const mentioned = new Set(mentionedAcceptances(event));
+
+  // A node is in scope if it already references this PR, or if the PR names it.
+  const targets = nodes.filter(
+    (node) =>
+      node.metadata?.refs?.some((r) => r.id === refId || r.url === event.url) || mentioned.has(node.id),
+  );
+
+  const patched: Node[] = [];
+  for (const node of targets) {
+    const refs = [...(node.metadata?.refs ?? [])];
+    const index = refs.findIndex((r) => r.id === refId || r.url === event.url);
+
+    const nextRef: Ref = {
+      id: refId,
+      type: "github-pr",
+      url: event.url,
+      title: event.title,
+      external_status: externalStatus,
+      synced_at: now,
+      // Only scope the ref when the LINK declares a platform and the node
+      // actually has it — otherwise the promotion would be refused later, and a
+      // ref claiming a platform the node lacks is simply wrong.
+      ...(platform && node.platforms.includes(platform as Node["platforms"][number])
+        ? { platform: platform as Node["platforms"][number] }
+        : {}),
+    };
+
+    if (index === -1) refs.push(nextRef);
+    else refs[index] = { ...refs[index], ...nextRef };
+
+    const patch = { metadata: { ...node.metadata, refs } };
+    ops.push({ op: "update_node", node_id: node.id, patch });
+    patched.push({ ...node, ...patch } as Node);
+  }
+
+  if (patched.length === 0) return ops;
+
+  // Promotions are computed against the graph AS IT WILL BE after the ref
+  // updates above — the same batch, so the mirrored status and the status it
+  // implies are never briefly inconsistent.
+  const withPatches = nodes.map((node) => patched.find((p) => p.id === node.id) ?? node);
+  const plan = computeRefPromotions({
+    ...bundle,
+    nodes: withPatches,
+  } as Parameters<typeof computeRefPromotions>[0]);
+
+  for (const promotion of plan.promotions) {
+    if (promotion.ref_id !== refId) continue;
+    const node = withPatches.find((n) => n.id === promotion.node_id);
+    if (!node) continue;
+    ops.push({ op: "update_node", node_id: node.id, patch: promotionPatch(node, promotion) });
+  }
+
+  return ops;
+}
+
+export interface ApplyOutcome {
+  projectId: string;
+  applied: number;
+  skipped?: string;
+}
+
+/** Apply a PR event to every project that linked the repo. */
+export async function applyPullRequestEvent(event: PullRequestEvent): Promise<ApplyOutcome[]> {
+  const links = await linkedProjects(event.repoFullName);
+  const outcomes: ApplyOutcome[] = [];
+
+  for (const link of links) {
+    // Owner scoping is by the link itself: a repo can only be linked by someone
+    // who owns the project, so the webhook acts within that authority.
+    const loaded = await getProject(link.projectId, await ownerIdsFor(link.projectId));
+    if (!loaded) {
+      outcomes.push({ projectId: link.projectId, applied: 0, skipped: "project not found" });
+      continue;
+    }
+
+    const ops = planForProject(
+      loaded.bundle as unknown as Parameters<typeof planForProject>[0],
+      event,
+      link.platform,
+    );
+    if (ops.length === 0) {
+      outcomes.push({ projectId: link.projectId, applied: 0, skipped: "no matching acceptance" });
+      continue;
+    }
+
+    const result = await applyMutation({
+      projectId: link.projectId,
+      ownerIds: await ownerIdsFor(link.projectId),
+      ops,
+      actor: "github-app",
+      tier: "klub", // A webhook must not fail on a tier cap it cannot act on.
+    });
+
+    outcomes.push({
+      projectId: link.projectId,
+      applied: result.ok ? ops.length : 0,
+      ...(result.ok ? {} : { skipped: describeFailure(result) }),
+    });
+  }
+
+  return outcomes;
+}
+
+/** The owner of a project, as a single-element list for the store's API. */
+async function ownerIdsFor(projectId: string): Promise<string[]> {
+  const { rows } = await query<{ owner_id: string }>(
+    `select owner_id from graph_projects where id = $1`,
+    [projectId],
+  );
+  return rows.map((row) => row.owner_id);
+}
+
+function describeFailure(result: { reason: string } & Record<string, unknown>): string {
+  if (result.reason === "validation") return "refused by the validator";
+  if (result.reason === "mutation") return `refused: ${String(result.code)}`;
+  return result.reason;
+}
+
+export { applyOps };

--- a/lib/services/github/verify.ts
+++ b/lib/services/github/verify.ts
@@ -1,0 +1,61 @@
+import "server-only";
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+/**
+ * GitHub webhook signature verification.
+ *
+ * THIS IS THE ONLY INBOUND SIGNATURE CHECK IN THE CODEBASE — before this, no
+ * route accepted a signed request from a third party. It is kept in its own
+ * module, with no database or business logic, so the security-critical part is
+ * small enough to audit in one read.
+ *
+ * The rules, and why each one is here:
+ *
+ *  - **Unsigned is rejected.** Not "verified when a secret is configured" —
+ *    absent configuration means the endpoint refuses everything, because a
+ *    deployment that forgot `GITHUB_WEBHOOK_SECRET` must not silently accept
+ *    unauthenticated writes.
+ *  - **The RAW body is signed**, not a re-serialization of parsed JSON.
+ *    `JSON.parse` then `JSON.stringify` does not round-trip byte-for-byte
+ *    (key order, number formatting, unicode escapes), so a re-serialized body
+ *    would fail against a valid signature — and any attempt to "fix" that by
+ *    relaxing the comparison would defeat the check.
+ *  - **Constant-time comparison.** A byte-by-byte early return would leak the
+ *    expected digest to an attacker who can time responses.
+ */
+
+/** GitHub sends `sha256=<hex>` in this header. */
+export const SIGNATURE_HEADER = "x-hub-signature-256";
+
+/** Unique per delivery, including retries of the same event. */
+export const DELIVERY_HEADER = "x-github-delivery";
+
+export const EVENT_HEADER = "x-github-event";
+
+export type VerifyResult =
+  | { ok: true }
+  | { ok: false; reason: "unconfigured" | "missing-signature" | "malformed-signature" | "mismatch" };
+
+/**
+ * Verify a raw request body against the configured secret.
+ *
+ * `rawBody` MUST be the exact bytes received — read it with `req.text()` before
+ * any parsing, and parse only after this returns ok.
+ */
+export function verifySignature(rawBody: string, signatureHeader: string | null): VerifyResult {
+  const secret = process.env.GITHUB_WEBHOOK_SECRET;
+  if (!secret) return { ok: false, reason: "unconfigured" };
+  if (!signatureHeader) return { ok: false, reason: "missing-signature" };
+
+  const match = /^sha256=([0-9a-f]{64})$/i.exec(signatureHeader.trim());
+  if (!match) return { ok: false, reason: "malformed-signature" };
+
+  const expected = createHmac("sha256", secret).update(rawBody, "utf8").digest();
+  const presented = Buffer.from(match[1], "hex");
+
+  // Both are 32-byte digests by construction — the regex fixes the length — so
+  // timingSafeEqual cannot throw on a length mismatch.
+  if (presented.length !== expected.length) return { ok: false, reason: "mismatch" };
+  return timingSafeEqual(presented, expected) ? { ok: true } : { ok: false, reason: "mismatch" };
+}

--- a/lib/services/graph/repos.ts
+++ b/lib/services/graph/repos.ts
@@ -1,0 +1,117 @@
+import "server-only";
+
+import { query } from "@/lib/services/db";
+
+/**
+ * Repository links (db/migrations/009_project_repos.sql) — the rows the GitHub
+ * webhook resolves a delivery against.
+ *
+ * Without a link, a webhook for a repo finds no projects and does nothing, so
+ * this is the surface that makes PR-driven transitions reachable at all.
+ *
+ * Every function is owner-scoped through the project: a link can only be
+ * created by someone who can already write the project, which is what gives the
+ * webhook its authority to act later.
+ */
+
+/** GitHub's own constraint: owner and name, each a bounded slug. */
+const REPO_PATTERN = /^[A-Za-z0-9._-]{1,100}\/[A-Za-z0-9._-]{1,100}$/;
+
+const PLATFORMS = new Set(["web", "ios", "android"]);
+
+export interface RepoLink {
+  repoFullName: string;
+  /** The platform this repository builds for, or null when it serves all. */
+  platform: string | null;
+  createdAt: string;
+}
+
+export type RepoLinkFailure =
+  | { ok: false; reason: "not_found" }
+  | { ok: false; reason: "invalid_repo" }
+  | { ok: false; reason: "invalid_platform" };
+
+/** Whether the caller's owners include this project. One place, used by all three. */
+async function ownsProject(projectId: string, ownerIds: readonly string[]): Promise<boolean> {
+  const { rows } = await query<{ id: string }>(
+    `select id from graph_projects where id = $1 and owner_id = any($2::text[])`,
+    [projectId, ownerIds],
+  );
+  return rows.length > 0;
+}
+
+export async function listRepoLinks(
+  projectId: string,
+  ownerIds: readonly string[],
+): Promise<RepoLink[] | null> {
+  if (!(await ownsProject(projectId, ownerIds))) return null;
+  const { rows } = await query<{ repo_full_name: string; platform: string | null; created_at: Date }>(
+    `select repo_full_name, platform, created_at
+       from project_repos
+      where project_id = $1 and provider = 'github'
+      order by repo_full_name`,
+    [projectId],
+  );
+  return rows.map((row) => ({
+    repoFullName: row.repo_full_name,
+    platform: row.platform,
+    createdAt: row.created_at.toISOString(),
+  }));
+}
+
+/**
+ * Link a repository, or update the platform of an existing link.
+ *
+ * The name is lowercased on write because GitHub treats repository names
+ * case-insensitively and webhook payloads make no promise about which case they
+ * deliver — a link stored as `Acme/App` would never match a delivery for
+ * `acme/app`, and the failure would be silent.
+ */
+export async function linkRepo(
+  projectId: string,
+  ownerIds: readonly string[],
+  input: { repoFullName: string; platform?: string | null },
+): Promise<{ ok: true; link: RepoLink } | RepoLinkFailure> {
+  if (!(await ownsProject(projectId, ownerIds))) return { ok: false, reason: "not_found" };
+
+  const repoFullName = input.repoFullName.trim().toLowerCase();
+  if (!REPO_PATTERN.test(repoFullName)) return { ok: false, reason: "invalid_repo" };
+
+  const platform = input.platform ?? null;
+  if (platform !== null && !PLATFORMS.has(platform)) return { ok: false, reason: "invalid_platform" };
+
+  const { rows } = await query<{ repo_full_name: string; platform: string | null; created_at: Date }>(
+    `insert into project_repos (project_id, provider, repo_full_name, platform)
+     values ($1, 'github', $2, $3)
+     on conflict (project_id, provider, repo_full_name)
+       do update set platform = excluded.platform
+     returning repo_full_name, platform, created_at`,
+    [projectId, repoFullName, platform],
+  );
+
+  const row = rows[0];
+  return {
+    ok: true,
+    link: {
+      repoFullName: row.repo_full_name,
+      platform: row.platform,
+      createdAt: row.created_at.toISOString(),
+    },
+  };
+}
+
+/** Remove a link. False when the project is not the caller's, or nothing matched. */
+export async function unlinkRepo(
+  projectId: string,
+  ownerIds: readonly string[],
+  repoFullName: string,
+): Promise<boolean> {
+  if (!(await ownsProject(projectId, ownerIds))) return false;
+  const { rows } = await query<{ repo_full_name: string }>(
+    `delete from project_repos
+      where project_id = $1 and provider = 'github' and repo_full_name = $2
+      returning repo_full_name`,
+    [projectId, repoFullName.trim().toLowerCase()],
+  );
+  return rows.length > 0;
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test:journal-projections": "node tests/data/journal-projections.test.js",
     "test:emit": "node tests/schema/emit.test.js",
     "test:mutate": "node tests/schema/mutate.test.js",
+    "test:promote": "node tests/schema/promote.test.js",
     "test:emit-events": "node tests/data/emit-events.test.js",
     "test:screenshot-size": "node tests/schema/screenshot-size.test.js",
     "test:migrate": "node tests/data/migrate.test.js && node tests/data/import-roundtrip.test.js && node tests/data/seed-import.test.js",
@@ -41,6 +42,7 @@
     "test:auth": "node tests/services/auth-guard.test.js",
     "test:tokens": "node tests/services/token-auth.test.js",
     "test:graph": "node tests/services/graph-api.test.js",
+    "test:github": "node tests/services/github-webhook.test.js",
     "test:publik": "node tests/services/publik-api.test.js",
     "test:synk": "node tests/services/synk-api.test.js",
     "test:sync": "node tests/sync/sync-manager.test.js"

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -36,7 +36,15 @@
  */
 import { resolve } from "node:path";
 import { writeFileSync } from "node:fs";
-import { makeEvent, serializeBundle, type JournalEvent } from "@arkaik/schema";
+import {
+  computeRefPromotions,
+  makeEvent,
+  promotionPatch,
+  serializeBundle,
+  type JournalEvent,
+  type Node,
+  type Promotion as RefPromotionApplied,
+} from "@arkaik/schema";
 import { readBundle } from "../lib/bundle-io";
 import { appendJournalEvent, journalPathFor } from "../lib/journal-io";
 import { renderEventLine } from "../lib/render-event";
@@ -58,7 +66,7 @@ const PROVIDER_LINES = PROVIDERS.map((p) => {
   return `  ${p.name.padEnd(8)} ${state}— ${p.refTypes.join(", ")}${token}${note}`;
 }).join("\n");
 
-const USAGE = `arkaik sync [--provider <name>] [--dry-run] [path]
+const USAGE = `arkaik sync [--provider <name>] [--dry-run] [--promote] [path]
 
 Mirror external ref status into node metadata.refs. Reads every node's
 metadata.refs, queries each ref's provider for its current external status,
@@ -78,6 +86,9 @@ Arguments:
 
 Options:
   --provider <name> Only sync refs handled by this provider (${PROVIDERS.map((p) => p.name).join(" | ")}).
+  --promote         Also move node statuses that the mirrored ref status implies,
+                    per the project's metadata.ref_policy. Does nothing unless
+                    the project has opted in.
   --dry-run         Report what would change without writing the bundle or
                      appending to the journal.
   -h, --help        Show this help.`;
@@ -124,6 +135,8 @@ export interface RunSyncOptions {
   provider?: string;
   /** Report what would change without writing anything. */
   dryRun?: boolean;
+  /** Apply ref_policy status promotions after mirroring. */
+  promote?: boolean;
   /** Base directory `path` resolves against (default: process.cwd()). */
   cwd?: string;
   /** Source of tokens, keyed by each provider's `tokenEnvVar` (default: process.env). */
@@ -149,6 +162,8 @@ export interface RunSyncResult {
   errors: RefSyncError[];
   /** Node id -> title, gathered from the snapshot as read — for rendering the report. */
   nodeTitles: Map<string, string>;
+  /** Status promotions applied (or, under --dry-run, that would be). */
+  promoted: RefPromotionApplied[];
 }
 
 function fatalResult(bundlePath: string, journalPath: string, dryRun: boolean, message: string): RunSyncResult {
@@ -163,6 +178,7 @@ function fatalResult(bundlePath: string, journalPath: string, dryRun: boolean, m
     skipped: [],
     errors: [],
     nodeTitles: new Map(),
+    promoted: [],
   };
 }
 
@@ -177,6 +193,7 @@ export async function runSync(options: RunSyncOptions = {}): Promise<RunSyncResu
   const filePath = resolve(cwd, options.path ?? DEFAULT_BUNDLE_PATH);
   const journalPath = journalPathFor(filePath);
   const dryRun = options.dryRun ?? false;
+  const promote = options.promote ?? false;
   const httpClient = options.httpClient ?? DEFAULT_HTTP_CLIENT;
   const now = options.now ?? (() => new Date());
   const env = options.env ?? process.env;
@@ -275,11 +292,48 @@ export async function runSync(options: RunSyncOptions = {}): Promise<RunSyncResu
     }
   }
 
+  // --promote: the SELF-HOSTING path to what the GitHub App does for hosted
+  // projects (docs/spec/bundle-format.md § References). Same shared
+  // computeRefPromotions, so an Inkognito deployment and arkaik.app cannot
+  // disagree about what a merged PR means. Still opt-in: a project without
+  // `ref_policy` gets nothing, exactly as before this flag existed.
+  const promoted: RefPromotionApplied[] = [];
+  if (promote) {
+    const plan = computeRefPromotions(bundle as unknown as Parameters<typeof computeRefPromotions>[0]);
+    for (const promotion of plan.promotions) {
+      const node = (bundle.nodes as Node[]).find((candidate) => candidate.id === promotion.node_id);
+      if (!node) continue;
+      promoted.push(promotion);
+      if (dryRun) continue;
+
+      const patch = promotionPatch(node, promotion);
+      Object.assign(node, patch);
+      dirty = true;
+
+      // A normal node.status_changed, carrying `platform` when the promotion is
+      // platform-scoped — the same event a human edit produces, so the journal
+      // reads the same whoever moved it.
+      appendJournalEvent(
+        journalPath,
+        makeEvent(
+          "node.status_changed",
+          {
+            node_id: promotion.node_id,
+            from: promotion.from,
+            to: promotion.to,
+            ...(promotion.platform ? { platform: promotion.platform } : {}),
+          },
+          { actor, ts: syncedAt },
+        ),
+      );
+    }
+  }
+
   if (dirty && !dryRun) {
     writeFileSync(filePath, serializeBundle(bundle as unknown as Parameters<typeof serializeBundle>[0]));
   }
 
-  return { ok: true, bundlePath: filePath, journalPath, dryRun, changed, unchanged, skipped, errors, nodeTitles };
+  return { ok: true, bundlePath: filePath, journalPath, dryRun, changed, unchanged, skipped, errors, nodeTitles, promoted };
 }
 
 /** A rendered `ref.status_changed` line for a change, reusing the shared event renderer. */
@@ -334,6 +388,7 @@ function report(result: RunSyncResult): void {
 export function runSyncCli(args: string[]): void {
   let provider: string | undefined;
   let dryRun = false;
+  let promote = false;
   const positionals: string[] = [];
 
   for (let i = 0; i < args.length; i++) {
@@ -343,6 +398,8 @@ export function runSyncCli(args: string[]): void {
       process.exit(0);
     } else if (arg === "--dry-run") {
       dryRun = true;
+    } else if (arg === "--promote") {
+      promote = true;
     } else if (arg === "--provider") {
       const value = args[++i];
       if (value === undefined) fail(`Missing value for --provider\n\n${USAGE}`);
@@ -356,7 +413,7 @@ export function runSyncCli(args: string[]): void {
 
   const filePath = positionals[0] ?? DEFAULT_BUNDLE_PATH;
 
-  runSync({ path: filePath, provider, dryRun })
+  runSync({ path: filePath, provider, dryRun, promote })
     .then((result) => {
       if (!result.ok) fail(`FATAL: ${result.fatal}`);
       report(result);

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -13,3 +13,4 @@ export * from "./maps";
 export * from "./emit";
 export * from "./derive";
 export * from "./mutate";
+export * from "./promote";

--- a/packages/schema/src/promote.ts
+++ b/packages/schema/src/promote.ts
@@ -1,0 +1,173 @@
+/**
+ * Ref-driven status promotion — turning "this PR merged" into "this acceptance
+ * shipped" (docs/spec/bundle-format.md § References).
+ *
+ * ── The rule this deliberately does not break ───────────────────────────────
+ * The format says: *"`status_mapped` never overwrites `node.status`
+ * automatically; it is advisory display data."* That default stands. A project
+ * opts in by declaring `project.metadata.ref_policy`, and only then does a
+ * mirrored ref status move a node. Absent policy = today's behaviour exactly,
+ * so nothing that exists changes meaning.
+ *
+ * Opting in is what makes the promotion honest rather than surprising: it is a
+ * recorded decision in the bundle, visible in a diff, not an implicit behaviour
+ * of the tooling.
+ *
+ * ── Per-platform, because acceptances are ──────────────────────────────────
+ * A ref may carry a `platform`. When it does, the promotion moves that
+ * platform's entry in `metadata.platformStatuses` and leaves the others alone —
+ * so a PR in an iOS repo marks iOS shipped and `computeParityGaps` correctly
+ * reports Web and Android as lagging. Moving the base `status` instead would
+ * silently claim parity the product does not have.
+ *
+ * Zod-free (type-only imports) like validate.ts / acceptance.ts / mutate.ts.
+ */
+
+import type { Node, ProjectBundle, Ref } from "./bundle";
+import type { PlatformId, StatusId } from "./ids";
+
+/**
+ * Which node status each mirrored external status implies, per ref type.
+ *
+ * `null` means "this transition moves nothing" — the way to say, for instance,
+ * that a PR closed without merging should leave the acceptance where it is
+ * rather than reverting work someone may still be doing.
+ */
+export interface RefPolicy {
+  [refType: string]: Record<string, StatusId | null> | undefined;
+}
+
+/**
+ * The policy a project gets when it opts in without naming one. PR opened →
+ * being worked on; merged → shipped; closed → deliberately nothing.
+ */
+export const DEFAULT_REF_POLICY: RefPolicy = {
+  "github-pr": { open: "development", merged: "live", closed: null },
+  "gitlab-mr": { open: "development", merged: "live", closed: null },
+};
+
+export interface Promotion {
+  node_id: string;
+  ref_id: string;
+  /** Present when the ref is platform-scoped; the promotion then targets that platform only. */
+  platform?: PlatformId;
+  from: StatusId;
+  to: StatusId;
+  /** The mirrored external status that implied this move. */
+  external_status: string;
+}
+
+/** Why a candidate promotion was skipped — surfaced so a no-op is explainable. */
+export interface SkippedPromotion {
+  node_id: string;
+  ref_id: string;
+  reason: "platform-not-applicable" | "archived" | "already-there" | "no-mapping";
+  detail?: string;
+}
+
+export interface PromotionPlan {
+  promotions: Promotion[];
+  skipped: SkippedPromotion[];
+}
+
+/** The effective policy for a bundle, or null when the project has not opted in. */
+export function resolveRefPolicy(bundle: Pick<ProjectBundle, "project">): RefPolicy | null {
+  const declared = (bundle.project.metadata as { ref_policy?: unknown } | undefined)?.ref_policy;
+  if (declared === undefined) return null;
+  // `ref_policy: true` is the shorthand for "use the defaults".
+  if (declared === true) return DEFAULT_REF_POLICY;
+  if (typeof declared !== "object" || declared === null || Array.isArray(declared)) return null;
+  return declared as RefPolicy;
+}
+
+/** The status a node currently has for the scope a ref targets. */
+function currentStatus(node: Node, platform?: PlatformId): StatusId {
+  if (!platform) return node.status;
+  return node.metadata?.platformStatuses?.[platform] ?? node.status;
+}
+
+/**
+ * The status changes a bundle's mirrored refs imply under its policy.
+ *
+ * Pure: it computes a plan and changes nothing. Applying it is the caller's
+ * job, through the normal mutation path, so every promotion lands as an
+ * ordinary `node.status_changed` event with a real actor — never a silent
+ * rewrite.
+ */
+export function computeRefPromotions(bundle: ProjectBundle): PromotionPlan {
+  const policy = resolveRefPolicy(bundle);
+  const promotions: Promotion[] = [];
+  const skipped: SkippedPromotion[] = [];
+  if (!policy) return { promotions, skipped };
+
+  for (const node of bundle.nodes) {
+    const refs = node.metadata?.refs;
+    if (!Array.isArray(refs) || refs.length === 0) continue;
+
+    for (const ref of refs as Ref[]) {
+      const mapping = policy[ref.type];
+      if (!mapping) continue;
+      if (!ref.external_status) continue;
+
+      const target = mapping[ref.external_status];
+      if (target === undefined) {
+        skipped.push({ node_id: node.id, ref_id: ref.id, reason: "no-mapping", detail: ref.external_status });
+        continue;
+      }
+      // An explicit null means "recognised, moves nothing" — not a gap.
+      if (target === null) continue;
+
+      // Archived is a deliberate end state; a stale PR must not resurrect it.
+      if (node.status === "archived") {
+        skipped.push({ node_id: node.id, ref_id: ref.id, reason: "archived" });
+        continue;
+      }
+
+      // `validateBundle` errors on a platformStatuses key outside `platforms`,
+      // so a ref naming an inapplicable platform is reported, never written.
+      if (ref.platform && !node.platforms.includes(ref.platform)) {
+        skipped.push({
+          node_id: node.id,
+          ref_id: ref.id,
+          reason: "platform-not-applicable",
+          detail: ref.platform,
+        });
+        continue;
+      }
+
+      const from = currentStatus(node, ref.platform);
+      if (from === target) {
+        skipped.push({ node_id: node.id, ref_id: ref.id, reason: "already-there", detail: target });
+        continue;
+      }
+
+      promotions.push({
+        node_id: node.id,
+        ref_id: ref.id,
+        ...(ref.platform ? { platform: ref.platform } : {}),
+        from,
+        to: target,
+        external_status: ref.external_status,
+      });
+    }
+  }
+
+  return { promotions, skipped };
+}
+
+/**
+ * The node patch a promotion implies — platform-scoped when the ref is.
+ *
+ * Returned as a patch rather than applied, so the caller runs it through
+ * `applyOps` and gets the usual derived events (a platform-scoped change emits
+ * `node.status_changed` carrying its `platform`).
+ */
+export function promotionPatch(node: Node, promotion: Promotion): Partial<Node> {
+  if (!promotion.platform) return { status: promotion.to };
+  return {
+    metadata: {
+      ...node.metadata,
+      platformStatuses: { ...node.metadata?.platformStatuses, [promotion.platform]: promotion.to },
+    },
+  };
+}

--- a/tests/schema/promote.test.js
+++ b/tests/schema/promote.test.js
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+
+/**
+ * Ref-driven status promotion (packages/schema/src/promote.ts).
+ *
+ * The rule this module must not break: docs/spec/bundle-format.md says
+ * `status_mapped` never overwrites `node.status` automatically. Promotion is
+ * therefore OPT-IN per project, and the first assertion below is that a project
+ * which has not opted in gets nothing at all — every other behaviour here is
+ * only reachable after a recorded decision in the bundle.
+ *
+ * The per-platform behaviour is the other load-bearing part: an acceptance
+ * shipped on one platform must NOT read as shipped everywhere, or the parity
+ * gap projection (#277) would report parity the product does not have.
+ */
+
+const { loadSchema } = require("./load-schema");
+
+let failures = 0;
+function check(name, cond, detail) {
+  if (cond) {
+    console.log(`PASS: ${name}`);
+  } else {
+    failures++;
+    console.log(`FAIL: ${name}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+function acceptance(id, extra = {}) {
+  return {
+    id,
+    project_id: "p",
+    species: "acceptance",
+    title: id,
+    status: "prioritized",
+    platforms: ["web", "ios"],
+    ...extra,
+  };
+}
+
+function ref(overrides = {}) {
+  return {
+    id: "gh-1",
+    type: "github-pr",
+    url: "https://github.com/o/r/pull/1",
+    external_status: "merged",
+    ...overrides,
+  };
+}
+
+function bundle(nodes, policy) {
+  return {
+    schema_version: 2,
+    project: {
+      id: "p",
+      title: "T",
+      created_at: "2026-01-01T00:00:00.000Z",
+      updated_at: "2026-01-01T00:00:00.000Z",
+      ...(policy === undefined ? {} : { metadata: { ref_policy: policy } }),
+    },
+    nodes,
+    edges: [],
+  };
+}
+
+function main() {
+  const { computeRefPromotions, promotionPatch, resolveRefPolicy, DEFAULT_REF_POLICY } = loadSchema();
+
+  // --- Opt-in is the whole contract ---------------------------------------
+  {
+    const withRef = acceptance("AC-a", { metadata: { refs: [ref()] } });
+    const plan = computeRefPromotions(bundle([withRef]));
+    check(
+      "a project that has not opted in promotes NOTHING",
+      plan.promotions.length === 0,
+      JSON.stringify(plan.promotions),
+    );
+    check("and reports no skips either (the feature is simply off)", plan.skipped.length === 0);
+    check("resolveRefPolicy returns null without opt-in", resolveRefPolicy(bundle([withRef])) === null);
+  }
+  {
+    const withRef = acceptance("AC-a", { metadata: { refs: [ref()] } });
+    check(
+      "`ref_policy: true` is shorthand for the defaults",
+      JSON.stringify(resolveRefPolicy(bundle([withRef], true))) === JSON.stringify(DEFAULT_REF_POLICY),
+    );
+    const plan = computeRefPromotions(bundle([withRef], true));
+    check("opting in with the shorthand promotes", plan.promotions.length === 1);
+    check("a merged PR means live", plan.promotions[0]?.to === "live", JSON.stringify(plan.promotions[0]));
+    check("the promotion records where it came from", plan.promotions[0]?.from === "prioritized");
+  }
+
+  // --- The default mapping -------------------------------------------------
+  {
+    const open = acceptance("AC-o", { metadata: { refs: [ref({ external_status: "open" })] } });
+    const plan = computeRefPromotions(bundle([open], true));
+    check("an open PR means development", plan.promotions[0]?.to === "development");
+  }
+  {
+    const closed = acceptance("AC-c", { metadata: { refs: [ref({ external_status: "closed" })] } });
+    const plan = computeRefPromotions(bundle([closed], true));
+    check(
+      "a PR closed WITHOUT merging moves nothing (null mapping)",
+      plan.promotions.length === 0,
+      JSON.stringify(plan.promotions),
+    );
+    check("and a null mapping is not reported as a gap", plan.skipped.length === 0, JSON.stringify(plan.skipped));
+  }
+  {
+    const odd = acceptance("AC-x", { metadata: { refs: [ref({ external_status: "draft" })] } });
+    const plan = computeRefPromotions(bundle([odd], true));
+    check("an unmapped external status is skipped, not guessed", plan.promotions.length === 0);
+    check("and the skip names the status", plan.skipped[0]?.reason === "no-mapping" && plan.skipped[0]?.detail === "draft");
+  }
+
+  // --- Per-platform is the point ------------------------------------------
+  {
+    const scoped = acceptance("AC-p", { metadata: { refs: [ref({ platform: "ios" })] } });
+    const plan = computeRefPromotions(bundle([scoped], true));
+    check("a platform-scoped ref promotes that platform", plan.promotions[0]?.platform === "ios");
+
+    const patch = promotionPatch(scoped, plan.promotions[0]);
+    check("the patch targets platformStatuses, not status", patch.status === undefined);
+    check("and sets only that platform", patch.metadata?.platformStatuses?.ios === "live");
+    check(
+      "leaving the other platform untouched (so parity gaps stay honest)",
+      patch.metadata?.platformStatuses?.web === undefined,
+      JSON.stringify(patch.metadata?.platformStatuses),
+    );
+  }
+  {
+    const unscoped = acceptance("AC-u", { metadata: { refs: [ref()] } });
+    const patch = promotionPatch(unscoped, computeRefPromotions(bundle([unscoped], true)).promotions[0]);
+    check("an unscoped ref moves the base status", patch.status === "live");
+    check("and does not invent platformStatuses", patch.metadata === undefined);
+  }
+  {
+    // validateBundle errors on a platformStatuses key outside `platforms`, so
+    // this must be reported rather than written.
+    const wrongPlatform = acceptance("AC-w", {
+      platforms: ["web"],
+      metadata: { refs: [ref({ platform: "android" })] },
+    });
+    const plan = computeRefPromotions(bundle([wrongPlatform], true));
+    check("a ref naming an inapplicable platform promotes nothing", plan.promotions.length === 0);
+    check(
+      "and says why",
+      plan.skipped[0]?.reason === "platform-not-applicable" && plan.skipped[0]?.detail === "android",
+      JSON.stringify(plan.skipped),
+    );
+  }
+
+  // --- Guards --------------------------------------------------------------
+  {
+    const archived = acceptance("AC-arch", { status: "archived", metadata: { refs: [ref()] } });
+    const plan = computeRefPromotions(bundle([archived], true));
+    check("an archived node is never resurrected by a stale PR", plan.promotions.length === 0);
+    check("and the skip says archived", plan.skipped[0]?.reason === "archived");
+  }
+  {
+    const alreadyLive = acceptance("AC-live", { status: "live", metadata: { refs: [ref()] } });
+    const plan = computeRefPromotions(bundle([alreadyLive], true));
+    check("a node already at the target is not re-promoted", plan.promotions.length === 0);
+    check("so a re-run is a no-op, not a churn of events", plan.skipped[0]?.reason === "already-there");
+  }
+  {
+    const scopedLive = acceptance("AC-sl", {
+      metadata: { platformStatuses: { ios: "live" }, refs: [ref({ platform: "ios" })] },
+    });
+    const plan = computeRefPromotions(bundle([scopedLive], true));
+    check(
+      "already-there is judged per platform, not on the base status",
+      plan.promotions.length === 0 && plan.skipped[0]?.reason === "already-there",
+      JSON.stringify(plan),
+    );
+  }
+
+  // --- A custom policy overrides the defaults ------------------------------
+  {
+    const node = acceptance("AC-cust", { metadata: { refs: [ref({ external_status: "merged" })] } });
+    const plan = computeRefPromotions(bundle([node], { "github-pr": { merged: "releasing" } }));
+    check("a custom policy is honoured", plan.promotions[0]?.to === "releasing");
+  }
+  {
+    const node = acceptance("AC-none", { metadata: { refs: [ref()] } });
+    const plan = computeRefPromotions(bundle([node], { "linear-issue": { done: "live" } }));
+    check("a policy that does not mention this ref type promotes nothing", plan.promotions.length === 0);
+  }
+
+  // --- Refs without a mirrored status --------------------------------------
+  {
+    const unsynced = acceptance("AC-un", { metadata: { refs: [ref({ external_status: undefined })] } });
+    const plan = computeRefPromotions(bundle([unsynced], true));
+    check("a ref never synced promotes nothing", plan.promotions.length === 0);
+  }
+
+  // --- Non-acceptance nodes are eligible too -------------------------------
+  {
+    const view = {
+      id: "V-a",
+      project_id: "p",
+      species: "view",
+      title: "A",
+      status: "prioritized",
+      platforms: ["web"],
+      metadata: { refs: [ref()] },
+    };
+    const plan = computeRefPromotions(bundle([view], true));
+    check(
+      "promotion is not acceptance-only — any node with a ref qualifies",
+      plan.promotions.length === 1 && plan.promotions[0].node_id === "V-a",
+    );
+  }
+
+  if (failures > 0) {
+    console.error(`\n${failures} check(s) failed.`);
+    process.exit(1);
+  }
+  console.log("\nAll promote checks passed.");
+}
+
+main();

--- a/tests/services/github-webhook.test.js
+++ b/tests/services/github-webhook.test.js
@@ -1,0 +1,309 @@
+#!/usr/bin/env node
+
+/**
+ * The GitHub webhook (app/api/github/webhook, lib/services/github/*).
+ *
+ * This is the only endpoint that accepts a signed request from a third party,
+ * and the first inbound signature check in the codebase, so the verification
+ * assertions carry the most weight here:
+ *
+ *   - an unsigned request is rejected;
+ *   - a WRONG signature is rejected (not merely a malformed one — a check that
+ *     only rejects garbage is not a check);
+ *   - a signature over DIFFERENT bytes is rejected, which is what catches an
+ *     implementation that verifies a re-serialization instead of the raw body;
+ *   - with no secret configured the endpoint refuses everything rather than
+ *     accepting unauthenticated writes.
+ *
+ * Plus the planning logic: which nodes a PR touches, per-platform scoping from
+ * the repo link, and idempotence — the property that lets a retry be safe.
+ *
+ * Runs against a real Postgres for the repo-link and delivery-ledger parts.
+ */
+
+const { Client } = require("pg");
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const { loadGithubApi, BUILD_DIR } = require("./load-github-api");
+
+let failures = 0;
+function check(name, cond, detail) {
+  if (cond) {
+    console.log(`PASS: ${name}`);
+  } else {
+    failures++;
+    console.log(`FAIL: ${name}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+const SECRET = "webhook-test-secret";
+const REPO = "acme/ios-app";
+
+function sign(body, secret = SECRET) {
+  return `sha256=${crypto.createHmac("sha256", secret).update(body, "utf8").digest("hex")}`;
+}
+
+let deliveryCounter = 0;
+function prPayload(overrides = {}) {
+  return JSON.stringify({
+    action: "closed",
+    repository: { full_name: REPO },
+    pull_request: {
+      number: 42,
+      html_url: "https://github.com/acme/ios-app/pull/42",
+      title: "Guest checkout",
+      body: "Implements AC-guest-checkout",
+      merged: true,
+      state: "closed",
+      ...(overrides.pull_request ?? {}),
+    },
+    ...(overrides.top ?? {}),
+  });
+}
+
+function webhookReq(body, { signature, event = "pull_request", delivery } = {}) {
+  const headers = {
+    "content-type": "application/json",
+    "x-github-event": event,
+    "x-github-delivery": delivery ?? `delivery-${++deliveryCounter}`,
+  };
+  if (signature !== null) headers["x-hub-signature-256"] = signature ?? sign(body);
+  return new Request("https://arkaik.test/api/github/webhook", { method: "POST", headers, body });
+}
+
+function acceptance(id, platforms, extra = {}) {
+  return {
+    id,
+    project_id: "gp",
+    species: "acceptance",
+    title: id,
+    status: "prioritized",
+    platforms,
+    ...extra,
+  };
+}
+
+async function main() {
+  if (!process.env.DATABASE_URL) {
+    console.error("DATABASE_URL is not set — this integration test needs a migrated Postgres.");
+    process.exit(1);
+  }
+  process.env.GITHUB_WEBHOOK_SECRET = SECRET;
+
+  const client = new Client({ connectionString: process.env.DATABASE_URL });
+  await client.connect();
+
+  const api = loadGithubApi();
+  const { verify, pullRequest, POST } = api;
+
+  try {
+    // --- Signature verification (pure; no database needed) -----------------
+    const body = prPayload();
+
+    check("a correct signature verifies", verify.verifySignature(body, sign(body)).ok === true);
+    check(
+      "a missing signature is rejected",
+      verify.verifySignature(body, null).reason === "missing-signature",
+    );
+    check(
+      "a malformed signature is rejected",
+      verify.verifySignature(body, "garbage").reason === "malformed-signature",
+    );
+    check(
+      "a signature from the WRONG SECRET is rejected",
+      verify.verifySignature(body, sign(body, "not-the-secret")).reason === "mismatch",
+    );
+    check(
+      "a valid signature over DIFFERENT bytes is rejected",
+      verify.verifySignature(body, sign(`${body} `)).reason === "mismatch",
+      "catches verifying a re-serialization instead of the raw body",
+    );
+    {
+      const saved = process.env.GITHUB_WEBHOOK_SECRET;
+      delete process.env.GITHUB_WEBHOOK_SECRET;
+      check(
+        "with no secret configured, everything is refused",
+        verify.verifySignature(body, sign(body)).reason === "unconfigured",
+      );
+      process.env.GITHUB_WEBHOOK_SECRET = saved;
+    }
+
+    // --- Route-level guards -------------------------------------------------
+    check(
+      "an unsigned request gets 401",
+      (await POST(webhookReq(body, { signature: null }))).status === 401,
+    );
+    check(
+      "a wrongly-signed request gets 401",
+      (await POST(webhookReq(body, { signature: sign(body, "wrong") }))).status === 401,
+    );
+    check(
+      "a request with no delivery id gets 400",
+      (
+        await POST(
+          new Request("https://arkaik.test/api/github/webhook", {
+            method: "POST",
+            headers: { "x-github-event": "pull_request", "x-hub-signature-256": sign(body) },
+            body,
+          }),
+        )
+      ).status === 400,
+    );
+    {
+      const res = await POST(webhookReq(body, { event: "ping" }));
+      check("a ping is acknowledged, not acted on", res.status === 202, String(res.status));
+    }
+    {
+      const ignored = prPayload({ top: { action: "labeled" } });
+      const res = await POST(webhookReq(ignored));
+      check("an uninteresting action is acknowledged", res.status === 202, String(res.status));
+    }
+
+    // --- Mention parsing ----------------------------------------------------
+    check(
+      "an acceptance id in the body is found",
+      pullRequest.mentionedAcceptances({ title: "x", body: "closes AC-guest-checkout" })[0] ===
+        "AC-guest-checkout",
+    );
+    check(
+      "an acceptance id in the title is found",
+      pullRequest.mentionedAcceptances({ title: "AC-a11y-labels: fix", body: "" })[0] === "AC-a11y-labels",
+    );
+    check(
+      "duplicates collapse",
+      pullRequest.mentionedAcceptances({ title: "AC-x", body: "AC-x again" }).length === 1,
+    );
+    check(
+      "unrelated text yields nothing",
+      pullRequest.mentionedAcceptances({ title: "chore: bump deps", body: "no ids here" }).length === 0,
+    );
+
+    // --- External status ----------------------------------------------------
+    check("merged wins over state", pullRequest.prExternalStatus({ merged: true, state: "closed" }) === "merged");
+    check("closed without merge is closed", pullRequest.prExternalStatus({ merged: false, state: "closed" }) === "closed");
+    check("otherwise open", pullRequest.prExternalStatus({ merged: false, state: "open" }) === "open");
+
+    // --- Planning: per-platform scoping from the LINK ------------------------
+    const optedIn = {
+      project: { id: "gp", title: "T", metadata: { ref_policy: true } },
+      nodes: [acceptance("AC-guest-checkout", ["web", "ios"])],
+      edges: [],
+    };
+    {
+      const ops = pullRequest.planForProject(optedIn, JSON.parse(prPayload()) && {
+        action: "closed",
+        repoFullName: REPO,
+        number: 42,
+        url: "https://github.com/acme/ios-app/pull/42",
+        title: "Guest checkout",
+        body: "Implements AC-guest-checkout",
+        merged: true,
+        state: "closed",
+      }, "ios");
+
+      check("a mentioned acceptance gets ops", ops.length === 2, JSON.stringify(ops.map((o) => o.op)));
+      const refOp = ops[0];
+      check("the first op attaches the ref", refOp.patch.metadata.refs[0].id === "gh-pr-42");
+      check("the ref mirrors the PR state", refOp.patch.metadata.refs[0].external_status === "merged");
+      check(
+        "the ref is scoped to the LINK's platform",
+        refOp.patch.metadata.refs[0].platform === "ios",
+        JSON.stringify(refOp.patch.metadata.refs[0]),
+      );
+      const promoteOp = ops[1];
+      check(
+        "the promotion targets that platform only",
+        promoteOp.patch.metadata.platformStatuses.ios === "live" &&
+          promoteOp.patch.metadata.platformStatuses.web === undefined,
+        JSON.stringify(promoteOp.patch.metadata.platformStatuses),
+      );
+    }
+    {
+      // A repo serving every platform declares no platform on the link.
+      const ops = pullRequest.planForProject(optedIn, {
+        action: "closed", repoFullName: REPO, number: 42,
+        url: "https://github.com/acme/ios-app/pull/42",
+        title: "t", body: "AC-guest-checkout", merged: true, state: "closed",
+      }, null);
+      check("an unscoped link moves the base status", ops[1]?.patch.status === "live", JSON.stringify(ops[1]));
+    }
+    {
+      // A link naming a platform the node does not have must not produce a
+      // platformStatuses key validateBundle would reject.
+      const webOnly = {
+        project: { id: "gp", title: "T", metadata: { ref_policy: true } },
+        nodes: [acceptance("AC-guest-checkout", ["web"])],
+        edges: [],
+      };
+      const ops = pullRequest.planForProject(webOnly, {
+        action: "closed", repoFullName: REPO, number: 42,
+        url: "https://github.com/acme/ios-app/pull/42",
+        title: "t", body: "AC-guest-checkout", merged: true, state: "closed",
+      }, "ios");
+      const ref = ops[0].patch.metadata.refs[0];
+      check("a ref never claims a platform the node lacks", ref.platform === undefined, JSON.stringify(ref));
+    }
+    {
+      const notOptedIn = {
+        project: { id: "gp", title: "T" },
+        nodes: [acceptance("AC-guest-checkout", ["web", "ios"])],
+        edges: [],
+      };
+      const ops = pullRequest.planForProject(notOptedIn, {
+        action: "closed", repoFullName: REPO, number: 42,
+        url: "https://github.com/acme/ios-app/pull/42",
+        title: "t", body: "AC-guest-checkout", merged: true, state: "closed",
+      }, "ios");
+      check(
+        "without ref_policy the ref is mirrored but NOTHING is promoted",
+        ops.length === 1 && ops[0].patch.metadata.refs,
+        JSON.stringify(ops.map((o) => o.op)),
+      );
+    }
+    {
+      const unrelated = pullRequest.planForProject(optedIn, {
+        action: "closed", repoFullName: REPO, number: 7,
+        url: "https://github.com/acme/ios-app/pull/7",
+        title: "chore: bump deps", body: "nothing here", merged: true, state: "closed",
+      }, "ios");
+      check("a PR mentioning no acceptance produces no ops", unrelated.length === 0);
+    }
+
+    // --- The delivery ledger -------------------------------------------------
+    const deliveryId = `test-delivery-${Date.now()}`;
+    check("a fresh delivery is claimed", (await pullRequest.claimDelivery(deliveryId)) === true);
+    check("the same delivery cannot be claimed twice", (await pullRequest.claimDelivery(deliveryId)) === false);
+    await pullRequest.releaseDelivery(deliveryId);
+    check(
+      "a released delivery can be claimed again (so a retry after failure works)",
+      (await pullRequest.claimDelivery(deliveryId)) === true,
+    );
+    await pullRequest.releaseDelivery(deliveryId);
+
+    {
+      // A redelivery of a handled event must not act twice.
+      const shared = `dup-${Date.now()}`;
+      const first = await POST(webhookReq(body, { delivery: shared }));
+      const second = await POST(webhookReq(body, { delivery: shared }));
+      check("the first delivery is processed", first.status === 200, String(first.status));
+      check("a redelivery is reported as a duplicate", second.status === 202, String(second.status));
+      check("and says so", (await second.json()).status === "duplicate");
+      await pullRequest.releaseDelivery(shared);
+    }
+  } finally {
+    await client.query(`delete from github_deliveries where delivery_id like 'delivery-%' or delivery_id like 'test-delivery-%' or delivery_id like 'dup-%'`).catch(() => {});
+    await client.end();
+    fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+  }
+
+  if (failures > 0) {
+    console.error(`\n${failures} check(s) failed.`);
+    process.exit(1);
+  }
+  console.log("\nAll github-webhook checks passed.");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/services/github-webhook.test.js
+++ b/tests/services/github-webhook.test.js
@@ -89,6 +89,12 @@ async function main() {
     process.exit(1);
   }
   process.env.GITHUB_WEBHOOK_SECRET = SECRET;
+  // getCaller() refuses everyone unless auth is configured, so the repo-link
+  // routes below would all 401 without these. NextAuth itself is stubbed; these
+  // are never used for a real round-trip.
+  process.env.AUTH_SECRET ||= "ghtest-secret";
+  process.env.AUTH_GITHUB_ID ||= "ghtest-id";
+  process.env.AUTH_GITHUB_SECRET ||= "ghtest-secret";
 
   const client = new Client({ connectionString: process.env.DATABASE_URL });
   await client.connect();
@@ -297,16 +303,20 @@ async function main() {
           edges: [],
         },
       });
+      check("the fixture project was created", created.ok === true, JSON.stringify(created));
       const projectId = created.id;
       const ctx = { params: Promise.resolve({ projectId }) };
       const origin = "https://arkaik.test";
 
       api.setSession({ user: { id: String(userId), name: "ghtest" } });
 
-      check(
-        "a fresh project has no repo links",
-        (await (await api.LIST_REPOS(new Request(origin), ctx)).json()).repos.length === 0,
-      );
+      const initial = await api.LIST_REPOS(new Request(origin), ctx);
+      const initialBody = await initial.json();
+      // Assert the response is what we think before reading into it — an
+      // unauthenticated 401 here would otherwise surface as a TypeError far
+      // from its cause.
+      check("listing repos is authorized", initial.status === 200, `${initial.status} ${JSON.stringify(initialBody)}`);
+      check("a fresh project has no repo links", initialBody.repos?.length === 0, JSON.stringify(initialBody));
 
       const linked = await api.LINK_REPO(
         new Request(origin, {
@@ -316,10 +326,12 @@ async function main() {
         }),
         ctx,
       );
-      check("linking a repo returns 201", linked.status === 201, String(linked.status));
+      const linkedBody = await linked.json();
+      check("linking a repo returns 201", linked.status === 201, `${linked.status} ${JSON.stringify(linkedBody)}`);
       check(
         "the name is lowercased on write (GitHub is case-insensitive)",
-        (await linked.json()).repo.repoFullName === "acme/ios-app",
+        linkedBody.repo?.repoFullName === "acme/ios-app",
+        JSON.stringify(linkedBody),
       );
 
       check(

--- a/tests/services/github-webhook.test.js
+++ b/tests/services/github-webhook.test.js
@@ -269,6 +269,137 @@ async function main() {
       check("a PR mentioning no acceptance produces no ops", unrelated.length === 0);
     }
 
+    // --- Repo links: the surface the webhook resolves against ----------------
+    // Without a link, a delivery finds no projects and does nothing. These
+    // assertions exist because the table and the webhook shipped before any way
+    // to create a row, which made the whole feature unreachable.
+    {
+      const email = `ghtest-${Date.now()}@example.com`;
+      const { rows } = await client.query(
+        `insert into users (name, email) values ('ghtest', $1) returning id`,
+        [email],
+      );
+      const userId = rows[0].id;
+      const ownerId = (await api.owners.resolveOwnerIds(userId))[0];
+      const created = await api.store.createProject({
+        ownerId,
+        tier: "klub",
+        bundle: {
+          schema_version: 2,
+          project: {
+            id: "gp",
+            title: "Linked",
+            metadata: { ref_policy: true },
+            created_at: "2026-01-01T00:00:00.000Z",
+            updated_at: "2026-01-01T00:00:00.000Z",
+          },
+          nodes: [acceptance("AC-guest-checkout", ["web", "ios"])],
+          edges: [],
+        },
+      });
+      const projectId = created.id;
+      const ctx = { params: Promise.resolve({ projectId }) };
+      const origin = "https://arkaik.test";
+
+      api.setSession({ user: { id: String(userId), name: "ghtest" } });
+
+      check(
+        "a fresh project has no repo links",
+        (await (await api.LIST_REPOS(new Request(origin), ctx)).json()).repos.length === 0,
+      );
+
+      const linked = await api.LINK_REPO(
+        new Request(origin, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ repo_full_name: "Acme/iOS-App", platform: "ios" }),
+        }),
+        ctx,
+      );
+      check("linking a repo returns 201", linked.status === 201, String(linked.status));
+      check(
+        "the name is lowercased on write (GitHub is case-insensitive)",
+        (await linked.json()).repo.repoFullName === "acme/ios-app",
+      );
+
+      check(
+        "a malformed repo name is rejected",
+        (
+          await api.LINK_REPO(
+            new Request(origin, {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({ repo_full_name: "not-a-repo" }),
+            }),
+            ctx,
+          )
+        ).status === 400,
+      );
+      check(
+        "an invalid platform is rejected",
+        (
+          await api.LINK_REPO(
+            new Request(origin, {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({ repo_full_name: "acme/x", platform: "windows" }),
+            }),
+            ctx,
+          )
+        ).status === 400,
+      );
+
+      // THE END-TO-END POINT: the webhook now finds the link.
+      const found = await pullRequest.linkedProjects("acme/ios-app");
+      check(
+        "the webhook resolves a delivery to the linked project",
+        found.some((l) => l.projectId === projectId && l.platform === "ios"),
+        JSON.stringify(found),
+      );
+      check(
+        "a delivery for a case-different name still resolves",
+        (await pullRequest.linkedProjects("Acme/iOS-App")).some((l) => l.projectId === projectId),
+      );
+
+      // Owner scoping.
+      const { rows: other } = await client.query(
+        `insert into users (name, email) values ('ghtest2', $1) returning id`,
+        [`ghtest2-${Date.now()}@example.com`],
+      );
+      await api.owners.resolveOwnerIds(other[0].id);
+      api.setSession({ user: { id: String(other[0].id), name: "other" } });
+      check(
+        "another owner cannot list this project's repos",
+        (await api.LIST_REPOS(new Request(origin), ctx)).status === 404,
+      );
+      check(
+        "another owner cannot link a repo to it",
+        (
+          await api.LINK_REPO(
+            new Request(origin, {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({ repo_full_name: "evil/repo" }),
+            }),
+            ctx,
+          )
+        ).status === 404,
+      );
+
+      api.setSession({ user: { id: String(userId), name: "ghtest" } });
+      const unlinked = await api.UNLINK_REPO(new Request(`${origin}?repo=acme%2Fios-app`), ctx);
+      check("unlinking returns 204", unlinked.status === 204, String(unlinked.status));
+      check(
+        "and the webhook no longer resolves it",
+        (await pullRequest.linkedProjects("acme/ios-app")).every((l) => l.projectId !== projectId),
+      );
+
+      await client.query(`delete from graph_projects where id = $1`, [projectId]);
+      await client.query(`delete from owner_members where user_id = any($1::int[])`, [[userId, other[0].id]]);
+      await client.query(`delete from owners where id = any($1::text[])`, [[ownerId, `own-u${other[0].id}`]]);
+      await client.query(`delete from users where id = any($1::int[])`, [[userId, other[0].id]]);
+    }
+
     // --- The delivery ledger -------------------------------------------------
     const deliveryId = `test-delivery-${Date.now()}`;
     check("a fresh delivery is claimed", (await pullRequest.claimDelivery(deliveryId)) === true);

--- a/tests/services/load-github-api.js
+++ b/tests/services/load-github-api.js
@@ -45,7 +45,11 @@ function loadGithubApi() {
   write("server-only-stub.js", "module.exports = {};\n");
   write(
     "auth-module-stub.js",
-    "module.exports = { auth: async () => null, __setSession: () => {} };\n",
+    "let current = null;\n" +
+      "module.exports = {\n" +
+      "  auth: async () => current,\n" +
+      "  __setSession: (s) => { current = s; },\n" +
+      "};\n",
   );
 
   const COMMON = [
@@ -57,6 +61,7 @@ function loadGithubApi() {
     ["@/lib/services/tokens", "./tokens.js"],
     ["@/lib/services/auth", "./auth.js"],
     ["@/lib/services/graph/store", "./graph-store.js"],
+    ["@/lib/services/graph/repos", "./graph-repos.js"],
     ["@/lib/services/github/verify", "./verify.js"],
     ["@/lib/services/github/pull-request", "./pull-request.js"],
     ["@/auth", "./auth-module-stub.js"],
@@ -70,6 +75,8 @@ function loadGithubApi() {
   write("tokens.js", transpile(src("lib", "services", "tokens.ts"), "tokens.ts", COMMON));
   write("auth.js", transpile(src("lib", "services", "auth.ts"), "auth.ts", COMMON));
   write("graph-store.js", transpile(src("lib", "services", "graph", "store.ts"), "store.ts", COMMON));
+  write("graph-repos.js", transpile(src("lib", "services", "graph", "repos.ts"), "repos.ts", COMMON));
+  write("repos-route.js", transpile(src("app", "api", "graph", "projects", "[projectId]", "repos", "route.ts"), "route.ts", COMMON));
   write("verify.js", transpile(src("lib", "services", "github", "verify.ts"), "verify.ts", COMMON));
   write("pull-request.js", transpile(src("lib", "services", "github", "pull-request.ts"), "pull-request.ts", COMMON));
   write("webhook-route.js", transpile(src("app", "api", "github", "webhook", "route.ts"), "route.ts", COMMON));
@@ -83,6 +90,13 @@ function loadGithubApi() {
     verify: req("verify.js"),
     pullRequest: req("pull-request.js"),
     store: req("graph-store.js"),
+    repos: req("graph-repos.js"),
+    LIST_REPOS: req("repos-route.js").GET,
+    LINK_REPO: req("repos-route.js").POST,
+    UNLINK_REPO: req("repos-route.js").DELETE,
+    owners: req("owners.js"),
+    tokens: req("tokens.js"),
+    setSession: require(path.join(BUILD_DIR, "auth-module-stub.js")).__setSession,
     POST: req("webhook-route.js").POST,
   };
 }

--- a/tests/services/load-github-api.js
+++ b/tests/services/load-github-api.js
@@ -1,0 +1,90 @@
+/**
+ * Loads the GitHub webhook route and its two service modules into a running
+ * Node process without a bundler — same approach as the other tests/services
+ * loaders. Nothing is stubbed: signature verification, the delivery ledger, the
+ * repo lookup and the planning logic all run for real.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const ts = require("typescript");
+const { loadSchema, BUILD_DIR: SCHEMA_BUILD_DIR } = require("../schema/load-schema");
+
+const ROOT = path.join(__dirname, "..", "..");
+const BUILD_DIR = path.join(__dirname, ".test-build-github");
+
+const COMPILER_OPTIONS = {
+  module: ts.ModuleKind.CommonJS,
+  target: ts.ScriptTarget.ES2020,
+  esModuleInterop: true,
+};
+
+function transpile(srcAbsPath, fileName, rewrites) {
+  const source = fs.readFileSync(srcAbsPath, "utf8");
+  let { outputText } = ts.transpileModule(source, { fileName, compilerOptions: COMPILER_OPTIONS });
+  for (const [specifier, replacement] of rewrites) {
+    const pattern = new RegExp(
+      `require\\((['"])${specifier.replace(/[.*+?^${}()|[\]\\/]/g, "\\$&")}\\1\\)`,
+      "g",
+    );
+    outputText = outputText.replace(pattern, `require(${JSON.stringify(replacement)})`);
+  }
+  return outputText;
+}
+
+function loadGithubApi() {
+  loadSchema();
+  const schemaIndex = path.join(SCHEMA_BUILD_DIR, "index.js");
+
+  fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+  fs.mkdirSync(BUILD_DIR, { recursive: true });
+  fs.writeFileSync(path.join(BUILD_DIR, "package.json"), JSON.stringify({ type: "commonjs" }));
+
+  const write = (name, text) => fs.writeFileSync(path.join(BUILD_DIR, name), text);
+  const serverOnlyStub = "./server-only-stub.js";
+  write("server-only-stub.js", "module.exports = {};\n");
+  write(
+    "auth-module-stub.js",
+    "module.exports = { auth: async () => null, __setSession: () => {} };\n",
+  );
+
+  const COMMON = [
+    ["server-only", serverOnlyStub],
+    ["@arkaik/schema", schemaIndex],
+    ["@/lib/services/db", "./db.js"],
+    ["@/lib/services/limits", "./limits.js"],
+    ["@/lib/services/owners", "./owners.js"],
+    ["@/lib/services/tokens", "./tokens.js"],
+    ["@/lib/services/auth", "./auth.js"],
+    ["@/lib/services/graph/store", "./graph-store.js"],
+    ["@/lib/services/github/verify", "./verify.js"],
+    ["@/lib/services/github/pull-request", "./pull-request.js"],
+    ["@/auth", "./auth-module-stub.js"],
+  ];
+
+  const src = (...parts) => path.join(ROOT, ...parts);
+
+  write("db.js", transpile(src("lib", "services", "db.ts"), "db.ts", COMMON));
+  write("limits.js", transpile(src("lib", "services", "limits.ts"), "limits.ts", COMMON));
+  write("owners.js", transpile(src("lib", "services", "owners.ts"), "owners.ts", COMMON));
+  write("tokens.js", transpile(src("lib", "services", "tokens.ts"), "tokens.ts", COMMON));
+  write("auth.js", transpile(src("lib", "services", "auth.ts"), "auth.ts", COMMON));
+  write("graph-store.js", transpile(src("lib", "services", "graph", "store.ts"), "store.ts", COMMON));
+  write("verify.js", transpile(src("lib", "services", "github", "verify.ts"), "verify.ts", COMMON));
+  write("pull-request.js", transpile(src("lib", "services", "github", "pull-request.ts"), "pull-request.ts", COMMON));
+  write("webhook-route.js", transpile(src("app", "api", "github", "webhook", "route.ts"), "route.ts", COMMON));
+
+  for (const name of fs.readdirSync(BUILD_DIR)) {
+    if (name.endsWith(".js")) delete require.cache[path.join(BUILD_DIR, name)];
+  }
+
+  const req = (name) => require(path.join(BUILD_DIR, name));
+  return {
+    verify: req("verify.js"),
+    pullRequest: req("pull-request.js"),
+    store: req("graph-store.js"),
+    POST: req("webhook-route.js").POST,
+  };
+}
+
+module.exports = { loadGithubApi, BUILD_DIR, SCHEMA_BUILD_DIR };


### PR DESCRIPTION
> Stacked on #290. GitHub retargets as each base merges.

## Summary

Opening a PR that names an acceptance moves it to `development`; merging moves it to `live` — **per platform**. This closes the loop the whole program was for.

### Opt-in, because the format says so

`docs/spec/bundle-format.md` states that `status_mapped` never overwrites `node.status` automatically. **That default stands.** Promotion happens only when a project declares `metadata.ref_policy`, so every bundle that predates this behaves exactly as before.

Opting in is a recorded decision, visible in a diff — not an implicit behaviour of the tooling. The spec is **amended to describe the opt-in** rather than quietly contradicted.

### Per-platform, from the link — not the PR

`project_repos` records which platform a repository serves. So a PR merged in the iOS repo marks **only iOS** shipped, with no per-PR annotation and no way for anyone to forget. Web and Android then surface as a real parity gap — which is exactly what `computeParityGaps` (#277) is for. Moving the base status instead would claim parity the product doesn't have.

### One implementation, two delivery paths

`computeRefPromotions` lives in `@arkaik/schema` and is shared by the hosted GitHub App **and** `arkaik sync --promote`, so a self-hosted (Inkognito) deployment and arkaik.app cannot disagree about what a merged PR means.

## The webhook

This is the **first inbound signature check in the codebase**, so verification is its own module with no database or business logic — small enough to audit in one read.

- Verifies the **raw body before parsing anything**. Re-serialized JSON doesn't round-trip byte-for-byte, so verifying a re-serialization would fail against valid signatures — and "fixing" that by relaxing the comparison would defeat the check entirely. There's a test asserting a valid signature over *different bytes* is rejected.
- Constant-time comparison.
- **Refuses everything when `GITHUB_WEBHOOK_SECRET` is unset**, rather than degrading to accepting unauthenticated writes.

### Replay handling, and why it releases

Deliveries are claimed in a ledger so GitHub's retries and its one-click redeliver can't re-apply a transition — and **released again if the apply throws**, because holding the claim would turn a transient failure into a permanently lost transition.

At-least-once is the right posture here: applying twice is a **no-op by construction**, since re-writing an identical ref derives no events (`diffNodeUpdate`) and promoting to a status already held is skipped as `already-there`. The ledger prevents wasted work, not incorrectness.

Every webhook write goes through `applyMutation`, so it faces the same validator gate and lands the same journal events as a human edit — with `github-app` as the actor, so the history says what acted.

## Verification

`tsc`, `lint` (0 errors), `next build`, the drift gate, and the suites: `promote` (**29 checks**), `mutate`, `cli`, `mcp`, `provider`, `acceptance`, `refs`, `validate:seeds`.

The promotion tests pin the semantics that matter: a project without `ref_policy` promotes **nothing**; a platform-scoped ref touches only that platform and leaves the others alone; a ref naming an inapplicable platform is reported rather than written (it would fail `validateBundle`); archived nodes are never resurrected by a stale PR; and a re-run is a no-op rather than a churn of events.

⚠️ **`tests/services/github-webhook.test.js` has not been run** — no Postgres locally, so CI is its first execution. Pre-flight without a database confirmed the loader resolves and that verification rejects a wrong secret, a malformed header, and a valid signature over different bytes.

## Correction: a gap found after opening this PR

`009` created `project_repos` and the webhook reads it — but **nothing wrote it**. No endpoint, no UI. A delivery would have resolved to zero projects and done nothing, forever: the entire feature was unreachable, and this PR body originally claimed the only gap was the refs editor. That was wrong.

Fixed in `6595d1c`: `lib/services/graph/repos.ts` plus `GET/POST/DELETE /api/graph/projects/{id}/repos`, and a `RepoLinksDialog` reachable from hosted project cards. Names are lowercased on write, because GitHub is case-insensitive about repository names and a link stored as `Acme/App` would silently never match a delivery for `acme/app`.

The new tests close the loop the unit tests could not: link a repo, then assert `linkedProjects` genuinely resolves a delivery to that project with the right platform (including for a case-different name), and that unlinking makes it stop.

## Still deferred, stated rather than hidden

The refs editor in `NodeDetailPanel` is **still read-only**. A human links a PR by mentioning the acceptance id in the PR body; attaching a ref by hand in the UI isn't possible yet. The agent path works today via `update_node`.

## Lab Note

```yaml
en:
  title: Your acceptances tick themselves off as you ship
  summary: Mention an acceptance in a pull request and it moves to in-progress on its own — then to shipped when the PR merges, on the platform that repository builds for.
fr:
  title: Tes acceptances se cochent toutes seules quand tu livres
  summary: Mentionne une acceptance dans une pull request et elle passe en cours toute seule — puis en livrée à la fusion, sur la plateforme que ce dépôt construit.
suggested:
  molecule: arkaik
  type: feature
  tags: [changelog]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

