### PR TITLE
docs: record what hosted projects changed in the specs, not just the how-to

### DIFF
--- a/docs/arkaik-skill/skill.md
+++ b/docs/arkaik-skill/skill.md
@@ -44,6 +44,26 @@ one the first time you make a change (see [Dual-write](#dual-write-snapshot--jou
 > | `{{BUNDLE_PATH}}` | Path to the snapshot | `docs/arkaik/bundle.json` |
 > | `{{JOURNAL_PATH}}` | Path to the journal sidecar | `docs/arkaik/journal.jsonl` |
 
+> **Check this first: is the map a file, or an account project?**
+>
+> If `docs/arkaik/arkaik.json` exists in this repository, the map is **hosted** —
+> it lives in an arkaik account, not in a file here. Everything below about
+> *what* to record still applies; everything about *how* to write it does not.
+>
+> | | File map | Hosted map (`docs/arkaik/arkaik.json` present) |
+> |---|---|---|
+> | Where it lives | `{{BUNDLE_PATH}}` in this repo | the account, reached over HTTP |
+> | How you edit it | patch the JSON, append to the journal | the `arkaik-mcp` tools (`create_node`, `update_node`, …) |
+> | Dual-write | you do it, by hand | the server does it — every mutation derives its own journal events |
+>
+> **Do not create or edit `{{BUNDLE_PATH}}` for a hosted map.** Nothing reads it,
+> the account never sees the change, and the next person to look finds two maps
+> disagreeing. If the MCP tools are unavailable, say so and stop rather than
+> falling back to the file — a silent fallback is the failure nobody notices.
+>
+> The tool catalog is identical in both modes, so the rest of this skill reads
+> the same either way. Setup: [hosted-projects.md](https://github.com/alexisbohns/arkaik/blob/main/docs/hosted-projects.md).
+
 ## When to Update the Map
 
 Update the map as a side-effect of your main work whenever you:

--- a/docs/spec/mcp.md
+++ b/docs/spec/mcp.md
@@ -25,15 +25,40 @@ This is the **audience-symmetry principle** (vision.md § Core Product) made con
 | Not a CLI subcommand | The `arkaik` CLI stays dependency-free; the MCP SDK would end that. The CLI usage text gains a pointer line; an `arkaik mcp` alias MAY wrap the package later |
 | SDK note | `@modelcontextprotocol/sdk` was the default choice; its zod-3 pin against the workspace's zod 4 resolved this to the fallback, taken all the way: the server speaks newline-delimited JSON-RPC directly (`src/protocol.ts`, ~150 lines — `initialize`, `tools/list`, `tools/call`, `ping`) with raw JSON-Schema tool definitions whose enums come from `@arkaik/schema` ids. `@arkaik/schema` remains the only validation authority; the SDK MAY be adopted later without changing the tool catalog |
 
-## Bundle Discovery (Kommit-first)
+## Graph Discovery — two modes, one catalog
 
-The server operates on the **repo bundle** — the Kommit mode where the map already lives next to the code, maintained as a side effect of development. Resolution order:
+The server serves a graph from one of two backends. **The tool catalog is identical in both**, which is the point: the mode is a `Store` implementation (`src/store.ts`), not a second set of tools, so repo and hosted behaviour cannot drift.
+
+### Repo bundle (Kommit-first, the default)
+
+The map lives next to the code, maintained as a side effect of development. Resolution order:
 
 1. `--bundle <path>` argument
 2. `ARKAIK_BUNDLE` environment variable
 3. `docs/arkaik/bundle.json` under the current working directory
 
 The journal is the sidecar resolved by the rules in [journal.md](journal.md) § Storage Shapes. The server MUST reload the bundle per tool call (files are small; external edits — a human, another agent, `git pull` — must be picked up).
+
+### Hosted project (the account backend)
+
+The map lives in an arkaik account and is reached over HTTP, so the app, this server, and the GitHub App all read and write one copy — no sync, no merge, no conflict UI ([hosted-projects.md](../hosted-projects.md), [services.md](services.md) § *Boundary 1 no longer holds for hosted projects*).
+
+Selected by `--remote`, or automatically by a `docs/arkaik/arkaik.json` written by `arkaik link`. Resolution:
+
+| | Order |
+|---|---|
+| Project | `--project`, then `$ARKAIK_PROJECT`, then `arkaik.json` |
+| Origin | `$ARKAIK_URL`, then `arkaik.json`, then `https://arkaik.app` |
+| Token | `$ARKAIK_TOKEN` only — never a file, because a credential in a repo file is a credential in a git history |
+
+`--bundle` always wins, so an explicit path overrides a link file.
+
+Two rules this mode MUST hold:
+
+- **The client sends OPS, not a mutated graph.** The server recomputes under its own row lock, so two writers cannot lose each other's work. `Store.persist` therefore takes an *intent* for the hosted backend where the file backend takes an *outcome*.
+- **A linked repo with no token exits non-zero.** It MUST NOT fall back to a repo bundle: a silent fallback serves a stale graph that looks fine, which is the failure an agent cannot notice.
+
+`propose_idea` and `file_request` are refused against a hosted project — the hosted write path has no journal-only operation yet — with an explicit message rather than a silent drop.
 
 ## Tool Catalog (v1)
 

--- a/docs/spec/services.md
+++ b/docs/spec/services.md
@@ -26,6 +26,39 @@ Three hard boundaries, inherited from [vision.md](../vision.md) and [journal.md]
 2. **No re-projection.** The server never derives a snapshot from a journal or vice versa. It stores what the client sent, verbatim (minus the Publik journal strip below).
 3. **No event-sourcing promises.** M4 sync is whole-bundle backup. The journal rides inside the bundle as opaque history; journal-based merge is a Basik/Klub design problem for M5+.
 
+> ### Boundary 1 no longer holds for hosted projects — decision record
+>
+> **Hosted projects (`graph_projects`, migration 008) deliberately cross boundary 1.**
+> For a project in an account, the server *is* the system of record, and it *does*
+> mutate bundles: `applyMutation` applies ops under a row lock, and the GitHub App
+> promotes acceptance statuses from pull-request events with no browser involved.
+>
+> This is recorded rather than quietly edited because boundary 1 is load-bearing
+> everywhere else, and it still holds everywhere else. Synk and Publik are
+> unchanged: they remain backup and share, storing what the client sent. Boundaries
+> 2 and 3 are untouched even for hosted projects — the server derives *events from
+> the diff it just applied*, which is emission, not re-projection, and there is
+> still no merge.
+>
+> **Why the boundary was worth crossing.** The browser cannot be the system of
+> record for a graph that a coding agent in any repository, and a webhook GitHub
+> calls, both write to. Keeping it there would have required two-way sync, conflict
+> resolution and merge — the M5+ problem boundary 3 defers — to deliver a feature
+> whose whole point is that there is one copy.
+>
+> **What still holds, and is what "validated storage" was protecting.** Every
+> server mutation passes the same `validateBundle` the CLI and MCP use, in the same
+> transaction, and is refused whole on any error. Every change lands as an ordinary
+> journal event with a real actor (`github-app` for the App), so the history says
+> what acted. The format stays portable and export is always available: a hosted
+> project can be exported and re-imported as a local one at any time.
+>
+> **The cost, stated plainly:** hosted projects do not work offline. Local-first
+> projects still do, and remain the default.
+>
+> See [hosted-projects.md](../hosted-projects.md) for the how-to and
+> [bundle-format.md](bundle-format.md) § References for the promotion rules.
+
 ## Backend — Decision Record
 
 **Chosen: Vercel-native.** Next.js route handlers under `app/api/` for compute, **Postgres (Neon via Vercel)** for all storage. No Supabase.

--- a/docs/spec/toolchain.md
+++ b/docs/spec/toolchain.md
@@ -6,7 +6,7 @@ order: 3
 
 # Toolchain & Packaging
 
-> Status: **Implemented** — `packages/schema` (`@arkaik/schema`), `packages/cli` (`arkaik`, with the `arkaik/io` subpath export), and `packages/mcp` (`arkaik-mcp`) are live workspace packages; the skill ships as a Claude Code plugin (`plugin/`) with generated assets (now including `.mcp.json`), and `scripts/generate/` drift-checks every generated artifact in CI. The legacy copy-paste skill remains under `docs/arkaik-skill/`. This document remains the normative contract; the MCP server companion is specified in [mcp.md](mcp.md).
+> Status: **Implemented** — `packages/schema` (`@arkaik/schema`), `packages/cli` (`arkaik`, with the `arkaik/io` subpath export), and `packages/mcp` (`arkaik-mcp`) are live workspace packages, with `arkaik` and `arkaik-mcp` published to npm (see [Releasing](#releasing) — publishing is manual); the skill ships as a Claude Code plugin (`plugin/`) with generated assets (now including `.mcp.json`), and `scripts/generate/` drift-checks every generated artifact in CI. The legacy copy-paste skill remains under `docs/arkaik-skill/`. This document remains the normative contract; the MCP server companion is specified in [mcp.md](mcp.md).
 > The key words MUST, SHOULD, and MAY are to be interpreted as in RFC 2119.
 
 ## Why npm
@@ -71,6 +71,39 @@ The agent skill graduates from copy-paste (`docs/arkaik-skill/`) to a managed as
 | Versioning | A version stamp in the skill frontmatter lets `arkaik init --update` upgrade cleanly instead of blind-overwriting local edits |
 | Skill v2 behavior | Dual-write per [journal.md](journal.md): surgical snapshot patches + appended events, validator as the hard gate — unchanged doctrine, new history duty |
 | Second channel | A Claude Code plugin (marketplace-installable) packaging the same generated assets, for users who prefer plugin management over `npx` |
+
+## Releasing
+
+**Both packages are published by hand. Nothing in CI publishes** — there is no
+release workflow and no `NPM_TOKEN`. That is a deliberate note rather than an
+omission, because the absence has already cost twice:
+
+- `arkaik` was never published at all, and *could not have been*: it declared
+  `@arkaik/schema` — a private package — as a runtime `dependency`, so
+  `npm i arkaik` would have failed to resolve it;
+- `arkaik-mcp` on npm drifted twelve days behind `main` and silently lacked
+  hosted mode entirely, so `npx -y arkaik-mcp` in a linked repo served a local
+  bundle instead of the account project. The version had not been bumped either,
+  so a publish would have been rejected as a duplicate.
+
+The rules that keep both from recurring:
+
+| Rule | Why |
+|---|---|
+| `@arkaik/schema` is a **devDependency** of both packages, never a dependency | It is private and not on the registry; both builds esbuild-bundle it, so the published `dist/index.js` imports nothing but `node:` builtins. A runtime dependency on it is unresolvable for consumers |
+| Bump the version in the same commit as the change that ships | npm refuses a duplicate version, so an unbumped package silently stays stale on the registry while `main` moves |
+| Build explicitly before publishing | Both packages have `prepublishOnly`, but it does **not** run when `ignore-scripts=true` is set in the publisher's npm config — a common and otherwise sensible supply-chain setting. Do not rely on it |
+| Verify from the registry, not the working tree | `npm pack <name>` the published tarball and check it contains what you expect. The stale-MCP failure was invisible from a local checkout |
+
+```bash
+npm run build -w arkaik && npm run build -w arkaik-mcp
+npm publish -w arkaik
+npm publish -w arkaik-mcp
+npm view arkaik version && npm view arkaik-mcp version
+```
+
+A tag-triggered workflow with a granular automation token is the durable fix and
+is not built; until it is, the checklist above is the process.
 
 ## Licensing
 

--- a/plugin/skills/arkaik/SKILL.md
+++ b/plugin/skills/arkaik/SKILL.md
@@ -44,6 +44,26 @@ one the first time you make a change (see [Dual-write](#dual-write-snapshot--jou
 > | `{{BUNDLE_PATH}}` | Path to the snapshot | `docs/arkaik/bundle.json` |
 > | `{{JOURNAL_PATH}}` | Path to the journal sidecar | `docs/arkaik/journal.jsonl` |
 
+> **Check this first: is the map a file, or an account project?**
+>
+> If `docs/arkaik/arkaik.json` exists in this repository, the map is **hosted** —
+> it lives in an arkaik account, not in a file here. Everything below about
+> *what* to record still applies; everything about *how* to write it does not.
+>
+> | | File map | Hosted map (`docs/arkaik/arkaik.json` present) |
+> |---|---|---|
+> | Where it lives | `{{BUNDLE_PATH}}` in this repo | the account, reached over HTTP |
+> | How you edit it | patch the JSON, append to the journal | the `arkaik-mcp` tools (`create_node`, `update_node`, …) |
+> | Dual-write | you do it, by hand | the server does it — every mutation derives its own journal events |
+>
+> **Do not create or edit `{{BUNDLE_PATH}}` for a hosted map.** Nothing reads it,
+> the account never sees the change, and the next person to look finds two maps
+> disagreeing. If the MCP tools are unavailable, say so and stop rather than
+> falling back to the file — a silent fallback is the failure nobody notices.
+>
+> The tool catalog is identical in both modes, so the rest of this skill reads
+> the same either way. Setup: [hosted-projects.md](https://github.com/alexisbohns/arkaik/blob/main/docs/hosted-projects.md).
+
 ## When to Update the Map
 
 Update the map as a side-effect of your main work whenever you:


### PR DESCRIPTION
Audit of every doc touching this week's work. The how-to page (`hosted-projects.md`) was in good shape — it was revised across #292/#293/#294. The **specs** were not: everything about the agent plane lived in that one file, and one spec now actively contradicted the code.

## `services.md` — the decision record that was owed

Boundary 1 still read:

> **The browser is the source of truth for every tier.** The server … is never the system of record. **No server-side mutation of bundles beyond validated storage.**

Both halves are false for hosted projects — the server *is* the system of record, and the GitHub App mutates bundles with no browser involved. The original plan said this needed "a decision record in that spec, not a quiet edit"; that never happened, through six slices and three PRs.

Recorded as a **scoped exception** rather than edited away, because the boundary is load-bearing everywhere else and still holds there: Synk and Publik are unchanged, and boundaries 2 and 3 hold even for hosted projects. It also states why crossing it was worth it (the alternative was two-way sync and merge — the M5+ problem boundary 3 defers — to deliver a feature whose entire point is that there is one copy), what "validated storage" was protecting and still gets, and the cost: **hosted projects do not work offline.**

## `mcp.md` — hosted mode was entirely undocumented

§ Bundle Discovery listed only the three repo-bundle steps. The spec described a server with one backend; the shipped one has two. Now § Graph Discovery covers both, leading with the fact that makes it safe — **the tool catalog is identical**, because the mode is a `Store` implementation and not a second set of tools, so the two cannot drift.

Adds the project/origin/token resolution order and the two rules the hosted path must hold: the client sends **ops**, not a mutated graph, so the server recomputes under its own lock; and a linked repo with no token **exits non-zero** rather than silently serving a stale local bundle. I verified each against `config.ts:76,85` and `remote-store.ts:104` before writing it.

## `skill.md` — the one most likely to bite today

This is the file **agents read**, and it described only the file model. An agent in a hosted repo would look for `docs/arkaik/bundle.json`, not find it, and either stall or write a file nothing reads — while the account never sees the change.

Now leads with how to tell the two apart (`docs/arkaik/arkaik.json`), a table of what differs, and says plainly: do not create the bundle file for a hosted map, and if the MCP tools are unavailable, **stop rather than fall back**.

Relevant to you specifically — this is the skill an agent in pbbls will be reading this week.

## `toolchain.md` — a § Releasing section that did not exist

Nothing documented how these packages get published, and that absence caused both of this week's packaging failures: a CLI that *could not* be published (private package as a runtime dependency) and an MCP on npm twelve days behind `main` that silently lacked hosted mode.

Four rules recorded, including two that are easy to get wrong: `prepublishOnly` does **not** run when `ignore-scripts=true` is in the publisher's npm config, and verification has to come from the published tarball rather than the working tree — the stale-MCP failure was invisible from a local checkout.

## Checked and found already correct

`.env.example` (thorough, accurate on the private key and the permission), `plugin/.mcp.json` (mode-agnostic by design), `bundle-format.md`, and both README indexes.

## Verified

`npm run generate` + drift gate clean, `build` green, `validate:seeds`, `test:mcp`. All new cross-links resolve.