### PR TITLE
fix: wait for the account answer before listing projects, so hosted ones show

### DIFF
--- a/lib/data/hosted-availability.ts
+++ b/lib/data/hosted-availability.ts
@@ -3,23 +3,106 @@
  * between the auth status hook (which learns it) and the routing provider
  * (which acts on it).
  *
- * Deliberately a module-level flag rather than React state or context: the
- * routing provider is plain data-layer code called from outside the component
- * tree, so it cannot read a hook. The flag is set on every `/api/auth/status`
- * resolution and read at call time, so the worst case is one listing that tries
- * the account a moment early or late — which the routing provider already
- * degrades from without failing.
+ * Deliberately module-level rather than React state or context: the routing
+ * provider is plain data-layer code called from outside the component tree, so
+ * it cannot read a hook.
+ *
+ * The subtlety is *timing*, not storage. `/api/auth/status` resolves a tick or
+ * two after the app mounts, and the surfaces that list projects start their
+ * listing on mount. A caller that merely samples the flag at that instant reads
+ * the "no account" default and silently drops every hosted project — which is
+ * exactly how `/projects` came to show fewer projects than the in-project
+ * switcher. So the signal is not just readable but *awaitable*:
+ * {@link whenHostedAvailabilityKnown} settles when the answer actually arrives.
+ *
+ * The wait is bounded. Not every surface renders a consumer of the auth status,
+ * and nothing may hang a project listing forever waiting for a report that is
+ * never coming — so an unanswered gate falls back to its current value (false,
+ * i.e. local-only) after {@link DEFAULT_TIMEOUT_MS}. The worst case is then one
+ * listing that misses the account, which is what the old behaviour did every
+ * single time.
  *
  * Defaults to false so the local-first app never issues a hosted request it has
  * no reason to expect will succeed.
  */
 
-let hostedAvailable = false;
+/** How long to wait for a status report before answering with the default. */
+const DEFAULT_TIMEOUT_MS = 3000;
+
+export interface HostedAvailability {
+  /** Report the answer, releasing anything waiting on {@link HostedAvailability.whenKnown}. */
+  set(available: boolean): void;
+  /** The answer as of right now — false until reported. */
+  isAvailable(): boolean;
+  /**
+   * The answer once it is actually known, or the current value if nothing
+   * reports one within the timeout.
+   */
+  whenKnown(): Promise<boolean>;
+}
+
+export interface HostedAvailabilityOptions {
+  timeoutMs?: number;
+}
+
+/**
+ * A standalone gate. Exported so a caller that owns its own lifecycle (a test,
+ * a future multi-account shell) can hold one without touching module state.
+ */
+export function createHostedAvailability(
+  options: HostedAvailabilityOptions = {},
+): HostedAvailability {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  let available = false;
+  let known = false;
+  let waiters: Array<(value: boolean) => void> = [];
+
+  return {
+    set(next: boolean) {
+      available = next;
+      known = true;
+      const pending = waiters;
+      waiters = [];
+      for (const resolve of pending) resolve(available);
+    },
+
+    isAvailable: () => available,
+
+    whenKnown() {
+      if (known) return Promise.resolve(available);
+
+      return new Promise<boolean>((resolve) => {
+        const timer = setTimeout(() => {
+          // Give up waiting, but leave the gate unknown: a report arriving
+          // later still counts, for this caller's next listing and everyone
+          // else's.
+          waiters = waiters.filter((waiter) => waiter !== settle);
+          resolve(available);
+        }, timeoutMs);
+
+        function settle(value: boolean) {
+          clearTimeout(timer);
+          resolve(value);
+        }
+
+        waiters.push(settle);
+      });
+    },
+  };
+}
+
+const shared = createHostedAvailability();
 
 export function setHostedAvailable(available: boolean): void {
-  hostedAvailable = available;
+  shared.set(available);
 }
 
 export function isHostedAvailable(): boolean {
-  return hostedAvailable;
+  return shared.isAvailable();
+}
+
+/** @see createHostedAvailability */
+export function whenHostedAvailabilityKnown(): Promise<boolean> {
+  return shared.whenKnown();
 }

--- a/lib/data/provider-registry.ts
+++ b/lib/data/provider-registry.ts
@@ -1,5 +1,5 @@
 import type { DataProvider } from "./data-provider";
-import { isHostedAvailable } from "./hosted-availability";
+import { whenHostedAvailabilityKnown } from "./hosted-availability";
 import { localProvider } from "./local-provider";
 import { createRemoteProvider } from "./remote-provider";
 import { createRoutingProvider } from "./routing-provider";
@@ -28,16 +28,21 @@ import { createRoutingProvider } from "./routing-provider";
  * For a local project this is behaviourally identical to before — every call
  * whose project id is not in the hosted `prj_` namespace goes straight to
  * `localProvider`. The only difference is `listProjects()`, which additionally
- * asks the account when {@link isHostedAvailable} says there is one, and falls
- * back to the local list if that request fails.
+ * asks the account when {@link whenHostedAvailabilityKnown} says there is one,
+ * and falls back to the local list if that request fails.
+ *
+ * It *waits* for that answer rather than sampling it: the projects page starts
+ * its listing on mount, before `/api/auth/status` has replied, so a sampled
+ * flag would read the signed-out default and drop every hosted project from
+ * the list.
  *
  * So the local-first app is unaffected: signed out, or with services
- * unconfigured, `isHostedAvailable()` is false and nothing reaches the network.
+ * unconfigured, the answer is false and nothing reaches the network.
  */
 let currentProvider: DataProvider = createRoutingProvider({
   local: localProvider,
   remote: createRemoteProvider(),
-  isRemoteAvailable: isHostedAvailable,
+  isRemoteAvailable: whenHostedAvailabilityKnown,
 });
 
 /** The active `DataProvider`. Defaults to `localProvider`. */

--- a/lib/data/routing-provider.ts
+++ b/lib/data/routing-provider.ts
@@ -27,8 +27,13 @@ export interface RoutingProviderOptions {
    * Whether hosted projects are reachable — false when signed out or when
    * services are unconfigured. `listProjects()` then returns local projects
    * alone instead of failing the whole listing.
+   *
+   * May answer asynchronously, and in production does: the answer comes from
+   * `/api/auth/status`, which is still in flight when the projects page mounts
+   * and starts listing. Sampling a flag at that instant reads "no account" and
+   * drops the hosted half of the list, so `listProjects()` awaits this.
    */
-  isRemoteAvailable: () => boolean;
+  isRemoteAvailable: () => boolean | Promise<boolean>;
 }
 
 export function createRoutingProvider(options: RoutingProviderOptions): DataProvider {
@@ -49,7 +54,7 @@ export function createRoutingProvider(options: RoutingProviderOptions): DataProv
      */
     async listProjects(): Promise<ProjectSummary[]> {
       const localProjects = await local.listProjects();
-      if (!isRemoteAvailable()) return localProjects;
+      if (!(await isRemoteAvailable())) return localProjects;
 
       try {
         const hosted = await remote.listProjects();

--- a/tests/data/provider-registry.test.js
+++ b/tests/data/provider-registry.test.js
@@ -194,12 +194,91 @@ async function main() {
     check("importProject goes to the local provider", calls.includes("importProject:imported"), calls.join(","));
   }
 
+  // --- Availability is awaited, not sampled --------------------------------
+  // The page that lists projects mounts before `/api/auth/status` answers. If
+  // `listProjects()` merely samples a flag at that instant it reads the "no
+  // account" default and silently drops every hosted project — the /projects
+  // page showing fewer projects than the in-project switcher.
+  {
+    let fetchCalls = 0;
+    const router = routing.createRoutingProvider({
+      local: reg.localFake,
+      remote: remote.createRemoteProvider({
+        fetchImpl: async () => {
+          fetchCalls++;
+          return jsonResponse({ projects: [] });
+        },
+      }),
+      isRemoteAvailable: async () => false,
+    });
+    const listed = await router.listProjects();
+    check("an async 'not available' is awaited, not treated as truthy", fetchCalls === 0, String(fetchCalls));
+    check("...and the local list still comes back", listed.length === 1);
+  }
+  {
+    const router = routing.createRoutingProvider({
+      local: reg.localFake,
+      remote: remote.createRemoteProvider({
+        fetchImpl: async () =>
+          jsonResponse({
+            projects: [
+              {
+                id: HOSTED,
+                title: "Hosted",
+                nodeCount: 3,
+                edgeCount: 2,
+                createdAt: "2026-01-01T00:00:00.000Z",
+                updatedAt: "2026-01-01T00:00:00.000Z",
+              },
+            ],
+          }),
+      }),
+      // Availability that only settles a tick later, exactly as the real auth
+      // status does — the listing must wait for it.
+      isRemoteAvailable: () => new Promise((resolve) => setTimeout(() => resolve(true), 5)),
+    });
+    const listed = await router.listProjects();
+    check(
+      "a listing started before auth resolves still includes hosted projects",
+      listed.length === 2,
+      JSON.stringify(listed.map((p) => p.project.id)),
+    );
+  }
+
   // --- The availability flag ------------------------------------------------
   check("hosted availability defaults to false", availability.isHostedAvailable() === false);
   availability.setHostedAvailable(true);
   check("hosted availability can be set", availability.isHostedAvailable() === true);
   availability.setHostedAvailable(false);
   check("hosted availability can be cleared", availability.isHostedAvailable() === false);
+
+  // --- Waiting for the answer instead of guessing ---------------------------
+  {
+    const gate = availability.createHostedAvailability();
+    let settled = null;
+    void gate.whenKnown().then((value) => {
+      settled = value;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    check("whenKnown() does not answer before the status is reported", settled === null, String(settled));
+
+    gate.set(true);
+    check("reporting the status answers waiters with it", (await gate.whenKnown()) === true);
+    check("...and the sync read agrees", gate.isAvailable() === true);
+  }
+  {
+    const gate = availability.createHostedAvailability();
+    gate.set(false);
+    check("once known, whenKnown() answers immediately", (await gate.whenKnown()) === false);
+  }
+  {
+    // Nothing must hang forever on a surface where no one reports the status.
+    const gate = availability.createHostedAvailability({ timeoutMs: 5 });
+    const started = Date.now();
+    const answer = await gate.whenKnown();
+    check("whenKnown() gives up and answers with the default", answer === false);
+    check("...promptly", Date.now() - started < 500, String(Date.now() - started));
+  }
 
   fs.rmSync(BUILD_DIR, { recursive: true, force: true });
 


### PR DESCRIPTION
## The bug

Signed in, `/projects` showed only local projects — but opening one and using the
project switcher showed those *plus* the hosted ones. Same data, same
`listProjects()` call, two different answers.

Whether hosted projects get listed at all was a module-level boolean, sampled at
call time:

- `lib/data/hosted-availability.ts` defaulted `hostedAvailable` to `false`.
- Only `useAuthStatus` flipped it, after `GET /api/auth/status` resolved.
- `routing-provider.ts` read it synchronously: `if (!isRemoteAvailable()) return localProjects;`

`/projects` starts its listing in a mount effect, which runs *before* that fetch
replies. So it read the signed-out default, skipped the hosted half, and never
re-listed. The switcher ran the identical code but mounted after a client-side
nav, by which point the flag was already `true`. Hard-reloading a project page
raced the same way.

It was never a title collision between a local project and its hosted copy —
`/projects` was showing too few, not de-duplicating.

## The fix

The flag becomes an awaitable gate. `createHostedAvailability()` returns
`{ set, isAvailable, whenKnown }`, and the module keeps one shared instance
behind the existing `setHostedAvailable` / `isHostedAvailable` plus a new
`whenHostedAvailabilityKnown()`.

`whenKnown()` settles the moment the status is reported, resolves immediately if
it is already known, and — because not every surface renders a consumer of the
auth status — falls back to the current value after 3s rather than hanging a
listing on a report that is never coming. The worst case is then one listing
that misses the account; the old behaviour did that every single time.

`RoutingProviderOptions.isRemoteAvailable` now accepts `boolean | Promise<boolean>`
and `listProjects()` awaits it. Neither page changed: both surfaces go through
`listProjects()`, so both are fixed at once.

Local-first behaviour is untouched — signed out or with services unconfigured
the answer is still `false` and nothing reaches the network.

## Tests

Written first, and they failed for the right reasons: an `async () => false`
availability check still hit the network (a pending Promise is truthy), and
`createHostedAvailability` did not exist. Six new checks in
`tests/data/provider-registry.test.js` cover the async-false case, a listing
started before auth resolves, and the gate's wait / already-known / timeout
paths.

`npm run test:provider` passes (32 checks), `tsc --noEmit` and `eslint` are
clean, `npm run build` succeeds.

Not verified in a browser: signing in against a hosted account needs services
this machine does not run, so the proof here is the regression test that
reproduces the race rather than a screenshot of four cards.

## Follow-up, deliberately not in this PR

With hosted projects listed again, the *intended* duplication becomes visible:
"Move to account" is a copy that leaves the local original in place, same title.
Worth offering "delete the local copy?" after a successful move — a separate
product call.

## Lab Note

```yaml
en:
  title: "All your projects, right where you left them"
  summary: "Your projects list now waits a beat for your account before it draws, so the ones you moved there show up alongside the ones on this device — no more wondering where half of them went."
fr:
  title: "Tous tes projets, là où tu les as laissés"
  summary: "Ta liste de projets attend maintenant ton compte avant de s'afficher : ceux que tu y as déplacés apparaissent bien à côté de ceux de cet appareil. Fini de chercher où est passée la moitié d'entre eux."
suggested:
  molecule: arkaik
  type: fix
  tags: [changelog]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
