### PR TITLE
docs: quote Lab Note titles and summaries, so a colon can't break the note

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,18 +10,20 @@
   Fill in the fields (see CLAUDE.md § Lab Note requirement, or the lab-note skill).
   Chore / refactor / infra / docs-only change? Delete this whole section — that's
   the gate. (If the reminder still comments, add the `no-lab-note` label.)
+  Keep the quotes around every title and summary: a colon in a sentence breaks
+  an unquoted YAML value, and that is the most common malformed note.
 -->
 ## Lab Note
 
 ```yaml
 en:
-  title: Short, benefit-first title             # required
-  summary: One or two sentences, user-facing.   # required
-fr:                                             # recommended — adaptation, informal "Tu"
-  title: Titre court, orienté bénéfice
-  summary: Une ou deux phrases, adaptées, pas traduites littéralement.
-suggested:                                      # optional — prefills triage
+  title: "Short, benefit-first title"            # required — always quoted
+  summary: "One or two sentences, user-facing."  # required — always quoted
+fr:                                              # recommended — adaptation, informal "Tu"
+  title: "Titre court, orienté bénéfice"
+  summary: "Une ou deux phrases, adaptées, pas traduites littéralement."
+suggested:                                       # optional — prefills triage
   molecule: arkaik
-  type: feature                                 # feature | improvement | fix | announcement
+  type: feature                                  # feature | improvement | fix | announcement
   tags: [changelog]
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,17 +28,24 @@ top-level keys are ignored. Skeleton:
 
 ```yaml
 en:
-  title: Short, benefit-first title             # required
-  summary: One or two sentences, user-facing.   # required
-fr:                                             # recommended — adaptation, informal "Tu"
-  title: Titre court, orienté bénéfice
-  summary: Une ou deux phrases, adaptées, pas traduites littéralement.
-suggested:                                      # optional — prefills triage in the Ariko admin
+  title: "Short, benefit-first title"            # required — always quoted
+  summary: "One or two sentences, user-facing."  # required — always quoted
+fr:                                              # recommended — adaptation, informal "Tu"
+  title: "Titre court, orienté bénéfice"
+  summary: "Une ou deux phrases, adaptées, pas traduites littéralement."
+suggested:                                       # optional — prefills triage in the Ariko admin
   molecule: arkaik       # THIS repo's molecule slug
   type: feature          # feature | improvement | fix | announcement
   tags: [changelog]
   # atom: <slug>         # ONLY when you know the slug exists — never guess
 ```
+
+**Always double-quote every title and summary.** A colon is the natural way to
+write a sentence ("Heads up: it moved", "ton compte : ceux que...") and it is
+exactly what an unquoted YAML value cannot hold — the parser reads `key: value`
+and the whole note fails. Quoting removes the failure mode outright, and makes
+apostrophes and em dashes free too. Slug-ish values (`molecule`, `type`,
+`tags`) need no quotes.
 
 **Tone.** Lead with the benefit, not the mechanism; keep it short; warm and a
 little playful, never corporate; no engineering jargon, ticket numbers, or
@@ -46,7 +53,9 @@ internal names.
 
 **This repo's molecule slug is `arkaik`.** A malformed note fails the
 post-on-merge job loudly (e.g. `en.title is required`); the advisory reminder
-surfaces the same problems at PR-open time. Fix by editing the PR body —
-posting is idempotent.
+surfaces the same problems at PR-open time, as a comment on the PR. **After
+opening a PR, read its comments** instead of assuming the note is fine — the
+reminder clears its own comment once the body is fixed. Fix by editing the PR
+body — posting is idempotent.
 
 Full pipeline docs: [ariko README — "Making it a requirement"](https://github.com/alexisbohns/ariko#lab-note-pipeline-c1--github-connector).


### PR DESCRIPTION
The always-loaded `CLAUDE.md` skeleton and the PR template both showed Lab Note
values unquoted. Write a normal sentence with a colon in it — "Heads up: it
moved", or the French spaced form "ton compte : ceux que..." — and the YAML no
longer parses: the parser reads `key: value` inside the plain scalar and gives
up on the whole block.

That is what happened on #298 in this repo. The advisory reminder caught it and
commented within ten seconds, which is the system working — but the guidance is
what put the colon there unquoted.

## What changed

Both skeletons now quote every title and summary, with the rule stated next to
each: always double-quote titles and summaries; slug-ish values (`molecule`,
`type`, `tags`) need no quotes. Quoting takes the failure mode off the table
entirely, apostrophes and em dashes included.

`CLAUDE.md` also now says to read the PR's comments after opening it, rather
than assuming the note is fine — the reminder names these problems in seconds
and clears its own comment once the body is fixed.

## Rollout

This is the sibling half of alexisbohns/ariko#21, which fixes the source of
truth: the `lab-note` skill and the README skeleton, plus a parse error that
names the cause ("the summary contains a colon, so it must be wrapped in
quotes") instead of js-yaml's "bad indentation of a mapping entry". Matching
PRs go to femfolk and pbbls.

No Lab Note — authoring guidance, nothing a user would notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)