### PR TITLE
Reach agent tokens from the account menu

### DIFF
--- a/components/auth/AuthButton.tsx
+++ b/components/auth/AuthButton.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { GithubIcon, LogOutIcon, UserRoundIcon } from "lucide-react";
+import { GithubIcon, KeyRoundIcon, LogOutIcon, UserRoundIcon } from "lucide-react";
 import { signIn, signOut } from "next-auth/react";
+import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -83,6 +84,15 @@ export function AuthButton() {
             <span className="truncate text-xs font-normal text-muted-foreground">{user.email}</span>
           ) : null}
         </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {/* Tokens belong to the account, not to a project — so the account menu
+            is the one place they are always reachable from. */}
+        <DropdownMenuItem asChild className="cursor-pointer">
+          <Link href="/settings/tokens">
+            <KeyRoundIcon />
+            <span>Agent tokens</span>
+          </Link>
+        </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem
           className="cursor-pointer"

--- a/components/layout/ProjectSwitcher.tsx
+++ b/components/layout/ProjectSwitcher.tsx
@@ -1,8 +1,16 @@
 "use client";
 
 import { useMemo } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { CheckIcon, ChevronsUpDownIcon, FolderOpenIcon, GithubIcon, LogOutIcon } from "lucide-react";
+import {
+  CheckIcon,
+  ChevronsUpDownIcon,
+  FolderOpenIcon,
+  GithubIcon,
+  KeyRoundIcon,
+  LogOutIcon,
+} from "lucide-react";
 import { signIn, signOut } from "next-auth/react";
 import {
   DropdownMenu,
@@ -138,6 +146,14 @@ export function ProjectSwitcher({
                 <DropdownMenuLabel className="text-xs text-muted-foreground">
                   {authStatus.user.name ?? authStatus.user.email ?? "Account"}
                 </DropdownMenuLabel>
+                {/* Account-level, like sign-out — a token reaches every project
+                    of the account, not the one currently open. */}
+                <DropdownMenuItem asChild className="cursor-pointer gap-2">
+                  <Link href="/settings/tokens">
+                    <KeyRoundIcon className="size-4" />
+                    <span>Agent tokens</span>
+                  </Link>
+                </DropdownMenuItem>
                 <DropdownMenuItem
                   className="cursor-pointer gap-2"
                   onClick={() => void signOut()}


### PR DESCRIPTION
Agent tokens are minted against an *owner* (the account), never a project, but `/settings/tokens` had no link anywhere in the UI — the only pointers were in CLI and MCP error strings.

Adds an **Agent tokens** item to both signed-in account surfaces:

- `components/auth/AuthButton.tsx` — the avatar dropdown on the projects page
- `components/layout/ProjectSwitcher.tsx` — the sidebar switcher’s account section

Both are `DropdownMenuItem asChild` wrapping a `next/link`, so they are real anchors, and both sit inside existing signed-in branches — signed-out and auth-unconfigured deployments are unchanged.

## Lab Note

```yaml
en:
  title: "Your agent tokens now have a front door"
  summary: "Agent tokens live with your account, and you can finally get to them from the account menu — no more hunting for the URL."
fr:
  title: "Tes tokens agents ont enfin une porte d’entrée"
  summary: "Les tokens agents appartiennent à ton compte, et tu peux maintenant les retrouver directement depuis le menu du compte — fini la chasse à l’URL."
suggested:
  molecule: arkaik
  type: improvement
  tags: [changelog]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)