### PR TITLE
Move project settings to dedicated page

### DIFF
--- a/app/project/[id]/layout.tsx
+++ b/app/project/[id]/layout.tsx
@@ -29,7 +29,9 @@ export default function ProjectLayout({
             ? "acceptances"
             : pathname.startsWith(`/project/${id}/pyramid`)
               ? "pyramid"
-              : "maps";
+              : pathname.startsWith(`/project/${id}/settings`)
+                ? "settings"
+                : "maps";
   const currentSpecies = currentView === "library" ? searchParams.get("species") : null;
   const currentQueryString = currentView === "library" ? searchParams.toString() : "";
 

--- a/app/project/[id]/settings/page.tsx
+++ b/app/project/[id]/settings/page.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+import { DeleteConfirmDialog } from "@/components/graph/DeleteConfirmDialog";
+import { RepoLinksPanel } from "@/components/settings/RepoLinksPanel";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+import { isHostedProjectId } from "@/lib/data/remote-provider";
+import { useProject } from "@/lib/hooks/useProject";
+import { archiveProject } from "@/lib/utils/export";
+
+/**
+ * The project's Settings page — the home for everything that configures a
+ * project rather than describes it.
+ *
+ * It exists because the projects listing was carrying this work: every card had
+ * a Repos button and a Delete button next to Open, which made a listing a
+ * control panel and put a destructive action one mis-click from the common one.
+ * Both moved here, and the card became the link it always should have been.
+ *
+ * Deletion sits in a Danger zone at the bottom, behind a confirmation, exactly
+ * because it is the one action here you cannot undo from the UI.
+ */
+export default function ProjectSettingsPage() {
+  const params = useParams();
+  const router = useRouter();
+  const id = Array.isArray(params.id) ? params.id[0] : params.id ?? "";
+
+  const { project, loading } = useProject(id);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  const title = project?.project.title ?? "Untitled project";
+  /**
+   * Repository links are a hosted-only feature: they live in the account
+   * database and the webhook resolves against them, so a browser-held project
+   * has nowhere to put one. Routing on the id prefix rather than on a fetched
+   * flag keeps the answer available on the first render (lib/data/routing-provider.ts).
+   */
+  const hosted = isHostedProjectId(id);
+
+  async function handleDelete() {
+    if (deleting) return;
+    setDeleting(true);
+    try {
+      await archiveProject(id);
+      setDeleteOpen(false);
+      toast.success(`"${title}" was deleted.`);
+      // Back to the listing: staying would leave every other page in this
+      // layout reading a project that is no longer there.
+      router.push("/projects");
+    } catch (err) {
+      console.error("[ProjectSettingsPage] Failed to archive project:", err);
+      toast.error(err instanceof Error ? err.message : "Could not delete this project.");
+      setDeleting(false);
+    }
+  }
+
+  return (
+    <div className="flex h-full w-full flex-col">
+      <header className="flex h-12 shrink-0 items-center gap-3 border-b bg-background/95 px-3 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+        <SidebarTrigger className="-ml-1 cursor-pointer" />
+        <Separator orientation="vertical" className="mx-1 h-4" />
+        <div className="min-w-0">
+          <p className="truncate text-sm font-medium">{title}</p>
+          <p className="truncate text-xs text-muted-foreground">Settings</p>
+        </div>
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-auto p-4 md:p-6">
+        <div className="mx-auto flex w-full max-w-3xl flex-col gap-10">
+          <section className="flex flex-col gap-3">
+            <div className="flex flex-col gap-1">
+              <h2 className="text-lg font-semibold">Linked repositories</h2>
+              <p className="text-sm text-muted-foreground">
+                Pull requests in these repositories can move {title}&rsquo;s acceptances. Naming the
+                platform a repository — or one folder of it — builds for means a merge there marks
+                only that platform shipped.
+              </p>
+            </div>
+            {hosted ? (
+              <RepoLinksPanel projectId={id} />
+            ) : (
+              <p className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
+                This project lives in this browser, so there is no account for a repository link to
+                hang off. Move it to your account from the projects page and the links appear here.
+              </p>
+            )}
+          </section>
+
+          <section className="flex flex-col gap-3">
+            <div className="flex flex-col gap-1">
+              <h2 className="text-lg font-semibold text-destructive">Danger zone</h2>
+              <p className="text-sm text-muted-foreground">
+                Actions here change the project itself, not what you are looking at.
+              </p>
+            </div>
+            <div className="flex flex-col gap-3 rounded-lg border border-destructive/40 p-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="min-w-0">
+                <p className="text-sm font-medium">Delete this project</p>
+                <p className="text-sm text-muted-foreground">
+                  {title} disappears from your projects, along with its nodes, edges and history.
+                </p>
+              </div>
+              <Button
+                variant="destructive"
+                className="shrink-0 cursor-pointer"
+                disabled={loading || deleting}
+                onClick={() => setDeleteOpen(true)}
+              >
+                {deleting ? "Deleting…" : "Delete project"}
+              </Button>
+            </div>
+          </section>
+        </div>
+      </div>
+
+      <DeleteConfirmDialog
+        open={deleteOpen}
+        onOpenChange={(open) => {
+          if (!open && !deleting) setDeleteOpen(false);
+        }}
+        title="Delete project"
+        description={`Archive "${title}" and remove it from your list?`}
+        onConfirm={() => void handleDelete()}
+      />
+    </div>
+  );
+}

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -13,13 +13,10 @@ import { AuthButton } from "@/components/auth/AuthButton";
 import { getProvider } from "@/lib/data/provider-registry";
 import type { Project, ProjectBundle } from "@/lib/data/types";
 import type { ProjectSummary } from "@/lib/data/data-provider";
-import { RepoLinksDialog } from "@/components/settings/RepoLinksDialog";
 import { exportProject as exportProjectBundle } from "@/lib/utils/export";
 import { createRemoteProvider } from "@/lib/data/remote-provider";
-import { archiveProject, importProjectFromFile, parseBundleFromFile } from "@/lib/utils/export";
-import { DeleteConfirmDialog } from "@/components/graph/DeleteConfirmDialog";
+import { importProjectFromFile, parseBundleFromFile } from "@/lib/utils/export";
 import { CreateProjectForm } from "@/components/panels/CreateProjectForm";
-import { PublishDialog } from "@/components/publik/PublishDialog";
 import { RestoreDialog } from "@/components/sync/RestoreDialog";
 import { SynkOnboardingBanner } from "@/components/sync/SynkOnboardingBanner";
 import { ProjectCard } from "@/components/projects/ProjectCard";
@@ -117,13 +114,9 @@ function ProjectsPageBody() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [createOpen, setCreateOpen] = useState(false);
-  const [deleteTarget, setDeleteTarget] = useState<ProjectSummary | null>(null);
-  const [publishTarget, setPublishTarget] = useState<ProjectSummary | null>(null);
   const [restoreOpen, setRestoreOpen] = useState(false);
   const [importing, setImporting] = useState(false);
-  const [deleting, setDeleting] = useState(false);
   const [moving, setMoving] = useState<string | null>(null);
-  const [repoTarget, setRepoTarget] = useState<ProjectSummary | null>(null);
   const searchParams = useSearchParams();
   /** Ids of projects with a Synk backup — the ONLY thing that separates Synked from Lokal. */
   const [backedUpIds, setBackedUpIds] = useState<Set<string>>(new Set());
@@ -413,22 +406,6 @@ function ProjectsPageBody() {
     await runImport(file, "lokal", "Failed to import example project");
   }
 
-  async function handleArchiveProject() {
-    if (!deleteTarget || deleting) return;
-    setDeleting(true);
-    setError(null);
-    try {
-      await archiveProject(deleteTarget.project.id);
-      setDeleteTarget(null);
-      await loadProjects();
-    } catch (err) {
-      console.error("[ProjectsPage] Failed to archive project:", err);
-      setError("Failed to archive project");
-    } finally {
-      setDeleting(false);
-    }
-  }
-
   const grouped = groupBySection(projects, backedUpIds);
 
   const openCreateDialog = (target: CreateTarget) => {
@@ -455,17 +432,17 @@ function ProjectsPageBody() {
   );
 
   // `ProjectSection` calls this via `items.map(renderCard)`, so it must set the key.
+  // The card is a link to the project now; publishing, repository links and
+  // deletion all live inside it (the sidebar footer and the Settings page), so
+  // the listing has nothing left to wire but the one thing you cannot do from
+  // inside a local project — moving it into the account.
   const renderCard = (summary: ProjectSummary) => (
     <ProjectCard
       key={summary.project.id}
       summary={summary}
       canHost={canHost}
       moving={moving === summary.project.id}
-      onOpen={() => router.push(`/project/${summary.project.id}`)}
-      onPublish={() => setPublishTarget(summary)}
-      onRepos={() => setRepoTarget(summary)}
       onMoveToAccount={() => void moveToAccount(summary)}
-      onDelete={() => setDeleteTarget(summary)}
     />
   );
 
@@ -607,33 +584,6 @@ function ProjectsPageBody() {
       </main>
 
       <CreateProjectForm open={createOpen} onOpenChange={setCreateOpen} onSubmit={createProject} />
-
-      <DeleteConfirmDialog
-        open={Boolean(deleteTarget)}
-        onOpenChange={(open) => {
-          if (!open) setDeleteTarget(null);
-        }}
-        title="Delete project"
-        description={`Archive \"${deleteTarget?.project.title ?? "this project"}\" and remove it from your list?`}
-        onConfirm={handleArchiveProject}
-      />
-
-      <RepoLinksDialog
-        projectId={repoTarget?.project.id ?? ""}
-        projectTitle={repoTarget?.project.title ?? "this project"}
-        open={Boolean(repoTarget)}
-        onOpenChange={(next) => {
-          if (!next) setRepoTarget(null);
-        }}
-      />
-      <PublishDialog
-        open={Boolean(publishTarget)}
-        onOpenChange={(open) => {
-          if (!open) setPublishTarget(null);
-        }}
-        projectId={publishTarget?.project.id ?? ""}
-        projectTitle={publishTarget?.project.title ?? "this project"}
-      />
 
       <RestoreDialog open={restoreOpen} onOpenChange={setRestoreOpen} />
     </>

--- a/components/layout/ProjectSidebar.tsx
+++ b/components/layout/ProjectSidebar.tsx
@@ -21,7 +21,7 @@ import {
   Settings2Icon,
   Share2Icon,
 } from "lucide-react";
-import { ProjectSwitcher } from "@/components/layout/ProjectSwitcher";
+import { ProjectSwitcher, type ProjectView } from "@/components/layout/ProjectSwitcher";
 import { PublishDialog } from "@/components/publik/PublishDialog";
 import {
   Sidebar,
@@ -40,7 +40,7 @@ import {
 interface ProjectSidebarProps {
   projectId: string;
   currentProjectTitle?: string;
-  currentView: "overview" | "maps" | "library" | "delivery" | "changelog" | "acceptances" | "pyramid";
+  currentView: ProjectView;
   currentSpecies: string | null;
   /** Active map id when currentView is "maps" and a specific map is open. */
   currentMapId: string | null;
@@ -73,6 +73,7 @@ export function ProjectSidebar({
   const deliveryHref = `/project/${projectId}/delivery`;
   const changelogHref = `/project/${projectId}/changelog`;
   const pyramidHref = `/project/${projectId}/pyramid`;
+  const settingsHref = `/project/${projectId}/settings`;
   const [publishOpen, setPublishOpen] = useState(false);
 
   return (
@@ -237,9 +238,11 @@ export function ProjectSidebar({
             </SidebarMenuButton>
           </SidebarMenuItem>
           <SidebarMenuItem>
-            <SidebarMenuButton disabled tooltip="Settings coming soon">
-              <Settings2Icon />
-              <span>Settings</span>
+            <SidebarMenuButton asChild isActive={currentView === "settings"} tooltip="Settings">
+              <Link href={settingsHref}>
+                <Settings2Icon />
+                <span>Settings</span>
+              </Link>
             </SidebarMenuButton>
           </SidebarMenuItem>
           <SidebarMenuItem>

--- a/components/layout/ProjectSwitcher.tsx
+++ b/components/layout/ProjectSwitcher.tsx
@@ -22,10 +22,26 @@ import {
 import { useAuthStatus } from "@/lib/hooks/useAuthStatus";
 import { useProjects } from "@/lib/hooks/useProjects";
 
+/**
+ * The project-scoped pages, which are also the path segment each one lives at —
+ * `buildProjectHref` below appends the value verbatim, so switching project
+ * lands on the same page in the new one. Declared once and shared with
+ * `ProjectSidebar`: two copies drifted apart the moment Settings was added.
+ */
+export type ProjectView =
+  | "overview"
+  | "maps"
+  | "library"
+  | "delivery"
+  | "changelog"
+  | "acceptances"
+  | "pyramid"
+  | "settings";
+
 interface ProjectSwitcherProps {
   currentProjectId: string;
   currentProjectTitle?: string;
-  currentView: "overview" | "maps" | "library" | "delivery" | "changelog" | "acceptances" | "pyramid";
+  currentView: ProjectView;
   currentQueryString?: string;
 }
 

--- a/components/projects/ProjectCard.tsx
+++ b/components/projects/ProjectCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { CloudUploadIcon, GithubIcon, Share2Icon } from "lucide-react";
+import Link from "next/link";
+import { CloudUploadIcon } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -20,77 +21,75 @@ interface ProjectCardProps {
   canHost: boolean;
   /** True while THIS project is being copied into the account. */
   moving: boolean;
-  onOpen: () => void;
-  onPublish: () => void;
-  onRepos: () => void;
   onMoveToAccount: () => void;
-  onDelete: () => void;
 }
 
 /**
- * One project card.
+ * One project card. THE CARD IS THE OPEN BUTTON.
  *
- * No "In your account" badge: the section heading above already says so, and
- * repeating it on every card was noise. "Move to account" stays, because with
- * sections it is now the ONLY way a Lokal or Synked project becomes Hosted.
+ * It used to carry a row of buttons — Open, Publish, Repos, Delete — which made
+ * the common action (open it) one target among four, and put a destructive one
+ * next to it. Each of the others now lives where it belongs once you are inside
+ * the project: Publish in the sidebar footer, repositories and deletion on the
+ * project's Settings page. What is left here is the one thing a listing is for.
+ *
+ * The title is a real `<Link>` stretched over the whole card with
+ * `after:absolute after:inset-0`, rather than an `onClick` on the div: that
+ * keeps keyboard focus, the browser status bar, and open-in-new-tab working,
+ * and announces one link per card to a screen reader instead of a clickable
+ * nothing. Anything else interactive on the card has to sit above that overlay
+ * — hence `relative z-10` on the sync control and the move button.
+ *
+ * "Move to account" stays, because with sections it is the ONLY way a Lokal or
+ * Synked project becomes Hosted. No "In your account" badge: the section
+ * heading above already says so.
  */
-export function ProjectCard({
-  summary,
-  canHost,
-  moving,
-  onOpen,
-  onPublish,
-  onRepos,
-  onMoveToAccount,
-  onDelete,
-}: ProjectCardProps) {
+export function ProjectCard({ summary, canHost, moving, onMoveToAccount }: ProjectCardProps) {
+  const showMove = !summary.hosted && canHost;
+
   return (
-    <Card>
+    <Card className="relative gap-4 transition-colors hover:border-foreground/20 hover:bg-accent/40 focus-within:border-foreground/20">
       <CardHeader>
-        <CardTitle className="truncate">{summary.project.title}</CardTitle>
+        <CardTitle className="truncate">
+          <Link
+            href={`/project/${summary.project.id}`}
+            className="outline-none after:absolute after:inset-0 after:rounded-xl focus-visible:after:ring-2 focus-visible:after:ring-ring"
+          >
+            {summary.project.title}
+          </Link>
+        </CardTitle>
         {summary.project.description && (
           <CardDescription>{summary.project.description}</CardDescription>
         )}
       </CardHeader>
-      <CardContent className="flex flex-col gap-2">
+      <CardContent>
         <p className="text-sm text-muted-foreground">
           {summary.nodeCount} node{summary.nodeCount !== 1 ? "s" : ""} ·{" "}
           {summary.edgeCount} edge{summary.edgeCount !== 1 ? "s" : ""}
         </p>
-        {/* Synk backs up browser-held projects; a hosted project is already on
-            the server and has nothing to back up. */}
-        {summary.hosted ? null : <ProjectSyncControl projectId={summary.project.id} />}
       </CardContent>
-      <CardFooter className="flex flex-wrap items-center gap-2">
-        <Button size="sm" className="cursor-pointer" onClick={onOpen}>
-          Open
-        </Button>
-        <Button size="sm" variant="outline" className="cursor-pointer" onClick={onPublish}>
-          <Share2Icon />
-          Publish
-        </Button>
-        {summary.hosted ? (
-          <Button size="sm" variant="outline" className="cursor-pointer" onClick={onRepos}>
-            <GithubIcon />
-            Repos
-          </Button>
-        ) : null}
-        {!summary.hosted && canHost ? (
-          <Button
-            size="sm"
-            variant="outline"
-            className="cursor-pointer"
-            disabled={moving}
-            onClick={onMoveToAccount}
-          >
-            <CloudUploadIcon />
-            {moving ? "Moving…" : "Move to account"}
-          </Button>
-        ) : null}
-        <Button size="sm" variant="outline" className="cursor-pointer" onClick={onDelete}>
-          Delete
-        </Button>
-      </CardFooter>
+      {/* Synk backs up browser-held projects; a hosted project is already on the
+          server and has nothing to back up — so a hosted card has no footer at
+          all, and the card is nothing but its link. `empty:hidden` covers the
+          signed-out case, where both children render nothing and the bare
+          footer would otherwise show as padding under the counts. */}
+      {summary.hosted ? null : (
+        <CardFooter className="relative z-10 flex flex-wrap items-center gap-2 empty:hidden">
+          <ProjectSyncControl projectId={summary.project.id} />
+          {showMove ? (
+            <Button
+              size="sm"
+              variant="outline"
+              className="cursor-pointer"
+              disabled={moving}
+              onClick={onMoveToAccount}
+            >
+              <CloudUploadIcon />
+              {moving ? "Moving…" : "Move to account"}
+            </Button>
+          ) : null}
+        </CardFooter>
+      )}
     </Card>
   );
 }

--- a/components/settings/RepoLinksPanel.tsx
+++ b/components/settings/RepoLinksPanel.tsx
@@ -6,13 +6,6 @@ import { toast } from "sonner";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -26,8 +19,13 @@ import { PLATFORMS } from "@/lib/config/platforms";
 /**
  * Linking a hosted project to the repositories that implement it.
  *
+ * This was a dialog opened from a button on the projects listing. It is a panel
+ * now, and it lives on the project's Settings page: repository links are
+ * configuration, and configuration belongs inside the project rather than on
+ * the card you click to get there.
+ *
  * These links are what the GitHub webhook resolves a delivery against — without
- * one, a PR in that repo finds no project and nothing happens. So this dialog is
+ * one, a PR in that repo finds no project and nothing happens. So this panel is
  * the difference between the PR-transition feature existing and being reachable.
  *
  * THE PLATFORM CHOICE IS THE POINT. Recording which platform a repository builds
@@ -100,14 +98,11 @@ interface RepoLink {
 /** The value the Select uses for "this repo builds every platform". */
 const ALL_PLATFORMS = "__all__";
 
-export interface RepoLinksDialogProps {
+export interface RepoLinksPanelProps {
   projectId: string;
-  projectTitle: string;
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
 }
 
-export function RepoLinksDialog({ projectId, projectTitle, open, onOpenChange }: RepoLinksDialogProps) {
+export function RepoLinksPanel({ projectId }: RepoLinksPanelProps) {
   const [links, setLinks] = useState<RepoLink[] | null>(null);
   const [repo, setRepo] = useState("");
   const [path, setPath] = useState("");
@@ -125,9 +120,11 @@ export function RepoLinksDialog({ projectId, projectTitle, open, onOpenChange }:
     setLinks(((await res.json()) as { repos: RepoLink[] }).repos);
   }, [projectId]);
 
+  // On the page rather than behind an `open` flag: the panel is only rendered
+  // once its section is on screen, so mounting is the moment to load.
   useEffect(() => {
-    if (open) void refresh();
-  }, [open, refresh]);
+    void refresh();
+  }, [refresh]);
 
   async function link() {
     const name = repo.trim();
@@ -180,133 +177,125 @@ export function RepoLinksDialog({ projectId, projectTitle, open, onOpenChange }:
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-lg">
-        <DialogHeader>
-          <DialogTitle>Linked repositories</DialogTitle>
-          <DialogDescription>
-            Pull requests in these repositories can move {projectTitle}&rsquo;s acceptances. Naming the
-            platform a repository — or one folder of it — builds for means a merge there marks only
-            that platform shipped.
-          </DialogDescription>
-        </DialogHeader>
-
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-col gap-2">
-            <div className="flex flex-col gap-2 sm:flex-row">
-              <Input
-                placeholder="owner/repository"
-                value={repo}
-                onChange={(e) => setRepo(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") void link();
-                }}
-                className="flex-1"
-              />
-              {/* Empty is the whole repository, so the placeholder has to say what
-                  leaving it alone means — otherwise it reads as a required field. */}
-              <Input
-                placeholder="apps/ios — blank for all of it"
-                value={path}
-                onChange={(e) => setPath(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") void link();
-                }}
-                className="font-mono sm:w-56"
-              />
-            </div>
-            <div className="flex gap-2">
-              <Select value={platform} onValueChange={setPlatform}>
-                <SelectTrigger className="flex-1">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value={ALL_PLATFORMS}>All platforms</SelectItem>
-                  {PLATFORMS.map((p) => (
-                    <SelectItem key={p.id} value={p.id}>
-                      {p.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <Button onClick={() => void link()} disabled={saving || !repo.trim()}>
-                {saving ? <Loader2Icon className="animate-spin" /> : <PlusIcon />}
-                <span>Link</span>
-              </Button>
-            </div>
-          </div>
-
-          {links === null ? (
-            <p className="text-sm text-muted-foreground">Loading…</p>
-          ) : links.length === 0 ? (
-            <p className="text-sm text-muted-foreground">
-              No repositories linked yet. Until one is, pull requests cannot move this project&rsquo;s
-              acceptances.
-            </p>
-          ) : (
-            <ul className="flex flex-col divide-y rounded-md border">
-              {/* Keyed on repository AND path: one monorepo can hold several
-                  links, and keying on the name alone would make React reuse one
-                  row for all of them. */}
-              {links.map((entry) => (
-                <li
-                  key={`${entry.repoFullName}#${entry.pathPrefix}`}
-                  className="flex items-center gap-2 px-3 py-2"
-                >
-                  <GithubIcon className="size-4 shrink-0 text-muted-foreground" />
-                  <code className="min-w-0 flex-1 truncate font-mono text-sm">
-                    {entry.repoFullName}
-                    {entry.pathPrefix ? (
-                      <span className="text-muted-foreground">/{entry.pathPrefix}</span>
-                    ) : null}
-                  </code>
-                  <Badge variant="outline" className="shrink-0 font-normal">
-                    {entry.platform
-                      ? (PLATFORMS.find((p) => p.id === entry.platform)?.label ?? entry.platform)
-                      : "All platforms"}
-                  </Badge>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => void unlink(entry.repoFullName, entry.pathPrefix)}
-                  >
-                    <Trash2Icon />
-                    <span className="sr-only">
-                      Unlink {entry.repoFullName}
-                      {entry.pathPrefix ? ` (${entry.pathPrefix})` : ""}
-                    </span>
-                  </Button>
-                </li>
-              ))}
-            </ul>
-          )}
-
-          <p className="text-xs text-muted-foreground">
-            A pull request moves an acceptance when its title or body mentions the acceptance id (for
-            example <code className="font-mono">AC-guest-checkout</code>), and the project has opted in
-            with <code className="font-mono">ref_policy</code>. Leave the path blank for a repository
-            that builds one thing. For a monorepo, link it <em>once per app</em> with the folder that
-            app lives in — <code className="font-mono">apps/ios</code> as iOS,{" "}
-            <code className="font-mono">apps/webapp</code> as Web — and the platform is read from the
-            files each pull request changed, with nothing to remember. A path matches whole folders and
-            is case-sensitive: <code className="font-mono">apps/ios</code> never matches{" "}
-            <code className="font-mono">apps/ios-legacy</code> or <code className="font-mono">Apps/iOS</code>.
-          </p>
-          <p className="text-xs text-muted-foreground">
-            A pull request can still name its own platform with{" "}
-            <code className="font-mono">AC-guest-checkout@ios</code>, which overrides both the path and
-            the choice above. A link with no path covers the whole repository and is what anything
-            outside every path falls back to; with no such link, a pull request touching none of the
-            paths moves nothing and the delivery response says why — as does one arkaik could not read
-            the changed files for, which needs this deployment&rsquo;s GitHub App private key. Under{" "}
-            <em>All platforms</em>, a pull request that names no platform moves the base status, which
-            marks the acceptance shipped on every platform that has no per-platform status of its own —
-            not on none. When a link names one platform and a pull request names an acceptance that does
-            not list it, nothing is moved at all — the delivery response says so rather than falling
-            back to marking every platform shipped.
-          </p>
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-2">
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <Input
+            placeholder="owner/repository"
+            value={repo}
+            onChange={(e) => setRepo(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void link();
+            }}
+            className="flex-1"
+          />
+          {/* Empty is the whole repository, so the placeholder has to say what
+              leaving it alone means — otherwise it reads as a required field. */}
+          <Input
+            placeholder="apps/ios — blank for all of it"
+            value={path}
+            onChange={(e) => setPath(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void link();
+            }}
+            className="font-mono sm:w-56"
+          />
         </div>
-      </DialogContent>
-    </Dialog>
+        <div className="flex gap-2">
+          <Select value={platform} onValueChange={setPlatform}>
+            <SelectTrigger className="flex-1">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ALL_PLATFORMS}>All platforms</SelectItem>
+              {PLATFORMS.map((p) => (
+                <SelectItem key={p.id} value={p.id}>
+                  {p.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button
+            className="cursor-pointer"
+            onClick={() => void link()}
+            disabled={saving || !repo.trim()}
+          >
+            {saving ? <Loader2Icon className="animate-spin" /> : <PlusIcon />}
+            <span>Link</span>
+          </Button>
+        </div>
+      </div>
+
+      {links === null ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : links.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          No repositories linked yet. Until one is, pull requests cannot move this project&rsquo;s
+          acceptances.
+        </p>
+      ) : (
+        <ul className="flex flex-col divide-y rounded-md border">
+          {/* Keyed on repository AND path: one monorepo can hold several
+              links, and keying on the name alone would make React reuse one
+              row for all of them. */}
+          {links.map((entry) => (
+            <li
+              key={`${entry.repoFullName}#${entry.pathPrefix}`}
+              className="flex items-center gap-2 px-3 py-2"
+            >
+              <GithubIcon className="size-4 shrink-0 text-muted-foreground" />
+              <code className="min-w-0 flex-1 truncate font-mono text-sm">
+                {entry.repoFullName}
+                {entry.pathPrefix ? (
+                  <span className="text-muted-foreground">/{entry.pathPrefix}</span>
+                ) : null}
+              </code>
+              <Badge variant="outline" className="shrink-0 font-normal">
+                {entry.platform
+                  ? (PLATFORMS.find((p) => p.id === entry.platform)?.label ?? entry.platform)
+                  : "All platforms"}
+              </Badge>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="cursor-pointer"
+                onClick={() => void unlink(entry.repoFullName, entry.pathPrefix)}
+              >
+                <Trash2Icon />
+                <span className="sr-only">
+                  Unlink {entry.repoFullName}
+                  {entry.pathPrefix ? ` (${entry.pathPrefix})` : ""}
+                </span>
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <p className="text-xs text-muted-foreground">
+        A pull request moves an acceptance when its title or body mentions the acceptance id (for
+        example <code className="font-mono">AC-guest-checkout</code>), and the project has opted in
+        with <code className="font-mono">ref_policy</code>. Leave the path blank for a repository
+        that builds one thing. For a monorepo, link it <em>once per app</em> with the folder that
+        app lives in — <code className="font-mono">apps/ios</code> as iOS,{" "}
+        <code className="font-mono">apps/webapp</code> as Web — and the platform is read from the
+        files each pull request changed, with nothing to remember. A path matches whole folders and
+        is case-sensitive: <code className="font-mono">apps/ios</code> never matches{" "}
+        <code className="font-mono">apps/ios-legacy</code> or <code className="font-mono">Apps/iOS</code>.
+      </p>
+      <p className="text-xs text-muted-foreground">
+        A pull request can still name its own platform with{" "}
+        <code className="font-mono">AC-guest-checkout@ios</code>, which overrides both the path and
+        the choice above. A link with no path covers the whole repository and is what anything
+        outside every path falls back to; with no such link, a pull request touching none of the
+        paths moves nothing and the delivery response says why — as does one arkaik could not read
+        the changed files for, which needs this deployment&rsquo;s GitHub App private key. Under{" "}
+        <em>All platforms</em>, a pull request that names no platform moves the base status, which
+        marks the acceptance shipped on every platform that has no per-platform status of its own —
+        not on none. When a link names one platform and a pull request names an acceptance that does
+        not list it, nothing is moved at all — the delivery response says so rather than falling
+        back to marking every platform shipped.
+      </p>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

Moved repository links and project deletion from the projects listing into a new dedicated Settings page at `/project/[id]/settings`. The projects card is now purely a link to open the project, eliminating the control-panel feel of the listing and moving destructive actions away from the common path.

**What changed:**
- Renamed `RepoLinksDialog` → `RepoLinksPanel` and removed dialog wrapper (now renders as a panel on the Settings page)
- Created new `app/project/[id]/settings/page.tsx` with repository links section and danger zone (delete project)
- Simplified `ProjectCard` to be a link-based card with only sync control and move-to-account button remaining
- Removed `PublishDialog`, `DeleteConfirmDialog`, and `RepoLinksDialog` state from projects listing
- Updated `ProjectSidebar` to include Settings navigation item and route detection
- Exported `ProjectView` type from `ProjectSwitcher` for shared use across layout components

**Why:** The projects listing was carrying too much UI responsibility — every card had Open, Publish, Repos, and Delete buttons, making the common action (open) one target among four and putting a destructive action next to it. Configuration belongs inside the project, not on the card you click to get there. Publish now lives in the sidebar footer, repositories and deletion on the Settings page.

## Lab Note

```yaml
en:
  title: "Settings page for projects"
  summary: "Repository links and project deletion moved from the listing to a dedicated Settings page inside each project. The card is now just a link."
fr:
  title: "Page de paramètres pour les projets"
  summary: "Les liens de dépôt et la suppression de projet ont quitté la liste pour une page Paramètres dédiée. La carte n'est plus qu'un lien."
suggested:
  molecule: arkaik
  type: feature
  tags: [changelog]
```

https://claude.ai/code/session_01S3n9sVvVcBT5YZYXB86WxL