### PR TITLE
fix: let a hosted project run the validator gate its skill requires

### DIFF
--- a/docs/spec/mcp.md
+++ b/docs/spec/mcp.md
@@ -53,10 +53,11 @@ Selected by `--remote`, or automatically by a `docs/arkaik/arkaik.json` written 
 
 `--bundle` always wins, so an explicit path overrides a link file.
 
-Two rules this mode MUST hold:
+Three rules this mode MUST hold:
 
 - **The client sends OPS, not a mutated graph.** The server recomputes under its own row lock, so two writers cannot lose each other's work. `Store.persist` therefore takes an *intent* for the hosted backend where the file backend takes an *outcome*.
 - **A linked repo with no token exits non-zero.** It MUST NOT fall back to a repo bundle: a silent fallback serves a stale graph that looks fine, which is the failure an agent cannot notice.
+- **`load()` returns a real `BundleValidation`, not a look-alike.** Most read tools touch only `bundle`/`nodes`/`edges`/`journal`, so a hosted `loaded` carrying just those passed unnoticed until `validate_bundle` — which also reads `result`, `valid` and `sidecarFindings` — crashed on it, putting the skill's hard validator gate out of reach for every hosted project. Hosted mode fetches the whole bundle plus its journal, so the findings come from running the same `validateBundle` over the same graph the server validated: one validator, one verdict, either side of the wire.
 
 `propose_idea` and `file_request` are refused against a hosted project — the hosted write path has no journal-only operation yet — with an explicit message rather than a silent drop.
 
@@ -121,6 +122,8 @@ A flow's playlist and its `composes` edges are two views of one relationship: th
 ## Testing
 
 `tests/mcp/run-mcp-tests.js` follows the CLI harness pattern: spawn the built server against a tmpdir fixture bundle + journal sidecar, speak JSON-RPC over stdio (`initialize`, `tools/list`, `tools/call`), and assert: read-tool shapes; a write round-trip (update → journal line appended → `validate_bundle` clean → snapshot canonical); and the gate (a mutation that would dangle an edge is refused with pathed findings and the files untouched).
+
+`tests/mcp/remote-store.test.js` runs the same built server against a stub of the hosted API. Assertions that a tool *behaves the same through both stores* belong here rather than in the file-mode suite, which by construction cannot see hosted-only drift: `validate_bundle` returning a verdict identical to repo mode — clean and broken — is checked that way.
 
 ## Non-Goals (v1)
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arkaik-mcp",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Arkaik MCP server — stdio tools over an Arkaik product-graph bundle: read projections plus validator-gated dual-write mutations.",
   "license": "MIT",
   "type": "module",

--- a/packages/mcp/src/remote-store.ts
+++ b/packages/mcp/src/remote-store.ts
@@ -21,7 +21,14 @@
  * would allow.
  */
 
-import type { EventInput, JournalEvent, Project, ValidationFinding } from "@arkaik/schema";
+import {
+  validateBundle,
+  type EventInput,
+  type JournalEvent,
+  type Project,
+  type ValidationFinding,
+  type ValidationResult,
+} from "@arkaik/schema";
 
 import type { LoadedGraph, Store, WriteResult } from "./store";
 
@@ -72,21 +79,42 @@ export function createRemoteStore(options: RemoteStoreOptions): Store {
 
       const nodes = (bundle.nodes ?? []) as unknown[];
       const edges = (bundle.edges ?? []) as unknown[];
+      const folded = { ...bundle, journal };
+
+      // `loaded` is a real BundleValidation, not a look-alike. It used to carry
+      // only the fields the read tools touch (bundle/nodes/edges/journal) behind
+      // a cast, and `validate_bundle` — the one read tool that reads `result` /
+      // `valid` / `sidecarFindings` — crashed on the missing `result` (#303).
+      // A shape the type system was told to stop checking is exactly where that
+      // kind of drift hides, so the cast is gone and every field is populated.
+      //
+      // The findings are computed HERE rather than asked of the server: hosted
+      // mode fetches the whole bundle plus its journal, so this runs the same
+      // `validateBundle` over the same graph the server validated — one
+      // validator, one verdict, whichever side of the wire the graph lives on.
+      //
+      // Lazily, though: every tool call loads, and only `validate_bundle` ever
+      // looks, so `list_nodes` must not pay for a full validator pass.
+      let validation: ValidationResult | undefined;
+      const validate = () => (validation ??= validateBundle(folded));
 
       return {
-        // `loaded` mirrors the file store's BundleValidation shape closely
-        // enough for the read tools, which only ever touch bundle/nodes/edges/
-        // journal. The server has already validated everything it stores, so
-        // there are no findings to carry here.
         loaded: {
-          bundle: { ...bundle, journal },
+          bundle: folded,
           nodes,
           edges,
           journal,
           sidecarLoaded: false,
-          errors: [] as ValidationFinding[],
-          warnings: [] as ValidationFinding[],
-        } as unknown as LoadedGraph["loaded"],
+          // Nothing was folded in from a JSONL sidecar, so there are no line
+          // findings — hosted journals arrive already parsed.
+          sidecarFindings: [],
+          get result(): ValidationResult {
+            return validate();
+          },
+          get valid(): boolean {
+            return validate().errors.length === 0;
+          },
+        },
         nodes,
         edges,
         project: bundle.project as Project,

--- a/tests/mcp/remote-store.test.js
+++ b/tests/mcp/remote-store.test.js
@@ -15,6 +15,8 @@
  *     agents cannot clobber each other;
  *   - a 422 from the server surfaces as the same refusal a local validator
  *     failure produces;
+ *   - `validate_bundle` — the one read tool that reads past bundle/nodes/edges/
+ *     journal — returns the SAME verdict from either store (#303);
  *   - configuration resolution: a link file is picked up, --bundle still wins,
  *     and hosted mode without a token fails loudly rather than silently
  *     serving a stale local file.
@@ -200,14 +202,79 @@ async function main() {
     const node = resultText(detail.responses, 4);
     check("get_node resolves against the hosted graph", node?.node?.id === "V-home", JSON.stringify(node));
 
+    // --- The validator gate is reachable in hosted mode (#303) -------------
+    // Every other read tool touches only bundle/nodes/edges/journal, so a
+    // `loaded` that merely resembled the file store's BundleValidation went
+    // unnoticed until `validate_bundle` reached for `result` and crashed. The
+    // skill makes this tool a hard gate, so a hosted project could not run the
+    // check it is told never to skip.
+    const hostedValid = await rpc(remoteEnv, [], [initialize, call(5, "validate_bundle", {})]);
+    const hostedVerdict = resultText(hostedValid.responses, 5);
+    // The crash was a -32603 protocol fault, not a tool error, so this asserts
+    // a result came back at all — an `isError` check alone would sail past it.
+    check(
+      "validate_bundle answers instead of crashing in hosted mode",
+      hostedVerdict !== undefined && !isError(hostedValid.responses, 5),
+      JSON.stringify(hostedValid.responses.find((r) => r.id === 5)),
+    );
+    check(
+      "the verdict is the full shape, sidecar findings included",
+      hostedVerdict?.valid === true &&
+        Array.isArray(hostedVerdict.errors) &&
+        Array.isArray(hostedVerdict.warnings) &&
+        Array.isArray(hostedVerdict.sidecarFindings),
+      JSON.stringify(hostedVerdict),
+    );
+
+    // One bundle, both stores, one tool: the parity the crash broke. This is
+    // the check that makes this class of drift visible at all — a file-mode-only
+    // suite cannot see it.
+    const fileValid = await rpc({}, ["--bundle", bundlePath], [initialize, call(5, "validate_bundle", {})]);
+    const fileVerdict = resultText(fileValid.responses, 5);
+    check(
+      "repo mode and hosted mode return the same verdict for the same bundle",
+      JSON.stringify(fileVerdict) === JSON.stringify(hostedVerdict),
+      `file: ${JSON.stringify(fileVerdict)} vs hosted: ${JSON.stringify(hostedVerdict)}`,
+    );
+
+    // And it must be a real verdict, not a hardcoded "clean". Serve a graph
+    // with a dangling edge and the same findings the file store would report
+    // have to come back — the client holds the whole bundle, so it runs the
+    // same validator over the same graph.
+    const healthy = state.bundle;
+    state.bundle = {
+      ...makeBundle(),
+      edges: [
+        { id: "e-V-home-V-ghost", project_id: "gp", edge_type: "composes", source_id: "V-home", target_id: "V-ghost" },
+      ],
+    };
+    const brokenRemote = await rpc(remoteEnv, [], [initialize, call(6, "validate_bundle", {})]);
+    const brokenVerdict = resultText(brokenRemote.responses, 6);
+
+    const brokenPath = path.join(tmp, "broken.json");
+    fs.writeFileSync(brokenPath, JSON.stringify(state.bundle, null, 2));
+    const brokenFile = await rpc({}, ["--bundle", brokenPath], [initialize, call(6, "validate_bundle", {})]);
+
+    state.bundle = healthy;
+    check(
+      "a broken hosted graph reports invalid with pathed findings",
+      brokenVerdict?.valid === false && brokenVerdict.errors.length > 0,
+      JSON.stringify(brokenVerdict),
+    );
+    check(
+      "and reports exactly what the file store reports",
+      JSON.stringify(resultText(brokenFile.responses, 6)) === JSON.stringify(brokenVerdict),
+      `file: ${JSON.stringify(resultText(brokenFile.responses, 6))} vs hosted: ${JSON.stringify(brokenVerdict)}`,
+    );
+
     // --- Writes send OPS, not a mutated graph ------------------------------
     state.receivedOps.length = 0;
     const write = await rpc(
       remoteEnv,
       [],
-      [initialize, call(5, "create_node", { species: "view", title: "Brand New", platforms: ["web"] })],
+      [initialize, call(7, "create_node", { species: "view", title: "Brand New", platforms: ["web"] })],
     );
-    const created = resultText(write.responses, 5);
+    const created = resultText(write.responses, 7);
     check("create_node succeeds against the hosted API", created?.node?.id === "V-brand-new", JSON.stringify(created));
     check("the write reached the mutations endpoint", state.receivedOps.length === 1, JSON.stringify(state.requests));
     check(
@@ -226,10 +293,10 @@ async function main() {
     const refused = await rpc(
       remoteEnv,
       [],
-      [initialize, call(6, "create_node", { species: "view", title: "Doomed", platforms: ["web"] })],
+      [initialize, call(8, "create_node", { species: "view", title: "Doomed", platforms: ["web"] })],
     );
-    check("a 422 from the server becomes a tool error", isError(refused.responses, 6));
-    const refusalBody = resultText(refused.responses, 6);
+    check("a 422 from the server becomes a tool error", isError(refused.responses, 8));
+    const refusalBody = resultText(refused.responses, 8);
     check(
       "the refusal carries the server's pathed findings",
       JSON.stringify(refusalBody).includes("dangling-edge"),
@@ -306,13 +373,13 @@ async function main() {
     const badToken = await rpc(
       { ARKAIK_URL: baseUrl, ARKAIK_TOKEN: "ark_deadbeef_nope", ARKAIK_PROJECT: PROJECT_ID },
       [],
-      [initialize, call(7, "list_nodes", {})],
+      [initialize, call(9, "list_nodes", {})],
     );
-    check("an invalid token produces a tool error", isError(badToken.responses, 7));
+    check("an invalid token produces a tool error", isError(badToken.responses, 9));
     check(
       "the error points at the token, not at a parse failure",
-      JSON.stringify(resultText(badToken.responses, 7)).includes("ARKAIK_TOKEN"),
-      JSON.stringify(resultText(badToken.responses, 7)),
+      JSON.stringify(resultText(badToken.responses, 9)).includes("ARKAIK_TOKEN"),
+      JSON.stringify(resultText(badToken.responses, 9)),
     );
   } finally {
     server.close();


### PR DESCRIPTION
`validate_bundle` crashed against every hosted project (#303):

    MCP error -32603: Cannot read properties of undefined (reading 'errors')

The remote store returned a `loaded` that carried only the fields the read
tools touch — bundle/nodes/edges/journal — with flat `errors`/`warnings` and
no `result`, `valid` or `sidecarFindings`, handed to the tool layer behind an
`as unknown as` cast. Thirteen of the fourteen tools never looked past those
four fields, so the gap was invisible; `validate_bundle` reads `loaded.result`
and found `undefined`.

The crash is the smaller half. The skill makes the validator a hard stop — do
not commit, hand off, or declare the task done until it exits 0 — so in hosted
mode every agent was told to run a check that could not be run. The two ways
out of that are stopping dead mid-task, or proceeding and reporting a map as
updated-but-unvalidated. A gate nobody can pass is worse than no gate.

So `loaded` is now a real `BundleValidation` rather than a look-alike, and the
cast is gone: a shape the type system was told to stop checking is exactly
where this class of drift hides. The findings come from running the same
`validateBundle` over the same graph, not from a hardcoded "clean" — hosted
mode already fetches the whole bundle plus its journal, so there is nothing to
ask the server that the client cannot answer itself. One validator, one
verdict, whichever side of the wire the graph lives on. It runs lazily, since
every tool call loads and only this one tool looks.

Tested through the tool surface in both stores, which is the only place this
was ever visible — a file-mode-only suite cannot see hosted-only drift. The
same bundle, clean and then dangling an edge, must produce byte-identical
verdicts from a file and from the hosted API. Mutation-tested by reverting the
store:

    FAIL: repo mode and hosted mode return the same verdict for the same bundle
          — file: {"valid":true,...} vs hosted: undefined

The crash was a -32603 protocol fault rather than a tool error, so the
liveness check asserts a result came back at all; an `isError` check sails
straight past it.

Bumped to 0.2.2 — 0.2.1 is published and cannot be replaced.

Fixes #303

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SzyPvs5BsozrdYXPVrPq37