### PR TITLE
Reorder sidebar: move Project section to top

### DIFF
--- a/components/layout/ProjectSidebar.tsx
+++ b/components/layout/ProjectSidebar.tsx
@@ -110,6 +110,45 @@ export function ProjectSidebar({
       </SidebarHeader>
 
       <SidebarContent>
+        {/* Project first — Overview is the landing page of a project. */}
+        <SidebarGroup>
+          <SidebarGroupLabel>Project</SidebarGroupLabel>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton asChild isActive={currentView === "overview"} tooltip="Overview">
+                <Link href={overviewHref}>
+                  <LayoutDashboardIcon />
+                  <span>Overview</span>
+                </Link>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+            <SidebarMenuItem>
+              <SidebarMenuButton asChild isActive={currentView === "pyramid"} tooltip="Value pyramid">
+                <Link href={pyramidHref}>
+                  <PyramidIcon />
+                  <span>Pyramid</span>
+                </Link>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+            <SidebarMenuItem>
+              <SidebarMenuButton asChild isActive={currentView === "delivery"} tooltip="Delivery board">
+                <Link href={deliveryHref}>
+                  <SquareKanbanIcon />
+                  <span>Delivery</span>
+                </Link>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+            <SidebarMenuItem>
+              <SidebarMenuButton asChild isActive={currentView === "changelog"} tooltip="Changelog">
+                <Link href={changelogHref}>
+                  <HistoryIcon />
+                  <span>Changelog</span>
+                </Link>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarGroup>
+
         <SidebarGroup>
           <SidebarGroupLabel>Maps</SidebarGroupLabel>
           <SidebarMenu>
@@ -203,44 +242,6 @@ export function ProjectSidebar({
                 </SidebarMenuButton>
               </SidebarMenuItem>
             ))}
-          </SidebarMenu>
-        </SidebarGroup>
-
-        <SidebarGroup>
-          <SidebarGroupLabel>Project</SidebarGroupLabel>
-          <SidebarMenu>
-            <SidebarMenuItem>
-              <SidebarMenuButton asChild isActive={currentView === "overview"} tooltip="Overview">
-                <Link href={overviewHref}>
-                  <LayoutDashboardIcon />
-                  <span>Overview</span>
-                </Link>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-            <SidebarMenuItem>
-              <SidebarMenuButton asChild isActive={currentView === "pyramid"} tooltip="Value pyramid">
-                <Link href={pyramidHref}>
-                  <PyramidIcon />
-                  <span>Pyramid</span>
-                </Link>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-            <SidebarMenuItem>
-              <SidebarMenuButton asChild isActive={currentView === "delivery"} tooltip="Delivery board">
-                <Link href={deliveryHref}>
-                  <SquareKanbanIcon />
-                  <span>Delivery</span>
-                </Link>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-            <SidebarMenuItem>
-              <SidebarMenuButton asChild isActive={currentView === "changelog"} tooltip="Changelog">
-                <Link href={changelogHref}>
-                  <HistoryIcon />
-                  <span>Changelog</span>
-                </Link>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
           </SidebarMenu>
         </SidebarGroup>
       </SidebarContent>


### PR DESCRIPTION
## Summary

Moved the "Project" sidebar group (Overview, Pyramid, Delivery, Changelog) to the top of the sidebar content, before the "Maps" section. This makes the project's primary navigation more prominent as the landing page entry point.

## Lab Note

```yaml
en:
  title: "Project navigation now appears first in the sidebar"
  summary: "The Project section with Overview, Pyramid, Delivery, and Changelog is now the first thing you see when you open a project, making it easier to navigate to the main views."
fr:
  title: "La navigation du projet apparaît maintenant en premier dans la barre latérale"
  summary: "La section Projet avec Aperçu, Pyramide, Livraison et Journal des modifications est maintenant la première chose que tu vois quand tu ouvres un projet."
suggested:
  molecule: arkaik
  type: improvement
  tags: [ui]
```

https://claude.ai/code/session_01GQtn8tST9WixLgGuZRVz5y