### PR TITLE
Redirect signed-in visitors from landing page to /projects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,9 @@ jobs:
       - name: Pyramid aggregation tests
         run: npm run test:pyramid
 
+      - name: Landing-page redirect tests (signed in → /projects)
+        run: npm run test:root-redirect
+
       - name: Journal write-primitive (emit) tests
         run: npm run test:emit
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Open [http://localhost:3000](http://localhost:3000) — create a project or load
 ```
 app/
   layout.tsx                  # Root layout: fonts, theme, global CSS
-  page.tsx                    # Home / landing page
+  page.tsx                    # Home / landing page (signed in → /projects)
   projects/page.tsx           # Project list, create, import, seed, restore
   project/[id]/canvas/        # Graph canvas (the Journey map)
   project/[id]/library/       # Filterable node browser

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,16 +1,41 @@
 import Link from "next/link";
+import { redirect } from "next/navigation";
 import { Gochi_Hand } from "next/font/google";
 import { Button } from "@/components/ui/button";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { ArkaikLogoBoil } from "@/components/branding/ArkaikLogoBoil";
 import { AsciiTerrainBackground } from "@/components/background/AsciiTerrainBackground";
+import { getSession } from "@/lib/services/auth";
 
 const gochiHand = Gochi_Hand({
   subsets: ["latin"],
   weight: "400",
 });
 
-export default function Home() {
+/**
+ * `force-dynamic` because the landing page's answer depends on the session
+ * cookie. Without it Next would prerender this page at build time, and the
+ * dynamic-usage error `getSession()` swallows (it degrades every failure to
+ * "no session") would silently bake the signed-out landing page in — the
+ * redirect would then never fire for anyone. Deciding per request is the whole
+ * point of the check, so the page has to be dynamic explicitly.
+ */
+export const dynamic = "force-dynamic";
+
+/**
+ * The landing page is for people who are not signed in yet. A signed-in visitor
+ * has already made the choice this page pitches, so send them straight to their
+ * projects instead of making them press "Start building" every time.
+ *
+ * GRACEFUL ABSENCE (docs/spec/services.md § Backend — env rules): `getSession()`
+ * returns null without touching env or Postgres when auth is unconfigured, so
+ * the local-first build renders exactly the page it always did.
+ */
+export default async function Home() {
+  const session = await getSession();
+  if (session?.user) {
+    redirect("/projects");
+  }
 
   return (
     <div className="relative flex min-h-screen flex-col overflow-hidden bg-background font-sans">

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test:coverage": "node tests/app/coverage.test.js",
     "test:effective-status": "node tests/app/effective-status.test.js",
     "test:pyramid": "node tests/app/pyramid.test.js",
+    "test:root-redirect": "node tests/app/root-redirect.test.js",
     "test:value-icons": "node tests/app/value-icons.test.js",
     "test:acceptance-matrix": "node tests/app/acceptance-matrix.test.js",
     "test:mcp": "npm run build -w arkaik && npm run build -w arkaik-mcp && node tests/mcp/run-mcp-tests.js && node tests/mcp/remote-store.test.js && node tests/mcp/version.test.js",

--- a/tests/app/root-redirect.test.js
+++ b/tests/app/root-redirect.test.js
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+
+/**
+ * Integration test for the landing page's signed-in redirect (app/page.tsx):
+ * a visitor with a session never sees the pitch, they land on /projects.
+ *
+ * Same bundler-free technique as tests/services/auth-guard.test.js — transpile
+ * the source with the TypeScript compiler and stub its imports at the module
+ * boundary — with one addition for JSX: the page is compiled with a custom
+ * factory (`__jsx`) installed as a global, so the markup collapses into inert
+ * calls and no React runtime is needed to exercise the guard above it.
+ *
+ * The `force-dynamic` assertion is not ceremony. Drop that export and Next
+ * prerenders the page at build time; `getSession()` degrades every failure
+ * (including the dynamic-usage error) to "no session", so the signed-out page
+ * would be baked in and the redirect would silently never fire for anyone.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const Module = require("module");
+const ts = require("typescript");
+
+const ROOT = path.join(__dirname, "..", "..");
+const SRC_FILE = path.join(ROOT, "app", "page.tsx");
+const BUILD_DIR = path.join(__dirname, ".test-build-root-redirect");
+
+let failures = 0;
+function check(name, cond, detail) {
+  if (cond) {
+    console.log(`PASS: ${name}`);
+  } else {
+    failures++;
+    console.log(`FAIL: ${name}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+// Controls what the stubbed getSession() returns for the current assertion.
+let currentSession = null;
+
+/** Stand-in for next/navigation's redirect(), which signals by throwing. */
+class RedirectSignal extends Error {
+  constructor(url) {
+    super(`NEXT_REDIRECT:${url}`);
+    this.url = url;
+  }
+}
+
+const STUBS = {
+  "next/navigation": {
+    redirect: (url) => {
+      throw new RedirectSignal(url);
+    },
+  },
+  "next/link": { default: () => null },
+  // next/font/google returns a loaded-font object; the page only reads .className.
+  "next/font/google": { Gochi_Hand: () => ({ className: "font-gochi" }) },
+  "@/components/ui/button": { Button: () => null },
+  "@/components/theme-toggle": { ThemeToggle: () => null },
+  "@/components/branding/ArkaikLogoBoil": { ArkaikLogoBoil: () => null },
+  "@/components/background/AsciiTerrainBackground": { AsciiTerrainBackground: () => null },
+  "@/lib/services/auth": { getSession: async () => currentSession },
+};
+
+function installStubs() {
+  const originalLoad = Module._load;
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (Object.prototype.hasOwnProperty.call(STUBS, request)) {
+      return STUBS[request];
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+  return () => {
+    Module._load = originalLoad;
+  };
+}
+
+function loadPage() {
+  fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+  fs.mkdirSync(BUILD_DIR, { recursive: true });
+  fs.writeFileSync(path.join(BUILD_DIR, "package.json"), JSON.stringify({ type: "commonjs" }));
+
+  const source = fs.readFileSync(SRC_FILE, "utf8");
+  const { outputText } = ts.transpileModule(source, {
+    fileName: "page.tsx",
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+      esModuleInterop: true,
+      jsx: ts.JsxEmit.React,
+      jsxFactory: "__jsx",
+      jsxFragmentFactory: "__jsxFragment",
+    },
+  });
+
+  const outFile = path.join(BUILD_DIR, "page.js");
+  fs.writeFileSync(outFile, outputText);
+  delete require.cache[outFile];
+  return require(outFile);
+}
+
+async function main() {
+  // The emitted markup calls these unqualified; a global keeps the element tree
+  // inert so the test exercises the guard, not the rendering.
+  globalThis.__jsx = (type, props, ...children) => ({ type, props, children });
+  globalThis.__jsxFragment = "fragment";
+
+  const restore = installStubs();
+  try {
+    const page = loadPage();
+    check("page exports a default component", typeof page.default === "function");
+    check(
+      "page opts out of static prerendering",
+      page.dynamic === "force-dynamic",
+      `dynamic = ${JSON.stringify(page.dynamic)}`,
+    );
+
+    // --- Signed in → redirected to /projects (the acceptance criterion) -----
+    currentSession = { user: { id: "user-123", name: "Ada" } };
+    let redirected = null;
+    try {
+      await page.default();
+    } catch (err) {
+      if (!(err instanceof RedirectSignal)) throw err;
+      redirected = err.url;
+    }
+    check("signed-in visitor is redirected", redirected !== null, "page rendered instead");
+    check("redirect target is /projects", redirected === "/projects", `got ${redirected}`);
+
+    // --- Signed out → the landing page still renders ------------------------
+    currentSession = null;
+    let signedOutTree = null;
+    try {
+      signedOutTree = await page.default();
+    } catch (err) {
+      if (!(err instanceof RedirectSignal)) throw err;
+      check("signed-out visitor is not redirected", false, `redirected to ${err.url}`);
+    }
+    check("signed-out visitor still gets the landing page", signedOutTree !== null);
+
+    // --- Auth unconfigured (local-first build) → identical to signed out ----
+    // getSession() answers null without touching env or Postgres; the page must
+    // not care that the difference exists.
+    currentSession = undefined;
+    let localFirstTree = null;
+    try {
+      localFirstTree = await page.default();
+    } catch (err) {
+      if (!(err instanceof RedirectSignal)) throw err;
+      check("local-first build is not redirected", false, `redirected to ${err.url}`);
+    }
+    check("local-first build still gets the landing page", localFirstTree !== null);
+  } finally {
+    restore();
+    delete globalThis.__jsx;
+    delete globalThis.__jsxFragment;
+    fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+  }
+
+  if (failures > 0) {
+    console.error(`\n${failures} check(s) failed.`);
+    process.exit(1);
+  }
+  console.log("\nAll root-redirect checks passed.");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

The landing page now checks the user's session and redirects signed-in visitors directly to `/projects`, since they've already made the choice the pitch promotes. Unsigned visitors and local-first builds (where auth is unconfigured) see the landing page as before.

The page is marked `force-dynamic` to ensure Next.js evaluates the session per request rather than prerendering it at build time — without this, the redirect would silently never fire.

## Lab Note

```yaml
en:
  title: "Skip the pitch for people already building"
  summary: "Signed-in visitors now go straight to their projects instead of seeing the landing page again."
fr:
  title: "Pas de pitch pour ceux qui construisent déjà"
  summary: "Les visiteurs connectés accèdent directement à leurs projets au lieu de revoir la page d'accueil."
suggested:
  molecule: arkaik
  type: improvement
  tags: [changelog]
```

## Changes

- **`app/page.tsx`**: Added session check with redirect to `/projects` for authenticated users; marked with `export const dynamic = "force-dynamic"` to prevent static prerendering
- **`tests/app/root-redirect.test.js`**: New integration test that verifies the redirect fires for signed-in visitors, doesn't fire for unsigned visitors, and works correctly in local-first builds (auth unconfigured)
- **`package.json`**: Added `test:root-redirect` script
- **`.github/workflows/ci.yml`**: Added test step to CI pipeline
- **`README.md`**: Updated `page.tsx` description to note the redirect behavior

## Test Plan

The new `test:root-redirect` test is now part of CI and verifies:
- Signed-in visitors are redirected to `/projects`
- Unsigned visitors see the landing page
- Local-first builds (no auth configured) render the landing page without errors
- The page opts out of static prerendering with `force-dynamic`

Run locally with `npm run test:root-redirect`.

https://claude.ai/code/session_01SQEnhjomu17xawD8MRDu6A