### PR TITLE
Add command palette to docs with searchable page catalogue

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It's not a task tracker, not a wiki, not a design tool. It's a navigable, multi-
 - **Publish & share** — Publik snapshots (`arkaik.app/p/{id}`) and full JSON import/export for backup, sharing, and self-hosting
 - **Agent-native** — an `arkaik` CLI, a Claude Code plugin/skill for coding agents that maintain the map as a side effect of development, and machine-readable schema surfaces (`/llms.txt`)
 - **Seed example** — ships with a "Pebbles" example project to explore immediately
-- **⌘K palette** — jump to any map, library, board or setting by typing it, with Tab completion
+- **⌘K palette** — jump to any map, library, board or setting by typing it, with Tab completion; the same palette searches the docs
 - **Dark mode** — light/dark theme toggle
 
 ## Quick Start

--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -1,6 +1,7 @@
+import { DocsSearch } from "@/components/docs/DocsSearch";
 import { DocsSidebar } from "@/components/layout/DocsSidebar";
 import { SidebarInset, SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
-import { getDocsNavigation } from "@/lib/utils/docs";
+import { getDocsNavigation, getDocsSearchPages } from "@/lib/utils/docs";
 
 export const runtime = "nodejs";
 
@@ -9,7 +10,11 @@ export default async function DocsLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const navigation = await getDocsNavigation();
+  // Both read the same cached index, so this costs one walk of the tree.
+  const [navigation, searchPages] = await Promise.all([
+    getDocsNavigation(),
+    getDocsSearchPages(),
+  ]);
 
   return (
     <SidebarProvider defaultOpen>
@@ -19,6 +24,7 @@ export default async function DocsLayout({
           <header className="flex h-11 items-center gap-2 border-b px-3">
             <SidebarTrigger />
             <span className="text-sm font-medium">Documentation</span>
+            <DocsSearch pages={searchPages} className="ml-auto" />
           </header>
           <div className="flex-1 overflow-auto">{children}</div>
         </div>

--- a/components/docs/DocsSearch.tsx
+++ b/components/docs/DocsSearch.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { SearchIcon } from "lucide-react";
+import { useTheme } from "next-themes";
+
+import { CommandPalette } from "@/components/layout/CommandPalette";
+import { useModKeyLabel } from "@/lib/hooks/useModKeyLabel";
+import {
+  buildDocsCommands,
+  type CommandActionId,
+  type DocsPage,
+} from "@/lib/utils/command-palette";
+import { isCommandPaletteShortcut } from "@/lib/utils/keyboard";
+import { cn } from "@/lib/utils";
+
+interface DocsSearchProps {
+  pages: readonly DocsPage[];
+  className?: string;
+}
+
+/**
+ * ⌘K for the documentation — the app's palette, pointed at the docs tree.
+ *
+ * The trigger and the shortcut live together here rather than being split
+ * across the layout and the sidebar: the docs shell has no other command state
+ * to own, so a self-contained button is the whole feature.
+ */
+export function DocsSearch({ pages, className }: DocsSearchProps) {
+  const modKey = useModKeyLabel();
+  const { theme, setTheme } = useTheme();
+  const [open, setOpen] = useState(false);
+
+  const commands = useMemo(() => buildDocsCommands({ pages }), [pages]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || !isCommandPaletteShortcut(event)) return;
+      event.preventDefault();
+      setOpen((current) => !current);
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  // Publish is a project action and has no meaning here, so the docs catalogue
+  // never offers it — the theme is the only action to dispatch.
+  const handleAction = useCallback(
+    (action: CommandActionId) => {
+      if (action !== "toggle-theme") return;
+      setTheme(theme === "dark" ? "light" : "dark");
+    },
+    [setTheme, theme],
+  );
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        // The label is hidden below sm, where the button is the icon alone.
+        aria-label="Search docs"
+        className={cn(
+          "flex h-7 cursor-pointer items-center gap-2 rounded-md border bg-muted/40 px-2 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground",
+          className,
+        )}
+      >
+        <SearchIcon className="size-3.5 shrink-0" />
+        <span className="hidden sm:inline">Search docs</span>
+        {modKey ? (
+          <kbd className="hidden items-center rounded border bg-background px-1.5 py-0.5 font-sans text-[10px] font-medium sm:inline-flex">
+            {modKey === "⌘" ? "⌘K" : "Ctrl+K"}
+          </kbd>
+        ) : null}
+      </button>
+
+      <CommandPalette
+        open={open}
+        onOpenChange={setOpen}
+        commands={commands}
+        onAction={handleAction}
+        placeholder="Jump to a page of the documentation…"
+        description="Search every page of the documentation, then press Enter to go there."
+      />
+    </>
+  );
+}

--- a/components/layout/CommandPalette.tsx
+++ b/components/layout/CommandPalette.tsx
@@ -72,6 +72,10 @@ interface CommandPaletteProps {
   commands: readonly PaletteCommand[];
   /** Runs the non-navigating commands — the palette itself only knows their id. */
   onAction: (action: CommandActionId) => void;
+  /** What the empty input suggests typing — the catalogue's own vocabulary. */
+  placeholder?: string;
+  /** Read to screen readers on open; says what this palette searches. */
+  description?: string;
 }
 
 interface PaletteSection {
@@ -112,17 +116,27 @@ function Kbd({ children }: { children: React.ReactNode }) {
  * ghost completion, and a keyboard contract that never needs the mouse —
  * Enter validates the first suggestion, Tab fills it in, arrows move.
  */
-export function CommandPalette({ open, onOpenChange, commands, onAction }: CommandPaletteProps) {
+export function CommandPalette({
+  open,
+  onOpenChange,
+  commands,
+  onAction,
+  placeholder = "Jump to a map, a library, a setting…",
+  description = "Search every page and action of this project, then press Enter to go there.",
+}: CommandPaletteProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="top-[15%] translate-y-0 gap-0 overflow-hidden p-0 shadow-2xl sm:max-w-[600px] [&>button]:hidden">
         <DialogTitle className="sr-only">Command palette</DialogTitle>
-        <DialogDescription className="sr-only">
-          Search every page and action of this project, then press Enter to go there.
-        </DialogDescription>
+        <DialogDescription className="sr-only">{description}</DialogDescription>
         {/* Radix unmounts the content on close, so the query and the selection
             reset by construction — no effect resetting state on open. */}
-        <PaletteBody commands={commands} onAction={onAction} onClose={() => onOpenChange(false)} />
+        <PaletteBody
+          commands={commands}
+          onAction={onAction}
+          onClose={() => onOpenChange(false)}
+          placeholder={placeholder}
+        />
       </DialogContent>
     </Dialog>
   );
@@ -132,9 +146,10 @@ interface PaletteBodyProps {
   commands: readonly PaletteCommand[];
   onAction: (action: CommandActionId) => void;
   onClose: () => void;
+  placeholder: string;
 }
 
-function PaletteBody({ commands, onAction, onClose }: PaletteBodyProps) {
+function PaletteBody({ commands, onAction, onClose, placeholder }: PaletteBodyProps) {
   const router = useRouter();
   const modKey = useModKeyLabel();
   const listId = useId();
@@ -278,7 +293,7 @@ function PaletteBody({ commands, onAction, onClose }: PaletteBodyProps) {
             aria-autocomplete="both"
             aria-activedescendant={active ? `${listId}-${activeIndex}` : undefined}
             className="relative w-full bg-transparent py-3.5 text-sm outline-none placeholder:text-muted-foreground"
-            placeholder="Jump to a map, a library, a setting…"
+            placeholder={placeholder}
             value={query}
             onChange={(event) => updateQuery(event.target.value)}
             onKeyDown={handleKeyDown}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -90,7 +90,7 @@ components/
     HealthCard.tsx          # Doc-health indicators with per-indicator evidence links
     MapsCard.tsx            # Every map with live subgraph counts
   layout/
-    CommandPalette.tsx      # ⌘K overlay: ranked search over every project destination
+    CommandPalette.tsx      # ⌘K overlay: ranked search over a catalogue (project or docs)
     Minimap.tsx             # React Flow minimap wrapper (unused — Canvas uses @xyflow/react MiniMap directly)
     ProjectSidebar.tsx      # Persistent in-project sidebar navigation
     ProjectSwitcher.tsx     # Sidebar header dropdown for cross-project navigation
@@ -174,7 +174,7 @@ lib/utils/docs.ts (filesystem discovery + slug-safe lookup)
   ↕
 components/docs/MarkdownContent.tsx (react-markdown + GFM + highlighting)
 
-Docs pages are rendered from markdown at request/build time using server-side file reads. The home route (`/docs`) is pinned to repository `README.md`, while nested routes resolve to markdown under `docs/`. Unknown paths redirect back to `/docs`.
+Docs pages are rendered from markdown at request/build time using server-side file reads. The home route (`/docs`) is pinned to repository `README.md`, while nested routes resolve to markdown under `docs/`. Unknown paths redirect back to `/docs`. The same index also feeds the docs ⌘K palette (`getDocsSearchPages()` → `components/docs/DocsSearch.tsx`), so the sidebar and the palette can never disagree about what exists.
 
 Prompt generation flow:
 
@@ -292,6 +292,25 @@ dispatches the non-navigating commands; `CommandPalette` renders the overlay and
 - Publish lives in the layout rather than the sidebar, so both triggers open one
   dialog.
 
+The palette is catalogue-agnostic: `buildProjectCommands` and `buildDocsCommands`
+are two lists feeding one overlay, one ranker and one shortcut. A new surface
+needs a builder, not a palette.
+
+### Docs palette (⌘K in /docs)
+
+`components/docs/DocsSearch.tsx` mounts the same overlay in the docs header —
+it owns the trigger button, the shortcut and the open state, because the docs
+shell has no other command state to share. Its catalogue comes from
+`getDocsSearchPages()` (`lib/utils/docs.ts`), the navigation tree flattened back
+into landable pages, and crosses to the client as plain data.
+
+- The page's own address is a synonym, hyphens and spaces both: "graph model"
+  finds `/docs/graph-model` even though its title says *The five species*.
+- The folder trail rides along as the row's hint ("Spec"), so same-named pages in
+  different sections stay tellable apart.
+- Publish is a project action and is simply absent from the catalogue; the theme
+  command is shared, so ⌘K switches it from either space.
+
 ## Theming
 
 - `next-themes` for light/dark mode
@@ -307,8 +326,8 @@ dispatches the non-navigating commands; `CommandPalette` renders the overlay and
 - Panel stack: [lib/utils/panel-stack.ts](../lib/utils/panel-stack.ts), [components/panels/PanelStack.tsx](../components/panels/PanelStack.tsx), [lib/hooks/useNodePanels.tsx](../lib/hooks/useNodePanels.tsx), [components/panels/NodeDetailStack.tsx](../components/panels/NodeDetailStack.tsx)
 - Library orchestration: [app/project/[id]/library/page.tsx](../app/project/[id]/library/page.tsx)
 - Sidebar components: [components/layout/ProjectSidebar.tsx](../components/layout/ProjectSidebar.tsx), [components/layout/ProjectSwitcher.tsx](../components/layout/ProjectSwitcher.tsx)
-- Command palette: [components/layout/CommandPalette.tsx](../components/layout/CommandPalette.tsx), [lib/utils/command-palette.ts](../lib/utils/command-palette.ts)
-- Docs shell + renderer: [app/docs/layout.tsx](../app/docs/layout.tsx), [app/docs/page.tsx](../app/docs/page.tsx), [app/docs/[...slug]/page.tsx](../app/docs/[...slug]/page.tsx), [components/layout/DocsSidebar.tsx](../components/layout/DocsSidebar.tsx), [components/docs/MarkdownContent.tsx](../components/docs/MarkdownContent.tsx), [lib/utils/docs.ts](../lib/utils/docs.ts)
+- Command palette: [components/layout/CommandPalette.tsx](../components/layout/CommandPalette.tsx), [lib/utils/command-palette.ts](../lib/utils/command-palette.ts), [components/docs/DocsSearch.tsx](../components/docs/DocsSearch.tsx)
+- Docs shell + renderer: [app/docs/layout.tsx](../app/docs/layout.tsx), [app/docs/page.tsx](../app/docs/page.tsx), [app/docs/[...slug]/page.tsx](../app/docs/[...slug]/page.tsx), [components/layout/DocsSidebar.tsx](../components/layout/DocsSidebar.tsx), [components/docs/MarkdownContent.tsx](../components/docs/MarkdownContent.tsx), [components/docs/DocsSearch.tsx](../components/docs/DocsSearch.tsx), [lib/utils/docs.ts](../lib/utils/docs.ts)
 - Prompt builder: [app/generate/page.tsx](../app/generate/page.tsx), [components/generate/PromptBuilderForm.tsx](../components/generate/PromptBuilderForm.tsx), [components/generate/PromptOutput.tsx](../components/generate/PromptOutput.tsx), [lib/prompts/assemble.ts](../lib/prompts/assemble.ts), [lib/prompts/blocks.ts](../lib/prompts/blocks.ts), [lib/prompts/types.ts](../lib/prompts/types.ts)
 - React Flow registry: [components/graph/Canvas.tsx](../components/graph/Canvas.tsx)
 - Data hooks: [lib/hooks/useNodes.ts](../lib/hooks/useNodes.ts), [lib/hooks/useEdges.ts](../lib/hooks/useEdges.ts), [lib/hooks/useProject.ts](../lib/hooks/useProject.ts), [lib/hooks/useProjects.ts](../lib/hooks/useProjects.ts)

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -45,7 +45,7 @@ docs/                   # This documentation
 ## Keyboard Shortcuts
 
 - Journey-map shortcuts are wired in `components/maps/JourneyMap.tsx` using `lib/hooks/useKeyboardShortcuts.ts`.
-- The ⌘K command palette is wired in `app/project/[id]/layout.tsx` (`isCommandPaletteShortcut`), so it answers from every project page.
+- The ⌘K command palette is wired in `app/project/[id]/layout.tsx` (`isCommandPaletteShortcut`), so it answers from every project page. The docs space wires the same shortcut in `components/docs/DocsSearch.tsx` — one overlay, one ranker, a catalogue each (`buildProjectCommands` / `buildDocsCommands`).
 - Shortcut key checks and focus guards live in `lib/utils/keyboard.ts`.
 - Keep shortcut handlers thin: they should call existing page handlers (`handleDeleteNodeRequest`, `handleExport`) instead of duplicating business logic.
 - Delete shortcuts must not directly mutate storage. Always route through the existing confirmation dialog flow.

--- a/lib/utils/command-palette.ts
+++ b/lib/utils/command-palette.ts
@@ -8,6 +8,10 @@
  * - **Rank**, so the first row is the one Enter should validate.
  * - **Complete**, so Tab can fill the input with the active row's own wording
  *   (its label, or the synonym the user is actually typing — "screens" → Views).
+ *
+ * One brain, several catalogues: `buildProjectCommands` covers a project's
+ * sidebar, `buildDocsCommands` covers the documentation tree. Everything below
+ * the catalogues is shared — a palette anywhere else only needs a builder.
  */
 
 /** Icon slots the overlay maps to Lucide components — a closed union so a new
@@ -34,10 +38,13 @@ export type CommandIconId =
   | "projects"
   | "tokens";
 
-export type CommandGroupId = "maps" | "library" | "project" | "actions";
+export type CommandGroupId = "pages" | "maps" | "library" | "project" | "actions";
 
-/** Group order in the palette — mirrors the sidebar, so the two read the same. */
+/** Group order in the palette — mirrors the sidebar, so the two read the same.
+ * A palette only ever renders the groups its own catalogue fills, so the docs
+ * ("Pages") and the project ("Maps"…) groups can share one list. */
 export const COMMAND_GROUPS = [
+  { id: "pages", label: "Pages" },
   { id: "maps", label: "Maps" },
   { id: "library", label: "Library" },
   { id: "project", label: "Project" },
@@ -240,6 +247,18 @@ export function completionSuffix(query: string, match: CommandMatch | undefined)
   return match.completion.slice(query.length);
 }
 
+/** Shared by every catalogue: the theme is an app-wide concern, and a palette
+ * that could switch it in one place but not another would just read as a bug. */
+const TOGGLE_THEME_COMMAND: PaletteCommand = {
+  id: "toggle-theme",
+  label: "Toggle theme",
+  group: "actions",
+  icon: "theme",
+  keywords: ["dark mode", "light mode", "appearance"],
+  hint: "Switch light and dark",
+  target: { kind: "action", action: "toggle-theme" },
+};
+
 interface ProjectCommandInput {
   projectId: string;
   /** Custom maps from `project.metadata.maps`, same list the sidebar renders. */
@@ -400,15 +419,7 @@ export function buildProjectCommands({ projectId, customMaps }: ProjectCommandIn
       hint: "Share a Publik snapshot",
       target: { kind: "action", action: "publish" },
     },
-    {
-      id: "toggle-theme",
-      label: "Toggle theme",
-      group: "actions",
-      icon: "theme",
-      keywords: ["dark mode", "light mode", "appearance"],
-      hint: "Switch light and dark",
-      target: { kind: "action", action: "toggle-theme" },
-    },
+    TOGGLE_THEME_COMMAND,
     {
       id: "projects",
       label: "All projects",
@@ -439,4 +450,66 @@ export function buildProjectCommands({ projectId, customMaps }: ProjectCommandIn
   ];
 
   return commands;
+}
+
+/** One page of the documentation, as the docs shell knows it. Plain data on
+ * purpose: it crosses the server/client boundary as a prop. */
+export interface DocsPage {
+  /** Route of the page — unique, so it doubles as the command id. */
+  href: string;
+  label: string;
+  /** Folder trail above the page ("Spec"), shown as the row's hint. */
+  section?: string;
+}
+
+/**
+ * What a page's own address offers a searcher for free. Titles and filenames
+ * drift apart ("The five species" lives at `graph-model`), and people type
+ * whichever one they remember — so the slug becomes a synonym, hyphens and all,
+ * spelled both ways.
+ */
+function slugKeywords(href: string): string[] {
+  const parts = href.replace(/^\/docs\/?/, "").split("/").filter(Boolean);
+  if (parts.length === 0) return ["docs", "documentation", "home", "readme"];
+
+  const keywords = new Set<string>([parts.join("/")]);
+  for (const part of parts) {
+    keywords.add(part);
+    if (part.includes("-")) keywords.add(part.replace(/-/g, " "));
+  }
+  return [...keywords];
+}
+
+interface DocsCommandInput {
+  /** Every navigable docs page, in the order the sidebar lists them. */
+  pages: readonly DocsPage[];
+}
+
+/**
+ * The documentation as one searchable list. Mirrors `DocsSidebar`: the same
+ * pages, the same reading order, minus the folder rows — a folder is a heading,
+ * not somewhere you can land.
+ */
+export function buildDocsCommands({ pages }: DocsCommandInput): PaletteCommand[] {
+  return [
+    ...pages.map<PaletteCommand>((page) => ({
+      id: `doc:${page.href}`,
+      label: page.label,
+      group: "pages",
+      icon: "docs",
+      keywords: slugKeywords(page.href),
+      hint: page.section,
+      target: { kind: "href", href: page.href },
+    })),
+    {
+      id: "back-to-app",
+      label: "Back to the app",
+      group: "actions",
+      icon: "projects",
+      keywords: ["arkaik", "projects", "leave the docs", "home"],
+      hint: "Your projects",
+      target: { kind: "href", href: "/projects" },
+    },
+    TOGGLE_THEME_COMMAND,
+  ];
 }

--- a/lib/utils/docs.ts
+++ b/lib/utils/docs.ts
@@ -4,6 +4,7 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import { cache } from "react";
 import matter from "gray-matter";
+import type { DocsPage } from "@/lib/utils/command-palette";
 
 const REPO_ROOT = process.cwd();
 const DOCS_DIR = path.join(REPO_ROOT, "docs");
@@ -293,3 +294,27 @@ export async function getAllDocEntries(): Promise<DocEntry[]> {
   const { entries } = await getDocsIndex();
   return entries;
 }
+
+/**
+ * The docs ⌘K palette's catalogue: the navigation tree flattened back into the
+ * pages you can actually land on, Overview included. Folder rows are dropped —
+ * the sidebar shows them as headings, and a heading is not a destination.
+ *
+ * Returns plain data, because the docs shell hands it to a client component.
+ */
+export const getDocsSearchPages = cache(async (): Promise<DocsPage[]> => {
+  const { entries } = await getDocsIndex();
+
+  return [
+    // Mirrors getDocsNavigation()'s first row, so both call the README the same.
+    { href: "/docs", label: "Overview" },
+    ...entries.map((entry) => {
+      const section = entry.slugParts.slice(0, -1).map(titleCase).join(" / ");
+      return {
+        href: entry.href,
+        label: entry.navTitle,
+        ...(section ? { section } : {}),
+      };
+    }),
+  ];
+});

--- a/tests/app/command-palette.test.js
+++ b/tests/app/command-palette.test.js
@@ -11,7 +11,7 @@
 const fs = require("fs");
 const { loadCommandPalette, BUILD_DIR } = require("./load-command-palette");
 
-const { buildProjectCommands, rankCommands, completionSuffix, COMMAND_GROUPS } =
+const { buildProjectCommands, buildDocsCommands, rankCommands, completionSuffix, COMMAND_GROUPS } =
   loadCommandPalette();
 
 let failures = 0;
@@ -149,6 +149,113 @@ assert(
   "stray whitespace suppresses the ghost rather than drawing a misaligned one",
 );
 assert(completionSuffix("acc", undefined) === "", "no active row, no ghost");
+
+// --- docs catalogue: the same brain, pointed at the documentation tree ---
+const docsPages = [
+  { href: "/docs", label: "Overview" },
+  { href: "/docs/vision", label: "Vision" },
+  { href: "/docs/conventions", label: "Conventions" },
+  // Title and filename drift apart on purpose here — that is the case the slug
+  // keywords exist for.
+  { href: "/docs/graph-model", label: "The five species" },
+  { href: "/docs/spec/bundle-format", label: "Bundle Format", section: "Spec" },
+  { href: "/docs/spec/journal", label: "Journal", section: "Spec" },
+];
+const docsCommands = buildDocsCommands({ pages: docsPages });
+
+function docsTopLabel(query) {
+  return rankCommands(docsCommands, query)[0]?.command.label;
+}
+
+function docsCommandById(id) {
+  return docsCommands.find((command) => command.id === id);
+}
+
+const docsHrefs = new Set(
+  docsCommands
+    .filter((command) => command.target.kind === "href")
+    .map((command) => command.target.href),
+);
+for (const page of docsPages) {
+  assert(docsHrefs.has(page.href), `docs catalogue reaches ${page.href}`);
+}
+assert(
+  new Set(docsCommands.map((command) => command.id)).size === docsCommands.length,
+  "docs command ids are unique (the href makes them so)",
+);
+assert(
+  docsCommands.every((command) => groupIds.has(command.group)),
+  "every docs command belongs to a declared group",
+);
+assert(
+  docsCommands
+    .filter((command) => command.group === "pages")
+    .every((command) => command.target.kind === "href" && !command.target.external),
+  "docs pages navigate in place — the docs shell is where you already are",
+);
+assert(
+  docsCommands
+    .filter((command) => command.group === "pages")
+    .every((command, index) => command.label === docsPages[index].label),
+  "docs pages keep the sidebar's reading order",
+);
+
+// Ranking: typing the page finds the page.
+assert(docsTopLabel("vision") === "Vision", `"vision" → Vision (got ${docsTopLabel("vision")})`);
+assert(
+  docsTopLabel("bundle") === "Bundle Format",
+  `"bundle" → Bundle Format (got ${docsTopLabel("bundle")})`,
+);
+assert(
+  docsTopLabel("conv") === "Conventions",
+  `"conv" → Conventions (got ${docsTopLabel("conv")})`,
+);
+
+// The address is a synonym: a page whose title says nothing about its filename
+// is still reachable by the filename, hyphens or spaces.
+assert(
+  docsTopLabel("graph-model") === "The five species",
+  `"graph-model" → The five species (got ${docsTopLabel("graph-model")})`,
+);
+assert(
+  docsTopLabel("graph model") === "The five species",
+  `"graph model" → The five species (got ${docsTopLabel("graph model")})`,
+);
+assert(
+  docsTopLabel("spec/journal") === "Journal",
+  `a full slug path finds its page (got ${docsTopLabel("spec/journal")})`,
+);
+assert(
+  completionSuffix("graph-mo", rankCommands(docsCommands, "graph-mo")[0]) === "del",
+  "Tab completes the slug being typed, not the unrelated title",
+);
+
+// The folder trail rides along as the row's hint, so two same-named pages in
+// different sections stay tellable apart.
+assert(
+  docsCommandById("doc:/docs/spec/journal").hint === "Spec",
+  "a nested page shows its section as the hint",
+);
+assert(
+  docsCommandById("doc:/docs/vision").hint === undefined,
+  "a top-level page has no section to show",
+);
+
+// Actions: the theme is shared with the project palette, Publish is not offered.
+assert(
+  docsTopLabel("dark mode") === "Toggle theme",
+  `"dark mode" → Toggle theme in the docs too (got ${docsTopLabel("dark mode")})`,
+);
+assert(
+  docsCommands.every(
+    (command) => !(command.target.kind === "action" && command.target.action === "publish"),
+  ),
+  "the docs palette never offers Publish — there is no project to publish",
+);
+assert(
+  docsCommandById("back-to-app").target.href === "/projects",
+  "the docs palette leads back to the app",
+);
 
 fs.rmSync(BUILD_DIR, { recursive: true, force: true });
 


### PR DESCRIPTION
## Summary

Adds a searchable command palette (⌘K) to the documentation, mirroring the project palette's architecture. The docs palette searches a flattened catalogue of all documentation pages, with slug-based synonyms so pages are findable by filename even when titles differ. Shared ranking, completion, and theme-toggle logic means the palette works identically across both surfaces.

## Changes

**New catalogue builder:** `buildDocsCommands()` in `lib/utils/command-palette.ts` generates a palette command for each docs page, with:
- Page title as the label
- Slug keywords (hyphens and spaces both) so `/docs/graph-model` ("The five species") is findable by typing "graph-model" or "graph model"
- Section hint (e.g., "Spec") to disambiguate same-named pages in different folders
- Navigation target pointing back to `/projects` for the "Back to the app" action

**Docs search UI:** New `DocsSearch` component in `components/docs/DocsSearch.tsx` owns the trigger button, ⌘K shortcut, and palette state for the docs header. It dispatches only the theme-toggle action (publish is project-only).

**Shared infrastructure:** Extracted `TOGGLE_THEME_COMMAND` as a constant so both catalogues include it without duplication. Updated `CommandPalette` to accept optional `placeholder` and `description` props so each surface can customize the UI text.

**Data flow:** `getDocsSearchPages()` in `lib/utils/docs.ts` flattens the navigation tree into landable pages and caches the result alongside `getDocsNavigation()`, so the sidebar and palette never disagree about what exists.

**Tests:** Added comprehensive test suite for `buildDocsCommands()` covering ranking, slug synonyms, section hints, and action filtering.

## Lab Note

```yaml
en:
  title: "Search the docs with ⌘K"
  summary: "The documentation now has a command palette just like the project view. Type to find any page by title or filename, then press Enter to jump there."
fr:
  title: "Cherche dans la doc avec ⌘K"
  summary: "La documentation a maintenant une palette de commandes comme la vue projet. Tu tapes pour trouver n'importe quelle page par titre ou nom de fichier, puis tu appuies sur Entrée pour y aller."
suggested:
  molecule: arkaik
  type: feature
  tags: [changelog]
```

https://claude.ai/code/session_011ZPM8GMZQhmtoqrYgDVqsj