### PR TITLE
Several apps, one graph — and a way to say which is which (#314)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,9 @@ jobs:
       - name: Product scope helper and store tests
         run: npm run test:product-scope
 
+      - name: Product editing rule tests
+        run: npm run test:product-editing
+
       - name: Landing-page redirect tests (signed in → /projects)
         run: npm run test:root-redirect
 

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@
 /tests/app/.test-build-graph-spotlight/
 /tests/app/.test-build-coverage/
 /tests/app/.test-build-panels-*/
+/tests/app/.test-build-product-*/
 /packages/cli/.test-build/
 
 # next.js

--- a/app/project/[id]/acceptances/page.tsx
+++ b/app/project/[id]/acceptances/page.tsx
@@ -1,21 +1,22 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useParams } from "next/navigation";
 import { PlusIcon } from "lucide-react";
 import { toast } from "sonner";
-import type { Node as DataNode } from "@/lib/data/types";
+import type { Node as DataNode, NodeMetadata } from "@/lib/data/types";
 import { useNodes } from "@/lib/hooks/useNodes";
 import { useEdges } from "@/lib/hooks/useEdges";
 import { useProjectPanels } from "@/lib/hooks/useProjectPanels";
 import { useProject } from "@/lib/hooks/useProject";
 import { useJournal } from "@/lib/hooks/useJournal";
-import { useEffectiveProduct } from "@/lib/hooks/useProductScope";
+import { useEffectiveProduct, useProductList } from "@/lib/hooks/useProductScope";
 import { useAcceptanceFilters } from "@/components/acceptances/acceptance-filters";
 import { filterAcceptances } from "@/lib/utils/acceptance-matrix";
 import { AcceptanceFilterBar } from "@/components/acceptances/AcceptanceFilterBar";
 import { AcceptanceMatrix } from "@/components/acceptances/AcceptanceMatrix";
 import { PageShell } from "@/components/layout/PageShell";
+import { NewAcceptanceForm, type NewAcceptanceFormData } from "@/components/panels/NewAcceptanceForm";
 import { generateNodeId } from "@/lib/utils/id";
 
 export default function ProjectAcceptancesPage() {
@@ -29,6 +30,7 @@ export default function ProjectAcceptancesPage() {
   const { project: projectBundle } = useProject(id);
   const { journal } = useJournal(id);
   const { filters, setFilters } = useAcceptanceFilters();
+  const [newAcceptanceOpen, setNewAcceptanceOpen] = useState(false);
 
   const acceptances = useMemo(
     () => dataNodes.filter((node) => node.species === "acceptance"),
@@ -51,6 +53,7 @@ export default function ProjectAcceptancesPage() {
   // shell owns which app they are looking at. Membership lives on nodes, so
   // this narrows correctly even before `useProject` has resolved the bundle.
   const scope = useEffectiveProduct(id, projectBundle);
+  const productList = useProductList(scope);
   const scopedFilters = useMemo(
     () => ({ ...filters, product: scope.productId }),
     [filters, scope.productId],
@@ -68,7 +71,14 @@ export default function ProjectAcceptancesPage() {
     await updateNode(nodeId, patch);
   }
 
-  async function handleCreateAcceptance(title: string) {
+  /**
+   * `metadata` carries the product the create dialog collected, and is the only
+   * thing this path gained: everything else about a new acceptance — idea
+   * status, every platform — is still decided here rather than asked for. It is
+   * threaded through rather than written as a second create path so the anchored
+   * variant below stays the *only* other way an acceptance is born.
+   */
+  async function handleCreateAcceptance(title: string, metadata: NodeMetadata = {}) {
     const created = await addNode({
       id: generateNodeId("acceptance", title, nodesById.keys()),
       project_id: id,
@@ -77,10 +87,20 @@ export default function ProjectAcceptancesPage() {
       status: "idea",
       // seed all platforms so a new acceptance renders in the parity matrix immediately (library/delivery seed []).
       platforms: ["web", "ios", "android"],
-      metadata: {},
+      metadata,
     });
     handleSelectNode(created);
     return created;
+  }
+
+  async function handleNewAcceptance({ title, metadata }: NewAcceptanceFormData) {
+    setNewAcceptanceOpen(false);
+    try {
+      await handleCreateAcceptance(title, metadata ?? {});
+    } catch (err) {
+      toast.error("Couldn't create the acceptance.");
+      console.error(err);
+    }
   }
 
   /**
@@ -128,52 +148,53 @@ export default function ProjectAcceptancesPage() {
   }
 
   return (
-    <PageShell
-      title="Acceptances"
-      meta={`${acceptances.length} total · ${filtered.length} shown`}
-      action={{
-        label: "New acceptance",
-        icon: PlusIcon,
-        // Lightweight create affordance: acceptances are primarily created at scale by
-        // the retro-population agents (via MCP), so this surface uses a simple prompt
-        // rather than the richer NewNodeForm dialog the library/delivery pages use.
-        onClick: async () => {
-          const title = window.prompt("Acceptance title (the What):");
-          if (!title || !title.trim()) return;
-          try {
-            await handleCreateAcceptance(title.trim());
-          } catch (err) {
-            toast.error("Couldn't create the acceptance.");
-            console.error(err);
-          }
-        },
-      }}
-      allNodes={dataNodes}
-      allEdges={dataEdges}
-      scope={scope}
-      journal={journal}
-      onUpdate={handleNodeUpdate}
-      onCreateAcceptanceForAnchor={handleCreateAcceptanceForAnchor}
-    >
-      <div className="h-full overflow-auto p-4 md:p-6">
-        <div className="flex w-full flex-col gap-4">
-          <AcceptanceFilterBar
-            filters={filters}
-            onChange={setFilters}
-            anchorOptions={anchorOptions}
-            projectId={id}
-            project={projectBundle}
-          />
-          <AcceptanceMatrix
-            acceptances={filtered}
-            edges={dataEdges}
-            nodesById={nodesById}
-            onSelect={handleSelectNode}
-            projectId={id}
-            project={projectBundle}
-          />
+    <>
+      <PageShell
+        title="Acceptances"
+        meta={`${acceptances.length} total · ${filtered.length} shown`}
+        action={{
+          label: "New acceptance",
+          icon: PlusIcon,
+          // A dialog rather than the `window.prompt` this used to be: a prompt
+          // returns a string and nothing else, so an acceptance created under a
+          // named scope carried no product and vanished from the scope it was
+          // created in. `NewAcceptanceForm` is the smallest surface that can ask.
+          onClick: () => setNewAcceptanceOpen(true),
+        }}
+        allNodes={dataNodes}
+        allEdges={dataEdges}
+        scope={scope}
+        journal={journal}
+        onUpdate={handleNodeUpdate}
+        onCreateAcceptanceForAnchor={handleCreateAcceptanceForAnchor}
+      >
+        <div className="h-full overflow-auto p-4 md:p-6">
+          <div className="flex w-full flex-col gap-4">
+            <AcceptanceFilterBar
+              filters={filters}
+              onChange={setFilters}
+              anchorOptions={anchorOptions}
+              projectId={id}
+              project={projectBundle}
+            />
+            <AcceptanceMatrix
+              acceptances={filtered}
+              edges={dataEdges}
+              nodesById={nodesById}
+              onSelect={handleSelectNode}
+              projectId={id}
+              project={projectBundle}
+            />
+          </div>
         </div>
-      </div>
-    </PageShell>
+      </PageShell>
+      <NewAcceptanceForm
+        open={newAcceptanceOpen}
+        onOpenChange={setNewAcceptanceOpen}
+        onSubmit={handleNewAcceptance}
+        products={productList}
+        defaultProductId={scope.productId}
+      />
+    </>
   );
 }

--- a/app/project/[id]/delivery/page.tsx
+++ b/app/project/[id]/delivery/page.tsx
@@ -68,6 +68,12 @@ export default function ProjectDeliveryPage() {
   // nothing flashes when the bundle arrives.
   const scope = useEffectiveProduct(id, projectBundle);
 
+  // The project's declared products, in declaration order, for the create
+  // form's picker. Memoized so the dialog is not handed a fresh array identity
+  // on every render; empty when the project declares none, which is what keeps
+  // the form looking exactly as it did before products existed.
+  const productList = useMemo(() => [...scope.productsById.values()], [scope.productsById]);
+
   const nodesById = useMemo(() => new Map(dataNodes.map((node) => [node.id, node])), [dataNodes]);
 
   // Built once per snapshot — `buildProductUsageIndex` is a graph traversal and
@@ -207,7 +213,13 @@ export default function ProjectDeliveryPage() {
         </div>
       </PageShell>
 
-      <NewNodeForm open={newNodeOpen} onOpenChange={setNewNodeOpen} onSubmit={handleCreateNode} />
+      <NewNodeForm
+        open={newNodeOpen}
+        onOpenChange={setNewNodeOpen}
+        onSubmit={handleCreateNode}
+        products={productList}
+        defaultProductId={scope.productId}
+      />
     </>
   );
 }

--- a/app/project/[id]/delivery/page.tsx
+++ b/app/project/[id]/delivery/page.tsx
@@ -20,7 +20,7 @@ import { useEdges } from "@/lib/hooks/useEdges";
 import { useJournal } from "@/lib/hooks/useJournal";
 import { useProjectPanels } from "@/lib/hooks/useProjectPanels";
 import { useNodes } from "@/lib/hooks/useNodes";
-import { useEffectiveProduct } from "@/lib/hooks/useProductScope";
+import { useEffectiveProduct, useProductList } from "@/lib/hooks/useProductScope";
 import { useProject } from "@/lib/hooks/useProject";
 import { computeDeliveryItems, groupItemsByStatus, type DeliveryItem } from "@/lib/utils/delivery";
 import { generateNodeId } from "@/lib/utils/id";
@@ -67,12 +67,7 @@ export default function ProjectDeliveryPage() {
   // node, i.e. today's board. So the first render is already correct and
   // nothing flashes when the bundle arrives.
   const scope = useEffectiveProduct(id, projectBundle);
-
-  // The project's declared products, in declaration order, for the create
-  // form's picker. Memoized so the dialog is not handed a fresh array identity
-  // on every render; empty when the project declares none, which is what keeps
-  // the form looking exactly as it did before products existed.
-  const productList = useMemo(() => [...scope.productsById.values()], [scope.productsById]);
+  const productList = useProductList(scope);
 
   const nodesById = useMemo(() => new Map(dataNodes.map((node) => [node.id, node])), [dataNodes]);
 

--- a/app/project/[id]/library/page.tsx
+++ b/app/project/[id]/library/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useParams, useSearchParams } from "next/navigation";
 import { PlusIcon } from "lucide-react";
 import { toast } from "sonner";
@@ -241,16 +241,33 @@ export default function ProjectLibraryPage() {
   }
 
   /**
-   * Selection is scoped to what is on screen. Ticking "all" while a species
-   * filter or a search is active must not quietly select the nodes the filter
-   * is hiding — a bulk move is exactly where an invisible selection does damage.
+   * Select-all is a UNION, and un-select-all a SUBTRACTION — never a
+   * replacement.
+   *
+   * The requirement is that ticking "all" while a species filter or a search is
+   * active must not quietly select the nodes the filter is *hiding*; a bulk move
+   * is exactly where an invisible selection does damage. Adding only the visible
+   * ids satisfies that outright.
+   *
+   * *Rejected:* replacing the set with the visible ids, which satisfies the same
+   * requirement and then silently destroys an off-screen selection — tick a
+   * node, search for something else, tick "all", and the first node is gone with
+   * no feedback but a changed count. Selection deliberately survives a filter
+   * change (that is what makes the bar's count equal what the move will touch),
+   * so a control labelled "all visible nodes" must not be the one thing that
+   * reaches outside the visible list to delete.
    */
   function toggleAllVisible() {
-    setSelectedIds((previous) =>
-      visibleNodes.length > 0 && visibleNodes.every((node) => previous.has(node.id))
-        ? new Set()
-        : new Set(visibleNodes.map((node) => node.id)),
-    );
+    setSelectedIds((previous) => {
+      const next = new Set(previous);
+      const allVisibleSelected =
+        visibleNodes.length > 0 && visibleNodes.every((node) => previous.has(node.id));
+      for (const node of visibleNodes) {
+        if (allVisibleSelected) next.delete(node.id);
+        else next.add(node.id);
+      }
+      return next;
+    });
   }
 
   // Ids survive a filter change (an id hidden by a search is still selected),
@@ -261,6 +278,30 @@ export default function ProjectLibraryPage() {
     () => dataNodes.filter((node) => selectedIds.has(node.id)),
     [dataNodes, selectedIds],
   );
+
+  // What the bar has to explain: "7 selected" over three ticked rows is an
+  // unexplained number, and the only way out of it would be all-or-nothing
+  // Clear. Counted here because the page is what owns the notion of "visible".
+  const hiddenSelectedCount = useMemo(() => {
+    const visibleIds = new Set(visibleNodes.map((node) => node.id));
+    return selectedNodes.filter((node) => !visibleIds.has(node.id)).length;
+  }, [selectedNodes, visibleNodes]);
+
+  /**
+   * A scope change is a change of subject, and the selection does not survive
+   * it.
+   *
+   * Under All products a user can tick an Admin flow and an end-user view; on
+   * switching to End-user app the Admin flow is neither shown nor mentioned by
+   * any filter the user set, yet it would still be in the set and still be moved.
+   * Worse, switching to a project state with no products at all flips
+   * `selectionEnabled` false, which removes every checkbox and the bar — leaving
+   * held ids with no surface able to show or clear them. Both cases are the same
+   * bug, so both are cleared by the same effect keyed on the scope id.
+   */
+  useEffect(() => {
+    setSelectedIds((previous) => (previous.size === 0 ? previous : new Set()));
+  }, [scope.productId, selectionEnabled]);
 
   /**
    * ONE write, never a loop of single updates: `planProductMove` decides which
@@ -398,18 +439,23 @@ export default function ProjectLibraryPage() {
                 onSearchChange={setSearch}
                 onDisplayModeChange={setDisplayMode}
               />
+              {/* Inside the sticky band, not in the scrolling column: the bar
+                  acts on rows the user ticked a screenful down, and a control
+                  that scrolls away from its own selection is unreachable exactly
+                  when it is needed. */}
+              {selectionEnabled && (
+                <LibrarySelectionBar
+                  selected={selectedNodes}
+                  hiddenCount={hiddenSelectedCount}
+                  products={productList}
+                  onClear={() => setSelectedIds(new Set())}
+                  onMove={(productId) => void handleMoveToProduct(productId)}
+                  busy={moving}
+                />
+              )}
             </StickyToolbar>
 
             <div className="flex flex-col gap-4 px-4 pb-4 md:px-6 md:pb-6">
-            {selectionEnabled && (
-              <LibrarySelectionBar
-                selected={selectedNodes}
-                products={productList}
-                onClear={() => setSelectedIds(new Set())}
-                onMove={(productId) => void handleMoveToProduct(productId)}
-                busy={moving}
-              />
-            )}
             {visibleNodes.length === 0 ? (
               <div className="rounded-xl border border-dashed p-10 text-center">
                 {/* An empty list under a named scope is not an empty project.

--- a/app/project/[id]/library/page.tsx
+++ b/app/project/[id]/library/page.tsx
@@ -166,6 +166,12 @@ export default function ProjectLibraryPage() {
   // never heard of products gets exactly today's library.
   const scope = useEffectiveProduct(id, projectBundle);
 
+  // The project's declared products, in declaration order, for the create
+  // form's picker. Memoized so the dialog is not handed a fresh array identity
+  // on every render; empty when the project declares none, which is what keeps
+  // the form looking exactly as it did before products existed.
+  const productList = useMemo(() => [...scope.productsById.values()], [scope.productsById]);
+
   const nodesById = useMemo(
     () => new Map(dataNodes.map((node) => [node.id, node])),
     [dataNodes],
@@ -370,6 +376,8 @@ export default function ProjectLibraryPage() {
         onOpenChange={setNewNodeOpen}
         onSubmit={handleCreateNode}
         defaultValues={speciesFilter !== "all" ? { species: speciesFilter } : undefined}
+        products={productList}
+        defaultProductId={scope.productId}
       />
     </>
   );

--- a/app/project/[id]/library/page.tsx
+++ b/app/project/[id]/library/page.tsx
@@ -302,11 +302,23 @@ export default function ProjectLibraryPage() {
    * Worse, switching to a project state with no products at all flips
    * `selectionEnabled` false, which removes every checkbox and the bar — leaving
    * held ids with no surface able to show or clear them. Both cases are the same
-   * bug, so both are cleared by the same effect keyed on the scope id.
+   * bug, so both are cleared by the same subject key.
+   *
+   * Adjusted **during render** rather than in an effect, which is what React
+   * documents for "reset state when a prop changes" and what
+   * `react-hooks/set-state-in-effect` exists to push callers towards: an effect
+   * would let one commit paint with the old selection still live under the new
+   * scope, and would cost a second render every time. Setting state while
+   * rendering *this* component restarts the render before anything is shown.
    */
-  useEffect(() => {
-    setSelectedIds((previous) => (previous.size === 0 ? previous : new Set()));
-  }, [scope.productId, selectionEnabled]);
+  const [selectionSubject, setSelectionSubject] = useState(
+    () => `${scope.productId ?? ""}:${selectionEnabled}`,
+  );
+  const currentSubject = `${scope.productId ?? ""}:${selectionEnabled}`;
+  if (selectionSubject !== currentSubject) {
+    setSelectionSubject(currentSubject);
+    if (selectedIds.size > 0) setSelectedIds(new Set());
+  }
 
   /**
    * ONE write, never a loop of single updates: `planProductMove` decides which

--- a/app/project/[id]/library/page.tsx
+++ b/app/project/[id]/library/page.tsx
@@ -24,7 +24,12 @@ import { useProject } from "@/lib/hooks/useProject";
 import { useJournal } from "@/lib/hooks/useJournal";
 import { findWhereUsed } from "@/lib/utils/where-used";
 import { generateNodeId } from "@/lib/utils/id";
-import { nodeInScope, productLabelsOfNode, type ProductGraph } from "@/lib/utils/product-scope";
+import {
+  nodeInScope,
+  productDisplayTitle,
+  productLabelsOfNode,
+  type ProductGraph,
+} from "@/lib/utils/product-scope";
 import { matchesSearch } from "@/lib/utils/search";
 import { applyProductPlan } from "@/lib/utils/apply-product-plan";
 import { planProductMove } from "@/lib/utils/product-editing";
@@ -343,12 +348,9 @@ export default function ProjectLibraryPage() {
   }
 
   const emptyLabel = SPECIES_EMPTY_LABELS[speciesFilter];
-  // `title` is not validated by `resolveProducts`, so fall back to the id the
-  // way `ProductScopeSelector` does rather than naming a blank product.
-  const scopeLabel =
-    typeof scope.product?.title === "string" && scope.product.title.trim() !== ""
-      ? scope.product.title
-      : scope.productId;
+  // `title` is not validated by `resolveProducts`, so fall back to the id
+  // rather than naming a blank product — the one rule, from its one home.
+  const scopeLabel = scope.product ? productDisplayTitle(scope.product) : scope.productId;
 
   const flowRollupByNodeId = useMemo(
     () => Object.fromEntries(

--- a/app/project/[id]/library/page.tsx
+++ b/app/project/[id]/library/page.tsx
@@ -17,7 +17,7 @@ import type { Node as DataNode } from "@/lib/data/types";
 import { useEdges } from "@/lib/hooks/useEdges";
 import { useProjectPanels } from "@/lib/hooks/useProjectPanels";
 import { useNodes } from "@/lib/hooks/useNodes";
-import { useEffectiveProduct } from "@/lib/hooks/useProductScope";
+import { useEffectiveProduct, useProductList } from "@/lib/hooks/useProductScope";
 import { useProject } from "@/lib/hooks/useProject";
 import { useJournal } from "@/lib/hooks/useJournal";
 import { findWhereUsed } from "@/lib/utils/where-used";
@@ -165,12 +165,7 @@ export default function ProjectLibraryPage() {
   // declared it resolves to every platform and every node, so a project that has
   // never heard of products gets exactly today's library.
   const scope = useEffectiveProduct(id, projectBundle);
-
-  // The project's declared products, in declaration order, for the create
-  // form's picker. Memoized so the dialog is not handed a fresh array identity
-  // on every render; empty when the project declares none, which is what keeps
-  // the form looking exactly as it did before products existed.
-  const productList = useMemo(() => [...scope.productsById.values()], [scope.productsById]);
+  const productList = useProductList(scope);
 
   const nodesById = useMemo(
     () => new Map(dataNodes.map((node) => [node.id, node])),

--- a/app/project/[id]/library/page.tsx
+++ b/app/project/[id]/library/page.tsx
@@ -3,9 +3,11 @@
 import { useMemo, useState } from "react";
 import { useParams, useSearchParams } from "next/navigation";
 import { PlusIcon } from "lucide-react";
+import { toast } from "sonner";
 import { LibraryFilterBar, type LibraryDisplayMode, type LibrarySpeciesFilter } from "@/components/library/LibraryFilterBar";
 import { NodeCard } from "@/components/library/NodeCard";
 import type { PlaylistPreviewItem } from "@/components/library/NodeCard";
+import { LibrarySelectionBar } from "@/components/library/LibrarySelectionBar";
 import { NodeTable, type NodeSortKey, type NodeSortState } from "@/components/library/NodeTable";
 import { NewNodeForm, type NewNodeFormData } from "@/components/panels/NewNodeForm";
 import { PageShell } from "@/components/layout/PageShell";
@@ -24,6 +26,8 @@ import { findWhereUsed } from "@/lib/utils/where-used";
 import { generateNodeId } from "@/lib/utils/id";
 import { nodeInScope, productLabelsOfNode, type ProductGraph } from "@/lib/utils/product-scope";
 import { matchesSearch } from "@/lib/utils/search";
+import { applyProductPlan } from "@/lib/utils/apply-product-plan";
+import { planProductMove } from "@/lib/utils/product-editing";
 import {
   computeFlowPlatformRollup,
   createEmptyRollup,
@@ -157,9 +161,9 @@ export default function ProjectLibraryPage() {
 
   const speciesFilter = parseSpeciesFilter(searchParams.get("species"));
 
-  const { nodes: dataNodes, loading: nodesLoading, updateNode, addNode } = useNodes(id);
+  const { nodes: dataNodes, loading: nodesLoading, updateNode, addNode, applyMutations } = useNodes(id);
   const { edges: dataEdges, loading: edgesLoading } = useEdges(id);
-  const { project: projectBundle } = useProject(id);
+  const { project: projectBundle, updateProject } = useProject(id);
   const { journal } = useJournal(id);
   // The shell's scope, never a URL param (§ Decision 2). With no products
   // declared it resolves to every platform and every node, so a project that has
@@ -209,6 +213,93 @@ export default function ProjectLibraryPage() {
       visibleNodes.map((node) => [node.id, productLabelsOfNode(node, scope, productGraph)]),
     );
   }, [productGraph, scope, visibleNodes]);
+
+  /**
+   * SELECTION ONLY EXISTS WHERE IT HAS SOMETHING TO DO (§ D6, degenerate case).
+   *
+   * Moving nodes between products is the only bulk action there is, so a project
+   * declaring no products gets no checkboxes and no bar — a column of boxes
+   * whose sole outcome is a bar reading "3 selected / Clear" is a control that
+   * exists to be dismissed, and the guarantee that a product-less project looks
+   * exactly as it did before products existed outranks a selection mechanism
+   * with nothing to offer. When the second action arrives (bulk status, bulk
+   * delete), this gate is the one line that changes, and the components below
+   * already treat selection as general: they know nothing about products.
+   */
+  const selectionEnabled = productList.length > 0;
+
+  const [selectedIds, setSelectedIds] = useState<ReadonlySet<string>>(new Set());
+  const [moving, setMoving] = useState(false);
+
+  function toggleSelected(nodeId: string) {
+    setSelectedIds((previous) => {
+      const next = new Set(previous);
+      if (next.has(nodeId)) next.delete(nodeId);
+      else next.add(nodeId);
+      return next;
+    });
+  }
+
+  /**
+   * Selection is scoped to what is on screen. Ticking "all" while a species
+   * filter or a search is active must not quietly select the nodes the filter
+   * is hiding — a bulk move is exactly where an invisible selection does damage.
+   */
+  function toggleAllVisible() {
+    setSelectedIds((previous) =>
+      visibleNodes.length > 0 && visibleNodes.every((node) => previous.has(node.id))
+        ? new Set()
+        : new Set(visibleNodes.map((node) => node.id)),
+    );
+  }
+
+  // Ids survive a filter change (an id hidden by a search is still selected),
+  // so the bar resolves them against the full node list rather than the visible
+  // one — it counts species, and a count of what is merely on screen would be a
+  // different number from what the move will touch.
+  const selectedNodes = useMemo(
+    () => dataNodes.filter((node) => selectedIds.has(node.id)),
+    [dataNodes, selectedIds],
+  );
+
+  /**
+   * ONE write, never a loop of single updates: `planProductMove` decides which
+   * of the selected nodes can actually hold a membership, and `applyProductPlan`
+   * commits every patch as a single atomic mutation. A per-node loop would leave
+   * a half-moved shelf behind on the first failure.
+   *
+   * An empty plan is reported, not written — everything selected is already in
+   * the target (or derives its product), and a silent no-op reads as a bug.
+   */
+  async function handleMoveToProduct(productId: string | null) {
+    if (moving) return;
+    setMoving(true);
+    const plan = planProductMove(dataNodes, [...selectedIds], productId);
+    try {
+      if (plan.reassignments.length === 0) {
+        toast.info("Those nodes are already there.");
+      } else {
+        await applyProductPlan(plan, {
+          nodesById,
+          projectMetadata: projectBundle?.project.metadata,
+          updateProject,
+          applyMutations,
+        });
+        const moved = plan.reassignments.length;
+        toast.success(
+          productId === null
+            ? `${moved} node${moved === 1 ? "" : "s"} unassigned.`
+            : `${moved} node${moved === 1 ? "" : "s"} moved.`,
+        );
+      }
+      setSelectedIds(new Set());
+    } catch (err) {
+      console.error("[LibraryPage] Failed to move nodes:", err);
+      toast.error(err instanceof Error ? err.message : "Could not move those nodes.");
+    } finally {
+      setMoving(false);
+    }
+  }
 
   const emptyLabel = SPECIES_EMPTY_LABELS[speciesFilter];
   // `title` is not validated by `resolveProducts`, so fall back to the id the
@@ -310,6 +401,15 @@ export default function ProjectLibraryPage() {
             </StickyToolbar>
 
             <div className="flex flex-col gap-4 px-4 pb-4 md:px-6 md:pb-6">
+            {selectionEnabled && (
+              <LibrarySelectionBar
+                selected={selectedNodes}
+                products={productList}
+                onClear={() => setSelectedIds(new Set())}
+                onMove={(productId) => void handleMoveToProduct(productId)}
+                busy={moving}
+              />
+            )}
             {visibleNodes.length === 0 ? (
               <div className="rounded-xl border border-dashed p-10 text-center">
                 {/* An empty list under a named scope is not an empty project.
@@ -341,6 +441,8 @@ export default function ProjectLibraryPage() {
                       usedInCount={usedInByNodeId[node.id] ?? 0}
                       scope={scope}
                       productLabels={productLabelsByNodeId?.[node.id]}
+                      selected={selectionEnabled ? selectedIds.has(node.id) : undefined}
+                      onToggleSelected={toggleSelected}
                       onClick={() => handleSelectNode(node)}
                     />
                   </li>
@@ -356,6 +458,9 @@ export default function ProjectLibraryPage() {
                   usedInByNodeId={usedInByNodeId}
                   scope={scope}
                   productLabelsByNodeId={productLabelsByNodeId}
+                  selectedIds={selectionEnabled ? selectedIds : undefined}
+                  onToggleSelected={toggleSelected}
+                  onToggleAll={toggleAllVisible}
                   onSortChange={handleSortChange}
                   onSelectNode={handleSelectNode}
                 />

--- a/app/project/[id]/settings/page.tsx
+++ b/app/project/[id]/settings/page.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 
 import { DeleteConfirmDialog } from "@/components/graph/DeleteConfirmDialog";
 import { PageShell } from "@/components/layout/PageShell";
+import { ProductManagerPanel } from "@/components/settings/ProductManagerPanel";
 import { RepoLinksPanel } from "@/components/settings/RepoLinksPanel";
 import { Button } from "@/components/ui/button";
 import { isHostedProjectId } from "@/lib/data/remote-provider";
@@ -29,7 +30,7 @@ export default function ProjectSettingsPage() {
   const router = useRouter();
   const id = Array.isArray(params.id) ? params.id[0] : params.id ?? "";
 
-  const { project, loading } = useProject(id);
+  const { project, loading, updateProject } = useProject(id);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
 
@@ -82,6 +83,21 @@ export default function ProjectSettingsPage() {
                   here.
                 </p>
               )}
+            </section>
+
+            <section className="flex flex-col gap-3">
+              <div className="flex flex-col gap-1">
+                <h2 className="text-lg font-semibold">Products</h2>
+                <p className="text-sm text-muted-foreground">
+                  A project can describe a family of apps sharing one graph. Naming them lets every
+                  page scope to one &mdash; and lets a web-only dashboard stop dragging down your
+                  Android numbers.
+                </p>
+              </div>
+              {/* The panel reads the node list itself: member counts and the
+                  reassignment a deletion offers both need it, and nothing else
+                  on this page does. */}
+              <ProductManagerPanel projectId={id} project={project} updateProject={updateProject} />
             </section>
 
             <section className="flex flex-col gap-3">

--- a/components/library/LibrarySelectionBar.tsx
+++ b/components/library/LibrarySelectionBar.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { PRODUCT_MEMBERSHIP_SPECIES, type ProductDefinition } from "@arkaik/schema";
+
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { Node } from "@/lib/data/types";
+
+/**
+ * The Library's bulk action bar. Selection is a **general** mechanism whose
+ * first action happens to be moving nodes between products (§ D6).
+ *
+ * Data models and API endpoints derive their membership from who consumes them,
+ * so a move cannot touch them — but their checkboxes are not disabled. Disabling
+ * them would tie a general selection mechanism to one action, and would answer
+ * "why can't I tick this?" with silence. Naming the subset instead is both
+ * honest and short: "Moves 3 of 5; data models and endpoints derive their
+ * product" says what will happen *and* why, in the one place the user is
+ * looking.
+ *
+ * THE DEGENERATE CASE. With no products declared this renders nothing at all,
+ * because "Move to product" is its only action and a bar reading "3 selected /
+ * Clear" is a control whose only purpose is to be dismissed. A project that has
+ * never heard of products must look exactly as it did before products existed,
+ * and that guarantee is worth more than a selection mechanism with nothing to
+ * do. The page enforces the same rule one level up by not handing the rows a
+ * checkbox at all; the guard is repeated here so the component cannot be
+ * mounted into a product-less surface by a future caller and quietly break it.
+ * *Rejected:* rendering the bar with the menu hidden — same empty affordance,
+ * one more branch, and it teaches the word "selected" to a user who has no bulk
+ * action available.
+ */
+
+/**
+ * Radix's `Select` reserves `""` for "nothing chosen", so "Unassigned" — which
+ * is a real destination, and the one that pulls a node back out of a product
+ * without editing JSON (§ D6) — needs a sentinel of its own.
+ */
+const UNASSIGNED = "__unassigned__";
+
+interface LibrarySelectionBarProps {
+  /** The selected nodes themselves, not just ids: the bar counts by species. */
+  selected: readonly Node[];
+  products: readonly ProductDefinition[];
+  onClear: () => void;
+  /** `null` means Unassigned — the key is removed, never blanked. */
+  onMove: (productId: string | null) => void;
+  busy?: boolean;
+}
+
+export function LibrarySelectionBar({
+  selected,
+  products,
+  onClear,
+  onMove,
+  busy,
+}: LibrarySelectionBarProps) {
+  if (selected.length === 0 || products.length === 0) return null;
+
+  const movable = selected.filter((node) =>
+    PRODUCT_MEMBERSHIP_SPECIES.includes(node.species),
+  ).length;
+  const derived = selected.length - movable;
+
+  return (
+    <div className="flex flex-wrap items-center gap-3 rounded-xl border bg-muted/40 px-4 py-2">
+      <span className="text-sm font-medium">{selected.length} selected</span>
+
+      <div className="flex flex-wrap items-center gap-2">
+        {/*
+          `value=""` keeps this a *command* menu rather than a field: it never
+          shows a current product, because a selection of many nodes has no
+          single one to show, and re-picking the same destination twice has to
+          stay possible.
+        */}
+        <Select
+          value=""
+          disabled={busy || movable === 0}
+          onValueChange={(next) => onMove(next === UNASSIGNED ? null : next)}
+        >
+          <SelectTrigger aria-label="Move to product" className="h-8 w-56">
+            <SelectValue placeholder="Move to product…" />
+          </SelectTrigger>
+          <SelectContent>
+            {products.map((product) => (
+              <SelectItem key={product.id} value={product.id}>
+                {/* `title` is not validated by `resolveProducts`; fall back to
+                    the id rather than rendering a nameless row. */}
+                {typeof product.title === "string" && product.title.trim() !== ""
+                  ? product.title
+                  : product.id}
+              </SelectItem>
+            ))}
+            <SelectItem value={UNASSIGNED}>Unassigned</SelectItem>
+          </SelectContent>
+        </Select>
+
+        <span className="text-xs text-muted-foreground">
+          {movable === 0
+            ? "None of these can hold a product — data models and endpoints derive theirs."
+            : derived > 0
+              ? `Moves ${movable} of ${selected.length}; data models and endpoints derive their product.`
+              : null}
+        </span>
+      </div>
+
+      <Button
+        variant="ghost"
+        className="ml-auto h-8 cursor-pointer"
+        onClick={onClear}
+        disabled={busy}
+      >
+        Clear
+      </Button>
+    </div>
+  );
+}

--- a/components/library/LibrarySelectionBar.tsx
+++ b/components/library/LibrarySelectionBar.tsx
@@ -11,6 +11,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import type { Node } from "@/lib/data/types";
+import { productDisplayTitle } from "@/lib/utils/product-scope";
 
 /**
  * The Library's bulk action bar. Selection is a **general** mechanism whose
@@ -20,9 +21,16 @@ import type { Node } from "@/lib/data/types";
  * so a move cannot touch them — but their checkboxes are not disabled. Disabling
  * them would tie a general selection mechanism to one action, and would answer
  * "why can't I tick this?" with silence. Naming the subset instead is both
- * honest and short: "Moves 3 of 5; data models and endpoints derive their
- * product" says what will happen *and* why, in the one place the user is
- * looking.
+ * honest and short.
+ *
+ * THE SUBSET IS PHRASED AS A CAPABILITY, NOT AS A PROMISE. "3 of 5 can hold a
+ * product" — never "moves 3 of 5". The bar filters on species, but
+ * `planProductMove` applies a *second* filter the bar cannot anticipate before a
+ * destination is picked: nodes already in the target are skipped. A bar
+ * promising "moves 3 of 5" followed by the toast "Those nodes are already
+ * there." contradicts itself, and the count cannot be made right before a
+ * destination exists — so the claim is what changes. Capability is true whatever
+ * is picked.
  *
  * THE DEGENERATE CASE. With no products declared this renders nothing at all,
  * because "Move to product" is its only action and a bar reading "3 selected /
@@ -35,6 +43,10 @@ import type { Node } from "@/lib/data/types";
  * *Rejected:* rendering the bar with the menu hidden — same empty affordance,
  * one more branch, and it teaches the word "selected" to a user who has no bulk
  * action available.
+ *
+ * IT IS OPAQUE AND CARD-SHAPED because it lives inside `StickyToolbar`, which
+ * contributes no background of its own — a translucent band there would let the
+ * list scroll visibly through it.
  */
 
 /**
@@ -47,6 +59,15 @@ const UNASSIGNED = "__unassigned__";
 interface LibrarySelectionBarProps {
   /** The selected nodes themselves, not just ids: the bar counts by species. */
   selected: readonly Node[];
+  /**
+   * How many of `selected` the current filter or search is hiding.
+   *
+   * Selection deliberately survives a filter change — that is what makes the
+   * count equal what a move will actually touch — but a bar saying "7 selected"
+   * over three ticked rows is an unexplained number, and the only way out of it
+   * would be the all-or-nothing Clear. Naming the gap costs a clause.
+   */
+  hiddenCount: number;
   products: readonly ProductDefinition[];
   onClear: () => void;
   /** `null` means Unassigned — the key is removed, never blanked. */
@@ -56,6 +77,7 @@ interface LibrarySelectionBarProps {
 
 export function LibrarySelectionBar({
   selected,
+  hiddenCount,
   products,
   onClear,
   onMove,
@@ -68,9 +90,27 @@ export function LibrarySelectionBar({
   ).length;
   const derived = selected.length - movable;
 
+  // Hoisted out of the JSX: an inline ternary evaluating to `null` still leaves
+  // a live <span> in the flex row, and a flex row pays for an empty child with
+  // a gap. Either there is a message or there is no element.
+  const subtext =
+    movable === 0
+      ? "None of these can hold a product — data models and endpoints derive theirs."
+      : derived > 0
+        ? `${movable} of ${selected.length} can hold a product; data models and endpoints derive theirs.`
+        : null;
+
   return (
-    <div className="flex flex-wrap items-center gap-3 rounded-xl border bg-muted/40 px-4 py-2">
-      <span className="text-sm font-medium">{selected.length} selected</span>
+    <div className="mt-2 flex flex-wrap items-center gap-3 rounded-xl border bg-card px-4 py-2">
+      <span className="text-sm font-medium">
+        {selected.length} selected
+        {hiddenCount > 0 && (
+          <span className="font-normal text-muted-foreground">
+            {" "}
+            ({hiddenCount} not shown by the current filter)
+          </span>
+        )}
+      </span>
 
       <div className="flex flex-wrap items-center gap-2">
         {/*
@@ -90,24 +130,16 @@ export function LibrarySelectionBar({
           <SelectContent>
             {products.map((product) => (
               <SelectItem key={product.id} value={product.id}>
-                {/* `title` is not validated by `resolveProducts`; fall back to
-                    the id rather than rendering a nameless row. */}
-                {typeof product.title === "string" && product.title.trim() !== ""
-                  ? product.title
-                  : product.id}
+                {/* `title` is not validated by `resolveProducts`; the shared
+                    fallback renders the id rather than a nameless row. */}
+                {productDisplayTitle(product)}
               </SelectItem>
             ))}
             <SelectItem value={UNASSIGNED}>Unassigned</SelectItem>
           </SelectContent>
         </Select>
 
-        <span className="text-xs text-muted-foreground">
-          {movable === 0
-            ? "None of these can hold a product — data models and endpoints derive theirs."
-            : derived > 0
-              ? `Moves ${movable} of ${selected.length}; data models and endpoints derive their product.`
-              : null}
-        </span>
+        {subtext !== null && <span className="text-xs text-muted-foreground">{subtext}</span>}
       </div>
 
       <Button

--- a/components/library/NodeCard.tsx
+++ b/components/library/NodeCard.tsx
@@ -45,6 +45,18 @@ interface NodeCardProps {
    * is the orphan worth flagging (§ Decision 8).
    */
   productLabels?: string[];
+  /**
+   * This card's selection state, or `undefined` when the surface has no
+   * selection at all.
+   *
+   * **`undefined` and `false` are different answers**, the same distinction
+   * `productLabels` above draws. `undefined` means no selection mechanism
+   * exists here and the card renders exactly as it did before selection did —
+   * no checkbox, no gutter, no layout shift. `false` means the surface *does*
+   * select and this card simply is not selected, which is a box to tick.
+   */
+  selected?: boolean;
+  onToggleSelected?: (nodeId: string) => void;
   onClick: () => void;
 }
 
@@ -108,6 +120,8 @@ export function NodeCard({
   usedInCount,
   scope,
   productLabels,
+  selected,
+  onToggleSelected,
   onClick,
 }: NodeCardProps) {
   const previewItems = playlistPreview.slice(0, 5);
@@ -130,7 +144,33 @@ export function NodeCard({
     >
       <Card className="h-full gap-3 py-4 transition-colors hover:bg-muted/40">
         <CardHeader className="gap-2 px-4">
-          <CardTitle className="line-clamp-2 text-base leading-tight">{node.title}</CardTitle>
+          {/*
+            The title row gains a gutter only when the surface selects. With
+            `selected === undefined` the title is rendered bare, exactly as it
+            was before selection existed — not inside a one-child flex row that
+            would be *almost* the same box. "Almost" is how a gallery of cards
+            drifts a pixel for every project that never asked for this.
+
+            `stopPropagation` on the click is what keeps ticking a box from
+            opening the node: the whole card is a click target.
+          */}
+          {selected === undefined ? (
+            <CardTitle className="line-clamp-2 text-base leading-tight">{node.title}</CardTitle>
+          ) : (
+            <div className="flex items-start gap-2">
+              <input
+                type="checkbox"
+                checked={selected}
+                aria-label={`Select ${node.title}`}
+                className="mt-0.5 size-4 shrink-0 cursor-pointer accent-primary"
+                onClick={(event) => event.stopPropagation()}
+                onChange={() => onToggleSelected?.(node.id)}
+              />
+              <CardTitle className="line-clamp-2 min-w-0 flex-1 text-base leading-tight">
+                {node.title}
+              </CardTitle>
+            </div>
+          )}
           <div className="flex flex-wrap items-center gap-2 text-xs">
             <SpeciesBadge
               species={node.species}

--- a/components/library/NodeCard.tsx
+++ b/components/library/NodeCard.tsx
@@ -151,21 +151,29 @@ export function NodeCard({
             would be *almost* the same box. "Almost" is how a gallery of cards
             drifts a pixel for every project that never asked for this.
 
-            `stopPropagation` on the click is what keeps ticking a box from
-            opening the node: the whole card is a click target.
+            The GUTTER swallows the click, not just the input. The whole card
+            opens the node, so a tap landing on the pixels above or beside a
+            4×4 box — which is most of a comfortable tap target — would navigate
+            away mid-selection. The span covers exactly the checkbox's slot and
+            no more: clicking the title still opens the node, which is what a
+            title is for.
           */}
           {selected === undefined ? (
             <CardTitle className="line-clamp-2 text-base leading-tight">{node.title}</CardTitle>
           ) : (
             <div className="flex items-start gap-2">
-              <input
-                type="checkbox"
-                checked={selected}
-                aria-label={`Select ${node.title}`}
-                className="mt-0.5 size-4 shrink-0 cursor-pointer accent-primary"
+              <span
+                className="-m-1 flex shrink-0 items-start p-1"
                 onClick={(event) => event.stopPropagation()}
-                onChange={() => onToggleSelected?.(node.id)}
-              />
+              >
+                <input
+                  type="checkbox"
+                  checked={selected}
+                  aria-label={`Select ${node.title}`}
+                  className="mt-0.5 size-4 cursor-pointer accent-primary"
+                  onChange={() => onToggleSelected?.(node.id)}
+                />
+              </span>
               <CardTitle className="line-clamp-2 min-w-0 flex-1 text-base leading-tight">
                 {node.title}
               </CardTitle>

--- a/components/library/NodeTable.tsx
+++ b/components/library/NodeTable.tsx
@@ -38,6 +38,23 @@ interface NodeTableProps {
    * node is in none of them.
    */
   productLabelsByNodeId?: Record<string, string[]>;
+  /**
+   * The selected node ids, or `undefined` when the surface has no selection.
+   *
+   * **`undefined` is not an empty set**, the same distinction
+   * `productLabelsByNodeId` above draws: it means there is no selection
+   * mechanism here, so the checkbox column does not exist and the table renders
+   * exactly the columns it did before. An empty set means the surface selects
+   * and nothing is selected yet.
+   */
+  selectedIds?: ReadonlySet<string>;
+  onToggleSelected?: (nodeId: string) => void;
+  /**
+   * Ticks or clears every row **this table was given** — which is the filtered,
+   * searched, currently-visible list, never the whole library. See the page's
+   * `toggleAllVisible`.
+   */
+  onToggleAll?: () => void;
   onSortChange: (key: NodeSortKey) => void;
   onSelectNode: (node: Node) => void;
 }
@@ -70,13 +87,34 @@ export function NodeTable({
   usedInByNodeId,
   scope,
   productLabelsByNodeId,
+  selectedIds,
+  onToggleSelected,
+  onToggleAll,
   onSortChange,
   onSelectNode,
 }: NodeTableProps) {
+  // Checked only when every visible row is in the set — and `nodes.length > 0`
+  // so an empty table does not render a ticked "select all" over nothing.
+  const allVisibleSelected =
+    selectedIds !== undefined &&
+    nodes.length > 0 &&
+    nodes.every((node) => selectedIds.has(node.id));
+
   return (
     <Table className="text-sm">
       <TableHeader>
         <TableRow>
+          {selectedIds !== undefined && (
+            <TableHead className="w-8">
+              <input
+                type="checkbox"
+                aria-label="Select all visible nodes"
+                className="size-4 cursor-pointer accent-primary"
+                checked={allVisibleSelected}
+                onChange={() => onToggleAll?.()}
+              />
+            </TableHead>
+          )}
           {SORTABLE_COLUMNS.map((column) => (
             <TableHead key={column.key}>
               <button
@@ -102,6 +140,20 @@ export function NodeTable({
           const platforms = scopedPlatforms(node, scope);
           return (
             <TableRow key={node.id} data-wobble-group className="cursor-pointer" onClick={() => onSelectNode(node)}>
+              {selectedIds !== undefined && (
+                // The whole row opens the node, so the cell swallows the click
+                // as well as the box: a fat-fingered tap on the padding around
+                // a checkbox must not navigate away mid-selection.
+                <TableCell className="w-8" onClick={(event) => event.stopPropagation()}>
+                  <input
+                    type="checkbox"
+                    aria-label={`Select ${node.title}`}
+                    className="size-4 cursor-pointer accent-primary"
+                    checked={selectedIds.has(node.id)}
+                    onChange={() => onToggleSelected?.(node.id)}
+                  />
+                </TableCell>
+              )}
               <TableCell className="font-mono text-xs">{node.id}</TableCell>
               <TableCell className="max-w-[280px] truncate">{node.title}</TableCell>
               <TableCell>{speciesLabelById[node.species] ?? node.species}</TableCell>

--- a/components/library/NodeTable.tsx
+++ b/components/library/NodeTable.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import { ArrowUpDownIcon } from "lucide-react";
 import { PRODUCT_MEMBERSHIP_SPECIES } from "@arkaik/schema";
 import type { Node } from "@/lib/data/types";
@@ -50,9 +51,10 @@ interface NodeTableProps {
   selectedIds?: ReadonlySet<string>;
   onToggleSelected?: (nodeId: string) => void;
   /**
-   * Ticks or clears every row **this table was given** — which is the filtered,
-   * searched, currently-visible list, never the whole library. See the page's
-   * `toggleAllVisible`.
+   * Adds every row **this table was given** to the selection, or removes them
+   * all when they are already in it — the filtered, searched, currently-visible
+   * list, never the whole library, and never at the expense of a selection made
+   * under another filter. See the page's `toggleAllVisible`.
    */
   onToggleAll?: () => void;
   onSortChange: (key: NodeSortKey) => void;
@@ -100,6 +102,25 @@ export function NodeTable({
     nodes.length > 0 &&
     nodes.every((node) => selectedIds.has(node.id));
 
+  /**
+   * SOME-BUT-NOT-ALL is a third state, and a native checkbox has no attribute
+   * for it — `indeterminate` is an IDLE property, settable only from JavaScript,
+   * which is why this needs a ref rather than a prop. Without it a partial
+   * selection renders an empty box indistinguishable from "nothing selected",
+   * and the control would misreport what a click is about to do: the box is
+   * unchecked, so clicking it *adds* the rest, while it looks like clicking will
+   * do nothing at all.
+   */
+  const someVisibleSelected =
+    selectedIds !== undefined && nodes.some((node) => selectedIds.has(node.id));
+  const selectAllRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (selectAllRef.current) {
+      selectAllRef.current.indeterminate = someVisibleSelected && !allVisibleSelected;
+    }
+  }, [allVisibleSelected, someVisibleSelected]);
+
   return (
     <Table className="text-sm">
       <TableHeader>
@@ -107,6 +128,7 @@ export function NodeTable({
           {selectedIds !== undefined && (
             <TableHead className="w-8">
               <input
+                ref={selectAllRef}
                 type="checkbox"
                 aria-label="Select all visible nodes"
                 className="size-4 cursor-pointer accent-primary"
@@ -147,7 +169,11 @@ export function NodeTable({
                 <TableCell className="w-8" onClick={(event) => event.stopPropagation()}>
                   <input
                     type="checkbox"
-                    aria-label={`Select ${node.title}`}
+                    // Titles are not unique in this app — two products' "Home"
+                    // views are ordinary — and the adjacent column already
+                    // renders the id, so the accessible name says both rather
+                    // than reading out three identical "Select Home" boxes.
+                    aria-label={`Select ${node.title} (${node.id})`}
                     className="size-4 cursor-pointer accent-primary"
                     checked={selectedIds.has(node.id)}
                     onChange={() => onToggleSelected?.(node.id)}

--- a/components/maps/JourneyMap.tsx
+++ b/components/maps/JourneyMap.tsx
@@ -23,7 +23,7 @@ import { Button } from "@/components/ui/button";
 import { useNodes } from "@/lib/hooks/useNodes";
 import { useEdges } from "@/lib/hooks/useEdges";
 import { useProject } from "@/lib/hooks/useProject";
-import { useEffectiveProduct } from "@/lib/hooks/useProductScope";
+import { useEffectiveProduct, useProductList } from "@/lib/hooks/useProductScope";
 import { useJournal } from "@/lib/hooks/useJournal";
 import { useProjectPanels } from "@/lib/hooks/useProjectPanels";
 import { useElkLayout } from "@/lib/hooks/useElkLayout";
@@ -95,12 +95,7 @@ export function JourneyMap({ projectId, definition }: JourneyMapProps) {
   // themselves. It is also this journey's default product, and so reaches the
   // anchor chain below.
   const scope = useEffectiveProduct(id, projectBundle);
-
-  // The project's declared products, in declaration order, for the create
-  // form's picker. Memoized so the dialog is not handed a fresh array identity
-  // on every render; empty when the project declares none, which is what keeps
-  // the form looking exactly as it did before products existed.
-  const productList = useMemo(() => [...scope.productsById.values()], [scope.productsById]);
+  const productList = useProductList(scope);
   const { journal } = useJournal(id);
 
   // Built-in maps have no stored definition to carry a `display`, so the id is

--- a/components/maps/JourneyMap.tsx
+++ b/components/maps/JourneyMap.tsx
@@ -95,6 +95,12 @@ export function JourneyMap({ projectId, definition }: JourneyMapProps) {
   // themselves. It is also this journey's default product, and so reaches the
   // anchor chain below.
   const scope = useEffectiveProduct(id, projectBundle);
+
+  // The project's declared products, in declaration order, for the create
+  // form's picker. Memoized so the dialog is not handed a fresh array identity
+  // on every render; empty when the project declares none, which is what keeps
+  // the form looking exactly as it did before products existed.
+  const productList = useMemo(() => [...scope.productsById.values()], [scope.productsById]);
   const { journal } = useJournal(id);
 
   // Built-in maps have no stored definition to carry a `display`, so the id is
@@ -790,6 +796,8 @@ export function JourneyMap({ projectId, definition }: JourneyMapProps) {
         onOpenChange={handleNewNodeOpenChange}
         onSubmit={handleAddNode}
         defaultValues={newNodePreset ?? undefined}
+        products={productList}
+        defaultProductId={selection.productId}
       />
       <InsertBetweenDialog
         open={insertBetweenOpen}

--- a/components/maps/JourneyMap.tsx
+++ b/components/maps/JourneyMap.tsx
@@ -30,7 +30,7 @@ import { useElkLayout } from "@/lib/hooks/useElkLayout";
 import { useKeyboardShortcuts } from "@/lib/hooks/useKeyboardShortcuts";
 import { generateNodeId, edgeId } from "@/lib/utils/id";
 import { wouldCreateCycle } from "@/lib/utils/cycle";
-import type { ProductGraph } from "@/lib/utils/product-scope";
+import { productDisplayTitle, type ProductGraph } from "@/lib/utils/product-scope";
 import type { SpeciesId } from "@/lib/config/species";
 import type { PlatformId } from "@/lib/config/platforms";
 import type { Node as DataNode, Edge as DataEdge, PlaylistEntry } from "@/lib/data/types";
@@ -705,10 +705,11 @@ export function JourneyMap({ projectId, definition }: JourneyMapProps) {
   // The product this journey reads through, as a reader would name it. Falls
   // back to the id for a scope pointing at a product the project no longer
   // declares, exactly as the selector and the Library badges do.
-  const productLabel =
-    selection.productId === null
-      ? null
-      : scope.productsById.get(selection.productId)?.title?.trim() || selection.productId;
+  const productLabel = (() => {
+    if (selection.productId === null) return null;
+    const product = scope.productsById.get(selection.productId);
+    return product ? productDisplayTitle(product) : selection.productId;
+  })();
 
   if (nodesLoading || edgesLoading || projectLoading) {
     return (

--- a/components/maps/SystemMap.tsx
+++ b/components/maps/SystemMap.tsx
@@ -25,7 +25,7 @@ import { useJournal } from "@/lib/hooks/useJournal";
 import { useProjectPanels } from "@/lib/hooks/useProjectPanels";
 import { useNodes } from "@/lib/hooks/useNodes";
 import { useProject } from "@/lib/hooks/useProject";
-import { useEffectiveProduct } from "@/lib/hooks/useProductScope";
+import { useEffectiveProduct, useProductList } from "@/lib/hooks/useProductScope";
 import { generateNodeId, edgeId } from "@/lib/utils/id";
 import { mapProductId, type ProductGraph } from "@/lib/utils/product-scope";
 import { buildSystemGraph } from "@/lib/utils/system-graph";
@@ -89,12 +89,7 @@ export function SystemMap({ projectId, definition }: SystemMapProps) {
   // draw and how many platforms any card may claim; the display decides how a
   // card draws whatever it was given.
   const scope = useEffectiveProduct(projectId, projectBundle);
-
-  // The project's declared products, in declaration order, for the create
-  // form's picker. Memoized so the dialog is not handed a fresh array identity
-  // on every render; empty when the project declares none, which is what keeps
-  // the form looking exactly as it did before products existed.
-  const productList = useMemo(() => [...scope.productsById.values()], [scope.productsById]);
+  const productList = useProductList(scope);
   const { journal } = useJournal(projectId);
 
   const nodesById = useMemo(() => new Map(dataNodes.map((node) => [node.id, node])), [dataNodes]);

--- a/components/maps/SystemMap.tsx
+++ b/components/maps/SystemMap.tsx
@@ -27,7 +27,7 @@ import { useNodes } from "@/lib/hooks/useNodes";
 import { useProject } from "@/lib/hooks/useProject";
 import { useEffectiveProduct } from "@/lib/hooks/useProductScope";
 import { generateNodeId, edgeId } from "@/lib/utils/id";
-import type { ProductGraph } from "@/lib/utils/product-scope";
+import { mapProductId, type ProductGraph } from "@/lib/utils/product-scope";
 import { buildSystemGraph } from "@/lib/utils/system-graph";
 import type { ElkLayoutOptions } from "@/lib/utils/elk-layout";
 
@@ -89,6 +89,12 @@ export function SystemMap({ projectId, definition }: SystemMapProps) {
   // draw and how many platforms any card may claim; the display decides how a
   // card draws whatever it was given.
   const scope = useEffectiveProduct(projectId, projectBundle);
+
+  // The project's declared products, in declaration order, for the create
+  // form's picker. Memoized so the dialog is not handed a fresh array identity
+  // on every render; empty when the project declares none, which is what keeps
+  // the form looking exactly as it did before products existed.
+  const productList = useMemo(() => [...scope.productsById.values()], [scope.productsById]);
   const { journal } = useJournal(projectId);
 
   const nodesById = useMemo(() => new Map(dataNodes.map((node) => [node.id, node])), [dataNodes]);
@@ -323,7 +329,13 @@ export function SystemMap({ projectId, definition }: SystemMapProps) {
           scope={scope}
         />
       </PageShell>
-      <NewNodeForm open={newNodeOpen} onOpenChange={setNewNodeOpen} onSubmit={handleCreateNode} />
+      <NewNodeForm
+        open={newNodeOpen}
+        onOpenChange={setNewNodeOpen}
+        onSubmit={handleCreateNode}
+        products={productList}
+        defaultProductId={mapProductId(definition, scope)}
+      />
       <EdgeTypeDialog
         open={edgeDialogOpen}
         onOpenChange={(open) => {

--- a/components/panels/AcceptanceEditor.tsx
+++ b/components/panels/AcceptanceEditor.tsx
@@ -8,6 +8,10 @@ import type { ValueId } from "@arkaik/schema";
 import { STATUSES } from "@/lib/config/statuses";
 import { getEditablePlatformStatuses } from "@/lib/utils/platform-status";
 import type { ProductScope } from "@/lib/utils/product-scope";
+import { productsOfAcceptance } from "@/lib/utils/product-scope";
+import { withProductMembership } from "@/lib/utils/product-editing";
+import { productOf } from "@arkaik/schema";
+import { ProductPicker } from "@/components/panels/ProductPicker";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { STATUS_ICONS, STATUS_STYLES, SPECIES_ICONS } from "@/components/graph/nodes/node-styles";
 import { PlatformVariants } from "@/components/panels/PlatformVariants";
@@ -50,6 +54,50 @@ export function AcceptanceEditor({ node, allNodes, allEdges, scope, onUpdate, on
     onUpdate(node.id, { metadata: { ...node.metadata, ...next } });
   }
 
+  /* --- Product (§ D5) ------------------------------------------------------
+   *
+   * The control is **always** shown once the project declares products, but what
+   * it displays depends on whether this acceptance covers anything.
+   *
+   * `productsOfAcceptance` is the authority and is asked rather than
+   * re-implemented: anchors govern when there are any, and the stored key is the
+   * answer only for an acceptance that covers nothing — the intake case, where a
+   * PM files an idea knowing which app it is for long before they know which
+   * screens it needs. Reading the stored value first would let a stale key
+   * out-vote the graph it is attached to.
+   *
+   * So when anchors exist the trigger shows the **derived** product(s) — the live
+   * answer every read surface already agrees on — via `displayOverride`, while
+   * the select still edits and reports the stored fallback. The two rejected
+   * alternatives are recorded in the spec: hiding the control the moment a
+   * `covers` edge appears makes a field materialise and vanish as edges change,
+   * and treating it as a plain editable field lets a user set a value the graph
+   * silently ignores.
+   *
+   * `anchorCount` counts *resolvable* anchors, not `covers` edges, because that
+   * is what the derivation counts: a dangling edge to a node this snapshot does
+   * not hold is skipped by `productsOfAcceptance`, and a hint promising "the 2
+   * nodes it covers" decide the answer when only one of them exists would be
+   * telling the reader something false about their own graph.
+   */
+  const anchorCount = coveredAnchors.length;
+  const derivedProducts = productsOfAcceptance(node, allEdges, nodesById);
+  // Declaration order, then ids the project no longer declares — the ordering
+  // `productLabelsOfNode` applies, for the same reason: a Set iterates in
+  // insertion order, which here is whatever the anchor list happened to hit
+  // first, and a label pair that flips between renders of an unchanged graph
+  // reads as a change.
+  const derivedLabels = [
+    ...[...scope.productsById.keys()].filter((id) => derivedProducts.has(id)),
+    ...[...derivedProducts].filter((id) => !scope.productsById.has(id)),
+  ]
+    .map((id) => {
+      const title = scope.productsById.get(id)?.title;
+      return typeof title === "string" && title.trim() !== "" ? title : id;
+    })
+    .join(", ");
+  const anchorNoun = `${anchorCount} node${anchorCount === 1 ? "" : "s"}`;
+
   return (
     <div className="px-6 flex flex-col gap-5">
       <section className="flex flex-col gap-1.5">
@@ -64,6 +112,38 @@ export function AcceptanceEditor({ node, allNodes, allEdges, scope, onUpdate, on
           </SelectContent>
         </Select>
       </section>
+
+      {scope.productsById.size > 0 && (
+        <section>
+          <ProductPicker
+            products={[...scope.productsById.values()]}
+            value={productOf(node)}
+            // `onUpdate` directly rather than `patchMetadata`: unassigning must
+            // *remove* the key (`withProductMembership` owns that rule — a stored
+            // `product: ""` names a product that cannot exist), and a spread
+            // merge can only ever add or overwrite one. The rest of the metadata
+            // — gherkin, values, platformStatuses — is carried through by
+            // `withProductMembership` itself, which is what `patchMetadata`
+            // would otherwise have been here for.
+            onChange={(nextProduct) =>
+              void onUpdate(node.id, { metadata: withProductMembership(node.metadata, nextProduct) })
+            }
+            label={anchorCount > 0 ? "Product (from what it covers)" : "Product"}
+            // Only when anchored: unanchored, the stored value *is* the answer,
+            // and overriding its display with itself would be a lie by ceremony.
+            displayOverride={
+              anchorCount > 0 ? { text: derivedLabels || "Unassigned" } : undefined
+            }
+            hint={
+              anchorCount > 0
+                ? derivedLabels
+                  ? `This acceptance belongs to ${derivedLabels}, taken from the ${anchorNoun} it covers. The value you set here applies only if it stops covering anything.`
+                  : `The ${anchorNoun} this covers have no product yet, so it appears under All products. The value you set here applies only if it stops covering anything.`
+                : "This acceptance covers nothing, so its product is whatever you set here."
+            }
+          />
+        </section>
+      )}
 
       <section className="flex flex-col gap-1.5">
         <span className="text-xs text-muted-foreground">Gherkin — the How (one Given/When/Then)</span>

--- a/components/panels/AcceptanceEditor.tsx
+++ b/components/panels/AcceptanceEditor.tsx
@@ -89,6 +89,17 @@ export function AcceptanceEditor({ node, allNodes, allEdges, scope, onUpdate, on
   // reason to build for a species that never consults one.
   const derivedLabels = productLabels(derivedProducts, scope).join(", ");
   const anchorNoun = `${anchorCount} node${anchorCount === 1 ? "" : "s"}`;
+  /**
+   * A stored key naming a product the project no longer declares — the stranded
+   * remnant of a rename or a deletion. Only meaningful when nothing is anchored,
+   * because with anchors the stored key is inert anyway and the hint already
+   * says so.
+   */
+  const storedProductId = productOf(node);
+  const staleProductId =
+    anchorCount === 0 && storedProductId !== null && !scope.productsById.has(storedProductId)
+      ? storedProductId
+      : null;
 
   return (
     <div className="px-6 flex flex-col gap-5">
@@ -131,7 +142,17 @@ export function AcceptanceEditor({ node, allNodes, allEdges, scope, onUpdate, on
                 ? derivedLabels
                   ? `This acceptance belongs to ${derivedLabels}, taken from the ${anchorNoun} it covers. The value you set here applies only if it stops covering anything.`
                   : `The ${anchorNoun} this covers have no product yet, so it appears under All products. The value you set here applies only if it stops covering anything.`
-                : "This acceptance covers nothing, so its product is whatever you set here."
+                : staleProductId
+                  // The stored key names a product the project no longer
+                  // declares, so the picker degrades its trigger to
+                  // "Unassigned" — and the id is about to be overwritten the
+                  // moment the control is touched. Echoing it is the only trace
+                  // left of the rename or deletion that stranded it, and it is
+                  // what lets a reader recognise their own product rather than
+                  // silently accept an unassignment they never asked for. Same
+                  // sentence `NodeDetailPanel` uses, for the same state.
+                  ? `Assigned to "${staleProductId}", which this project no longer declares — it appears under All products only.`
+                  : "This acceptance covers nothing, so its product is whatever you set here."
             }
           />
         </section>

--- a/components/panels/AcceptanceEditor.tsx
+++ b/components/panels/AcceptanceEditor.tsx
@@ -8,7 +8,7 @@ import type { ValueId } from "@arkaik/schema";
 import { STATUSES } from "@/lib/config/statuses";
 import { getEditablePlatformStatuses } from "@/lib/utils/platform-status";
 import type { ProductScope } from "@/lib/utils/product-scope";
-import { productsOfAcceptance } from "@/lib/utils/product-scope";
+import { productLabels, productsOfAcceptance } from "@/lib/utils/product-scope";
 import { withProductMembership } from "@/lib/utils/product-editing";
 import { productOf } from "@arkaik/schema";
 import { ProductPicker } from "@/components/panels/ProductPicker";
@@ -82,20 +82,12 @@ export function AcceptanceEditor({ node, allNodes, allEdges, scope, onUpdate, on
    */
   const anchorCount = coveredAnchors.length;
   const derivedProducts = productsOfAcceptance(node, allEdges, nodesById);
-  // Declaration order, then ids the project no longer declares — the ordering
-  // `productLabelsOfNode` applies, for the same reason: a Set iterates in
-  // insertion order, which here is whatever the anchor list happened to hit
-  // first, and a label pair that flips between renders of an unchanged graph
-  // reads as a change.
-  const derivedLabels = [
-    ...[...scope.productsById.keys()].filter((id) => derivedProducts.has(id)),
-    ...[...derivedProducts].filter((id) => !scope.productsById.has(id)),
-  ]
-    .map((id) => {
-      const title = scope.productsById.get(id)?.title;
-      return typeof title === "string" && title.trim() !== "" ? title : id;
-    })
-    .join(", ");
+  // `productLabels`, not an inline sort-and-title: the declaration ordering and
+  // the title-falls-back-to-the-id rule are `product-scope`'s to hold, and a
+  // second copy here is a copy that drifts. Not `productLabelsOfNode`, which
+  // would re-enter `productsOfNode` and demand a `usageIndex` this editor has no
+  // reason to build for a species that never consults one.
+  const derivedLabels = productLabels(derivedProducts, scope).join(", ");
   const anchorNoun = `${anchorCount} node${anchorCount === 1 ? "" : "s"}`;
 
   return (

--- a/components/panels/NewAcceptanceForm.tsx
+++ b/components/panels/NewAcceptanceForm.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import type { ProductDefinition } from "@arkaik/schema";
+import type { NodeMetadata } from "@/lib/data/types";
+import { ProductPicker } from "@/components/panels/ProductPicker";
+import { useSeedOnOpen } from "@/lib/hooks/useSeedOnOpen";
+import { withProductMembership } from "@/lib/utils/product-editing";
+
+/**
+ * Create one acceptance: a title, and the product it belongs to.
+ *
+ * **Why this exists at all.** The Acceptances page used to create through a
+ * `window.prompt`, which was a reasonable call while acceptances were made at
+ * scale by the retro-population agents and by hand only rarely. It stopped being
+ * reasonable the moment products shipped: a prompt returns a string and nothing
+ * else, so every acceptance created under a named scope landed with no
+ * membership — and an acceptance covering nothing reads its membership from its
+ * own stored key, so it appeared under All products only. The user watched the
+ * thing they had just created vanish from the scope they were standing in, with
+ * no explanation. A dialog is the smallest surface that can carry the product.
+ *
+ * **Deliberately smaller than `NewNodeForm`.** No species (it is always an
+ * acceptance), no platforms and no status (acceptances are created as ideas
+ * across every platform, and both of those are the page's business, not the
+ * user's, at create time). Adding fields here would change what an acceptance
+ * *is* on creation; this only stops one from being born outside its scope.
+ *
+ * **The degenerate case is byte-identical to the prompt's replacement.** With no
+ * products declared this is a title field and nothing else — no picker, no
+ * label, no new word.
+ */
+
+export interface NewAcceptanceFormData {
+  title: string;
+  /** Omitted entirely when there is no membership to record. */
+  metadata?: NodeMetadata;
+}
+
+interface NewAcceptanceFormProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (data: NewAcceptanceFormData) => void;
+  /**
+   * The project's declared products. **Empty means the picker never renders** —
+   * the same guarantee, and the same guard, as `NewNodeForm`.
+   */
+  products?: readonly ProductDefinition[];
+  /** The scope the user is standing in, pre-filled and editable (§ D1). */
+  defaultProductId?: string | null;
+}
+
+export function NewAcceptanceForm({
+  open,
+  onOpenChange,
+  onSubmit,
+  products = [],
+  defaultProductId = null,
+}: NewAcceptanceFormProps) {
+  const [title, setTitle] = useState("");
+  const [product, setProduct] = useState<string | null>(defaultProductId);
+
+  const showsProductPicker = products.length > 0;
+
+  // Seeded on the closed → open transition only. The page keeps this dialog
+  // mounted, and `scope.productId` resolves late against a bundle that loads in
+  // an effect, so neither the initial `useState` nor a bare `open` effect is
+  // enough — see `useSeedOnOpen`.
+  useSeedOnOpen(open, defaultProductId, setProduct);
+
+  function resetForm() {
+    setTitle("");
+    setProduct(defaultProductId);
+  }
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen) resetForm();
+    onOpenChange(nextOpen);
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!title.trim()) return;
+
+    // `withProductMembership` removes the key for null rather than blanking it,
+    // so an unassigned acceptance carries no `product` at all — and the whole
+    // object is dropped when it would be empty, leaving the created node exactly
+    // as it was before this dialog existed.
+    const metadata = showsProductPicker ? withProductMembership(undefined, product) : {};
+
+    onSubmit({
+      title: title.trim(),
+      metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+    });
+    resetForm();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>New acceptance</DialogTitle>
+          <DialogDescription className="sr-only">
+            Name the acceptance, and choose which product it belongs to.
+          </DialogDescription>
+        </DialogHeader>
+        <form id="new-acceptance-form" onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Title</span>
+            <Input
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="The What — what must be true"
+              required
+              aria-label="Acceptance title"
+            />
+          </div>
+          {showsProductPicker && (
+            <ProductPicker
+              products={products}
+              value={product}
+              onChange={setProduct}
+              hint={
+                product === null
+                  ? "Unassigned acceptances appear under All products only."
+                  : undefined
+              }
+            />
+          )}
+        </form>
+        <DialogFooter>
+          <Button variant="outline" type="button" onClick={() => handleOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button type="submit" form="new-acceptance-form">
+            Create acceptance
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/panels/NewNodeForm.tsx
+++ b/components/panels/NewNodeForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -33,6 +33,7 @@ import type { PlatformId } from "@/lib/config/platforms";
 import type { NodeMetadata } from "@/lib/data/types";
 import { PRODUCT_MEMBERSHIP_SPECIES, type ProductDefinition } from "@arkaik/schema";
 import { ProductPicker } from "@/components/panels/ProductPicker";
+import { useSeedOnOpen } from "@/lib/hooks/useSeedOnOpen";
 import {
   constrainPlatforms,
   platformMenuFor,
@@ -88,12 +89,23 @@ export function NewNodeForm({
   const storesProduct = PRODUCT_MEMBERSHIP_SPECIES.includes(species);
   const showsProductPicker = products.length > 0 && storesProduct;
 
+  /**
+   * The definition an id names, or `null` for unassigned — and for an id this
+   * project no longer declares, which `platformMenuFor` reads as "every
+   * platform" rather than as none.
+   *
+   * One lookup, three callers (the menu below, the change handler, the open
+   * seed). Written out at each site they drifted immediately: the menu guarded
+   * on `product !== null` and the handler on `nextProduct === null`, which are
+   * the same rule spelled twice and one edit away from disagreeing.
+   */
+  const findProduct = (id: string | null) =>
+    id === null ? null : products.find((candidate) => candidate.id === id) ?? null;
+
   // The containment rule at its source (§ D4): a node may only claim platforms
   // its product ships on. An unassigned node — or a project with no products —
   // gets every platform, which is today's behaviour unchanged.
-  const platformMenu = platformMenuFor(
-    storesProduct && product !== null ? products.find((p) => p.id === product) ?? null : null,
-  );
+  const platformMenu = platformMenuFor(storesProduct ? findProduct(product) : null);
 
   // A platform-less product means availability is not a tracked dimension here
   // (a CLI, a public API), so there is nothing to toggle — RFC decision 2.
@@ -112,18 +124,22 @@ export function NewNodeForm({
     (species === "view" && platformMenu.length === 0);
 
   /**
-   * Re-seed the scoped default whenever the dialog opens.
+   * Re-seed the scoped default on each closed → open transition, and never
+   * once the dialog is already open.
    *
    * These call sites mount the form once and keep it mounted, so the initial
    * `useState` runs long before the user picks a scope: without this, switching
    * to Admin and creating a view would pre-fill whatever scope the page was
-   * first rendered under. Keyed on `open` so an in-progress edit is never
-   * overwritten — the dialog is modal, and the scope selector sits behind it.
+   * first rendered under.
+   *
+   * The transition, not merely `open`, because `defaultProductId` moves on its
+   * own — `useEffectiveProduct` resolves against a bundle that arrives in an
+   * effect, so a dialog opened in that window would have the user's choice
+   * overwritten a beat later. `useSeedOnOpen` owns that latch; the seed goes
+   * through `handleProductChange` so the platform constraint runs in the same
+   * step rather than leaving a selection the seeded product forbids.
    */
-  useEffect(() => {
-    if (!open) return;
-    setProduct(defaultProductId);
-  }, [open, defaultProductId]);
+  useSeedOnOpen(open, defaultProductId, handleProductChange);
 
   function resetForm() {
     setTitle("");
@@ -151,9 +167,7 @@ export function NewNodeForm({
    */
   function handleProductChange(nextProduct: string | null) {
     setProduct(nextProduct);
-    const nextMenu = platformMenuFor(
-      nextProduct === null ? null : products.find((p) => p.id === nextProduct) ?? null,
-    );
+    const nextMenu = platformMenuFor(findProduct(nextProduct));
     setPlatforms((previous) => constrainPlatforms(previous, nextMenu));
   }
 

--- a/components/panels/NewNodeForm.tsx
+++ b/components/panels/NewNodeForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -31,6 +31,13 @@ import type { SpeciesId } from "@/lib/config/species";
 import type { StatusId } from "@/lib/config/statuses";
 import type { PlatformId } from "@/lib/config/platforms";
 import type { NodeMetadata } from "@/lib/data/types";
+import { PRODUCT_MEMBERSHIP_SPECIES, type ProductDefinition } from "@arkaik/schema";
+import { ProductPicker } from "@/components/panels/ProductPicker";
+import {
+  constrainPlatforms,
+  platformMenuFor,
+  withProductMembership,
+} from "@/lib/utils/product-editing";
 
 export interface NewNodeFormData {
   title: string;
@@ -46,22 +53,84 @@ interface NewNodeFormProps {
   onSubmit: (data: NewNodeFormData) => void;
   /** Pre-fill species when opening from an "Add child" action. */
   defaultValues?: Partial<Pick<NewNodeFormData, "species">>;
+  /**
+   * The project's declared products. **Empty means the picker never renders** —
+   * a project that has never heard of products must see no new field, no new
+   * label, and no new word (§ degenerate-case guarantee).
+   */
+  products?: readonly ProductDefinition[];
+  /**
+   * The scope the user is standing in, pre-filled into the picker (§ D1).
+   *
+   * Visible and editable, never silent: creating a node under a named scope
+   * without this produced a node that vanished from the scope the moment it was
+   * created, because an unassigned flow or view shows under All products only.
+   */
+  defaultProductId?: string | null;
 }
 
-export function NewNodeForm({ open, onOpenChange, onSubmit, defaultValues }: NewNodeFormProps) {
+export function NewNodeForm({
+  open,
+  onOpenChange,
+  onSubmit,
+  defaultValues,
+  products = [],
+  defaultProductId = null,
+}: NewNodeFormProps) {
   const [title, setTitle] = useState("");
   const [species, setSpecies] = useState<SpeciesId>(defaultValues?.species ?? "view");
   const [status, setStatus] = useState<StatusId>("idea");
   const [platforms, setPlatforms] = useState<PlatformId[]>([]);
-  const usesSingleStatusField = species === "data-model" || species === "api-endpoint";
-  const usesPlatformDefaultStatus = species === "view";
-  const allowsPlatformEditing = species !== "flow";
+  const [product, setProduct] = useState<string | null>(defaultProductId);
+
+  // Only three species *store* membership; the system layer derives it from who
+  // consumes it and must never be offered the control.
+  const storesProduct = PRODUCT_MEMBERSHIP_SPECIES.includes(species);
+  const showsProductPicker = products.length > 0 && storesProduct;
+
+  // The containment rule at its source (§ D4): a node may only claim platforms
+  // its product ships on. An unassigned node — or a project with no products —
+  // gets every platform, which is today's behaviour unchanged.
+  const platformMenu = platformMenuFor(
+    storesProduct && product !== null ? products.find((p) => p.id === product) ?? null : null,
+  );
+
+  // A platform-less product means availability is not a tracked dimension here
+  // (a CLI, a public API), so there is nothing to toggle — RFC decision 2.
+  const allowsPlatformEditing = species !== "flow" && platformMenu.length > 0;
+
+  // A view's status is normally the *default* it stamps onto each platform it
+  // claims. Inside a platform-less product there are no platforms to stamp, so
+  // the same field becomes the node's one status — RFC decision 2, and the other
+  // half of what "no platform toggles" has to mean. Without this the view would
+  // lose its status field entirely, and submit would write an empty
+  // `platformStatuses` map that no read surface can get a status out of.
+  const usesPlatformDefaultStatus = species === "view" && platformMenu.length > 0;
+  const usesSingleStatusField =
+    species === "data-model" ||
+    species === "api-endpoint" ||
+    (species === "view" && platformMenu.length === 0);
+
+  /**
+   * Re-seed the scoped default whenever the dialog opens.
+   *
+   * These call sites mount the form once and keep it mounted, so the initial
+   * `useState` runs long before the user picks a scope: without this, switching
+   * to Admin and creating a view would pre-fill whatever scope the page was
+   * first rendered under. Keyed on `open` so an in-progress edit is never
+   * overwritten — the dialog is modal, and the scope selector sits behind it.
+   */
+  useEffect(() => {
+    if (!open) return;
+    setProduct(defaultProductId);
+  }, [open, defaultProductId]);
 
   function resetForm() {
     setTitle("");
     setSpecies(defaultValues?.species ?? "view");
     setStatus("idea");
     setPlatforms([]);
+    setProduct(defaultProductId);
   }
 
   function handleOpenChange(nextOpen: boolean) {
@@ -75,19 +144,49 @@ export function NewNodeForm({ open, onOpenChange, onSubmit, defaultValues }: New
     );
   }
 
+  /**
+   * Switching to a narrower product drops the platforms it does not ship on,
+   * rather than storing a claim the product forbids and letting
+   * `effectiveNodePlatforms` silently hide it at render time.
+   */
+  function handleProductChange(nextProduct: string | null) {
+    setProduct(nextProduct);
+    const nextMenu = platformMenuFor(
+      nextProduct === null ? null : products.find((p) => p.id === nextProduct) ?? null,
+    );
+    setPlatforms((previous) => constrainPlatforms(previous, nextMenu));
+  }
+
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!title.trim()) return;
 
-    const metadata: NodeMetadata | undefined = species === "view"
+    const platformStatuses = usesPlatformDefaultStatus
       ? {
           platformStatuses: Object.fromEntries(
             platforms.map((platformId) => [platformId, status]),
           ) as Record<PlatformId, StatusId>,
         }
-      : undefined;
+      : {};
 
-    onSubmit({ title: title.trim(), species, status, platforms, metadata });
+    // Membership only for the species that store it, and only when the project
+    // has products at all. `withProductMembership` removes the key for null
+    // rather than blanking it — unassigned has to mean absent. The two
+    // contributions are *merged*: a view in a product needs both, and either one
+    // overwriting the other would silently drop the other's key.
+    const membership = storesProduct && products.length > 0
+      ? withProductMembership(undefined, product)
+      : {};
+
+    const metadata: NodeMetadata = { ...membership, ...platformStatuses };
+
+    onSubmit({
+      title: title.trim(),
+      species,
+      status,
+      platforms,
+      metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+    });
     resetForm();
   }
 
@@ -124,6 +223,18 @@ export function NewNodeForm({ open, onOpenChange, onSubmit, defaultValues }: New
               </SelectContent>
             </Select>
           </div>
+          {showsProductPicker && (
+            <ProductPicker
+              products={products}
+              value={product}
+              onChange={handleProductChange}
+              hint={
+                product === null
+                  ? "Unassigned nodes appear under All products only."
+                  : undefined
+              }
+            />
+          )}
           {(usesSingleStatusField || usesPlatformDefaultStatus) && (
             <div className="flex flex-col gap-1.5">
               <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">

--- a/components/panels/NodeDetailPanel.tsx
+++ b/components/panels/NodeDetailPanel.tsx
@@ -219,6 +219,26 @@ function ProductSection({ node, scope, onUpdate }: ProductSectionProps) {
   if (!onUpdate) return null;
 
   const stored = productOf(node);
+  // Whether the membership RESOLVES, not merely whether one is stored. A key
+  // naming a product the project no longer declares degrades to "Unassigned" in
+  // the trigger (`ProductPicker` displays it, deliberately, rather than healing
+  // it), so keying the hint off `stored === null` would suppress the explanation
+  // in exactly the case that needs one most: the trigger says Unassigned and
+  // nothing on screen says why.
+  const resolved = stored !== null && scope.productsById.has(stored);
+  // The two unresolved cases get different sentences because they are different
+  // situations and have different fixes. Never-assigned is a normal state — the
+  // node is in triage and the hint just says where to find it. A stale key is a
+  // fault: something named a product that no longer exists, the id is the only
+  // trace of it left, and echoing it back is what lets a reader recognise a
+  // rename or a deletion they can undo. Collapsing both into one sentence would
+  // throw that id away, and it is unrecoverable from the UI once the select is
+  // touched.
+  const hint = resolved
+    ? undefined
+    : stored === null
+      ? "Unassigned nodes appear under All products only."
+      : `Assigned to "${stored}", which this project no longer declares — it appears under All products only.`;
 
   return (
     <div className="px-6">
@@ -232,7 +252,7 @@ function ProductSection({ node, scope, onUpdate }: ProductSectionProps) {
         onChange={(nextProduct) =>
           void onUpdate(node.id, { metadata: withProductMembership(node.metadata, nextProduct) })
         }
-        hint={stored === null ? "Unassigned nodes appear under All products only." : undefined}
+        hint={hint}
       />
     </div>
   );

--- a/components/panels/NodeDetailPanel.tsx
+++ b/components/panels/NodeDetailPanel.tsx
@@ -30,6 +30,9 @@ import {
   scopedRollupPlatforms,
 } from "@/lib/utils/platform-status";
 import type { ProductScope } from "@/lib/utils/product-scope";
+import { ProductPicker } from "@/components/panels/ProductPicker";
+import { withProductMembership } from "@/lib/utils/product-editing";
+import { productOf } from "@arkaik/schema";
 import { findWhereUsed } from "@/lib/utils/where-used";
 import { computeNodeTimeline } from "@/lib/utils/journal";
 import { describeJournalEvent, formatEventDate } from "@/components/journal/describe-event";
@@ -173,6 +176,64 @@ function NodeFields({ node, onUpdate }: NodeFieldsProps) {
           </Select>
         </div>
       )}
+    </div>
+  );
+}
+
+interface ProductSectionProps {
+  node: Node;
+  scope: ProductScope;
+  onUpdate?: (id: string, patch: Partial<Omit<Node, "id" | "project_id">>) => Promise<void> | void;
+}
+
+/**
+ * Which product this node belongs to — the edit path for the key the read
+ * surfaces already scope on.
+ *
+ * **Renders nothing at all in a project that declares no products.** Not a
+ * disabled field, not an empty select, not the word "product": `productsById` is
+ * empty exactly when the project has never heard of the concept, and the whole
+ * feature's guarantee is that such a project looks byte-identical to how it did
+ * before products existed. The guard lives here rather than inside
+ * `ProductPicker` because only the call site knows which layout to omit.
+ *
+ * **Flows and views only, though `PRODUCT_MEMBERSHIP_SPECIES` also lists
+ * acceptances.** An acceptance already gets a picker from `AcceptanceEditor`,
+ * which is the only place that can say the true thing about it — its membership
+ * is derived from its `covers` anchors (§ D5) and this control cannot express
+ * that. Testing `PRODUCT_MEMBERSHIP_SPECIES` here, as the plan's sketch did,
+ * would put two pickers on the same acceptance panel disagreeing about the same
+ * node. Data models and API endpoints derive membership from their consumers and
+ * are excluded for the original reason: a stored key on one is a value every read
+ * surface ignores and the validator warns about
+ * (`product-membership-wrong-species`).
+ *
+ * Without `onUpdate` there is no save path, so the control does not render —
+ * showing an assignment that silently fails to persist is worse than showing
+ * none. The species-scoped read-only surfaces (the Library card, the graph node)
+ * already report membership for panels opened that way.
+ */
+function ProductSection({ node, scope, onUpdate }: ProductSectionProps) {
+  if (scope.productsById.size === 0) return null;
+  if (node.species !== "flow" && node.species !== "view") return null;
+  if (!onUpdate) return null;
+
+  const stored = productOf(node);
+
+  return (
+    <div className="px-6">
+      <ProductPicker
+        products={[...scope.productsById.values()]}
+        value={stored}
+        // Routed through `withProductMembership`, never assembled here: it owns
+        // the "unassigned means *absent*, never `product: \"\"`" rule and it
+        // carries the rest of the metadata (platformStatuses, notes,
+        // screenshots) through untouched — a patch replaces `metadata` wholesale.
+        onChange={(nextProduct) =>
+          void onUpdate(node.id, { metadata: withProductMembership(node.metadata, nextProduct) })
+        }
+        hint={stored === null ? "Unassigned nodes appear under All products only." : undefined}
+      />
     </div>
   );
 }
@@ -477,6 +538,7 @@ export function NodeDetailPanel({
   return (
     <div className="min-h-0 flex-1 overflow-y-auto flex flex-col gap-4 pb-6">
       <NodeFields key={node.id} node={node} onUpdate={onUpdate} />
+      <ProductSection key={`product-${node.id}`} node={node} scope={scope} onUpdate={onUpdate} />
       <RefsSection key={`refs-${node.id}`} node={node} />
       {(node.species === "view" || node.species === "flow") && allNodes && allEdges && (
         <AcceptancesSection

--- a/components/panels/ProductPicker.tsx
+++ b/components/panels/ProductPicker.tsx
@@ -1,6 +1,10 @@
 "use client";
 
 import type { ProductDefinition } from "@arkaik/schema";
+// The blank-title fallback is one rule with one home. This component renders
+// the products the three assignment forms offer, so a private copy here would
+// be the copy most users actually read.
+import { productDisplayTitle } from "@/lib/utils/product-scope";
 import {
   Select,
   SelectContent,
@@ -63,11 +67,6 @@ interface ProductPickerProps {
   disabled?: boolean;
 }
 
-/** The product's `title`, or its id when the definition carries none. */
-function productLabel(product: ProductDefinition): string {
-  return typeof product.title === "string" && product.title.trim() !== "" ? product.title : product.id;
-}
-
 export function ProductPicker({
   products,
   value,
@@ -101,7 +100,7 @@ export function ProductPicker({
           <SelectItem value={UNASSIGNED}>Unassigned</SelectItem>
           {products.map((product) => (
             <SelectItem key={product.id} value={product.id}>
-              {productLabel(product)}
+              {productDisplayTitle(product)}
             </SelectItem>
           ))}
         </SelectContent>

--- a/components/panels/ProductPicker.tsx
+++ b/components/panels/ProductPicker.tsx
@@ -39,6 +39,27 @@ interface ProductPickerProps {
   label?: string;
   /** Secondary line under the control — the caller's explanation, if any. */
   hint?: string;
+  /**
+   * Render `text` in the trigger **instead of** the selected option's label,
+   * while the menu keeps selecting and reporting `value` unchanged.
+   *
+   * It exists for exactly one caller: the acceptance editor (§ D5). An
+   * acceptance's membership is derived from its `covers` anchors, so when it has
+   * any, the live answer is the derived product(s) while `value` is the stored
+   * fallback that only applies if the acceptance stops covering anything. Without
+   * this the trigger would render the fallback as though it were the answer —
+   * which is the precise confusion `productsOfAcceptance` was written to prevent.
+   *
+   * *Rejected:* a separate read-only "derived product" line above an ordinary
+   * picker, which puts two different answers to "what product is this?" on
+   * screen at once and leaves the reader to guess which one the app believes.
+   * *Rejected:* forking a `DerivedProductPicker`, which would duplicate the
+   * `UNASSIGNED` sentinel and the stale-key degradation — the two rules this
+   * component exists to keep in one place.
+   *
+   * The stored value is still fully editable; only its *display* is deferred.
+   */
+  displayOverride?: { text: string };
   disabled?: boolean;
 }
 
@@ -53,6 +74,7 @@ export function ProductPicker({
   onChange,
   label = "Product",
   hint,
+  displayOverride,
   disabled,
 }: ProductPickerProps) {
   // A stored membership naming a product this project no longer declares
@@ -70,7 +92,10 @@ export function ProductPicker({
         disabled={disabled}
       >
         <SelectTrigger aria-label={label}>
-          <SelectValue />
+          {/* `SelectValue` renders the *selected* option, which is the stored
+              value. When a caller has a different live answer it supplies the
+              text itself — see `displayOverride`. */}
+          {displayOverride ? <span>{displayOverride.text}</span> : <SelectValue />}
         </SelectTrigger>
         <SelectContent>
           <SelectItem value={UNASSIGNED}>Unassigned</SelectItem>

--- a/components/panels/ProductPicker.tsx
+++ b/components/panels/ProductPicker.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import type { ProductDefinition } from "@arkaik/schema";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+/**
+ * The one control that assigns a node to a product.
+ *
+ * One component, three forms (the create form, the node detail panel, the
+ * acceptance editor), for the same reason `ProductScopeSelector` is one
+ * control: the rules about what "unassigned" means are subtle enough that three
+ * copies would diverge, and the third copy would be the one that stored `""`.
+ *
+ * **The caller decides whether to render it at all.** This component does not
+ * check whether the project declares products — its callers do, because a form
+ * that has no products to offer must not render an empty field, a label, or the
+ * word "product" anywhere. That is the degenerate-case guarantee, and it lives
+ * at the call site because only the call site knows what layout to omit.
+ */
+
+/**
+ * Radix reserves the empty string for "no selection", so "Unassigned" — a real
+ * choice, not an absence — needs a sentinel. It never leaves this file; the
+ * value handed back is `null`.
+ */
+const UNASSIGNED = "__unassigned__";
+
+interface ProductPickerProps {
+  products: readonly ProductDefinition[];
+  value: string | null;
+  onChange: (productId: string | null) => void;
+  /** Defaults to "Product". The acceptance editor overrides it. */
+  label?: string;
+  /** Secondary line under the control — the caller's explanation, if any. */
+  hint?: string;
+  disabled?: boolean;
+}
+
+/** The product's `title`, or its id when the definition carries none. */
+function productLabel(product: ProductDefinition): string {
+  return typeof product.title === "string" && product.title.trim() !== "" ? product.title : product.id;
+}
+
+export function ProductPicker({
+  products,
+  value,
+  onChange,
+  label = "Product",
+  hint,
+  disabled,
+}: ProductPickerProps) {
+  // A stored membership naming a product this project no longer declares
+  // degrades to Unassigned in the trigger, matching `ProductScopeSelector`. It
+  // is displayed, not healed — writing state as a side effect of rendering
+  // would make a half-synced bundle permanently forget a real assignment.
+  const selected = products.find((product) => product.id === value) ?? null;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">{label}</span>
+      <Select
+        value={selected ? selected.id : UNASSIGNED}
+        onValueChange={(next) => onChange(next === UNASSIGNED ? null : next)}
+        disabled={disabled}
+      >
+        <SelectTrigger aria-label={label}>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={UNASSIGNED}>Unassigned</SelectItem>
+          {products.map((product) => (
+            <SelectItem key={product.id} value={product.id}>
+              {productLabel(product)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {hint ? <p className="text-xs text-muted-foreground">{hint}</p> : null}
+    </div>
+  );
+}

--- a/components/settings/ProductDeleteDialog.tsx
+++ b/components/settings/ProductDeleteDialog.tsx
@@ -19,6 +19,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { productDisplayTitle } from "@/lib/utils/product-scope";
 
 /**
  * Delete a product, and decide what happens to the nodes that named it (§ D3).
@@ -87,7 +88,10 @@ export function ProductDeleteDialog({
     if (open) setReassignTo(UNASSIGNED);
   }, [open, product]);
 
-  const title = displayTitle(product);
+  // The title-or-id fallback is `productDisplayTitle`'s, so a product with no
+  // stored title is named identically in the dialog that deletes it and in the
+  // row it was deleted from.
+  const title = productDisplayTitle(product);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -116,7 +120,7 @@ export function ProductDeleteDialog({
                 <SelectItem value={UNASSIGNED}>Leave them unassigned</SelectItem>
                 {otherProducts.map((other) => (
                   <SelectItem key={other.id} value={other.id}>
-                    {displayTitle(other)}
+                    {productDisplayTitle(other)}
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -152,16 +156,4 @@ export function ProductDeleteDialog({
       </DialogContent>
     </Dialog>
   );
-}
-
-/**
- * The same title-or-id fallback the manager list and `ProductScopeSelector`
- * use, so a product with no stored `title` is named identically in the dialog
- * that deletes it and the row it was deleted from.
- */
-function displayTitle(product: ProductDefinition | null): string {
-  if (!product) return "";
-  return typeof product.title === "string" && product.title.trim() !== ""
-    ? product.title
-    : product.id;
 }

--- a/components/settings/ProductDeleteDialog.tsx
+++ b/components/settings/ProductDeleteDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import type { ProductDefinition } from "@arkaik/schema";
 
 import { Button } from "@/components/ui/button";
@@ -76,17 +76,19 @@ export function ProductDeleteDialog({
   onConfirm,
   busy,
 }: ProductDeleteDialogProps) {
-  const [reassignTo, setReassignTo] = useState<string>(UNASSIGNED);
-
   /**
-   * Default to unassigned every time the dialog opens. A destination remembered
-   * from the previous deletion is exactly the state that moves forty nodes
-   * somewhere nobody chose, and the safe default is the one whose consequence
-   * is visible in the list rather than buried in another product.
+   * Unassigned every time the dialog opens. A destination remembered from the
+   * previous deletion is exactly the state that moves forty nodes somewhere
+   * nobody chose, and the safe default is the one whose consequence is visible
+   * in the list rather than buried in another product.
+   *
+   * Freshness comes from the **caller**, which keys this component on the
+   * product being deleted, so opening it is a mount and `useState`'s initial
+   * value is the reset. The rejected alternative was an effect resetting on
+   * `open` — a `setState` in an effect body, which cascades a second render on
+   * every open and which `react-hooks/set-state-in-effect` rejects outright.
    */
-  useEffect(() => {
-    if (open) setReassignTo(UNASSIGNED);
-  }, [open, product]);
+  const [reassignTo, setReassignTo] = useState<string>(UNASSIGNED);
 
   // The title-or-id fallback is `productDisplayTitle`'s, so a product with no
   // stored title is named identically in the dialog that deletes it and in the

--- a/components/settings/ProductDeleteDialog.tsx
+++ b/components/settings/ProductDeleteDialog.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { ProductDefinition } from "@arkaik/schema";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+/**
+ * Delete a product, and decide what happens to the nodes that named it (§ D3).
+ *
+ * THE COUNT COMES BEFORE THE CHOICE, because it is the whole reason there is a
+ * choice: deleting an empty product is a one-click nothing, and deleting one
+ * with forty views is a decision. So the destination field does not even render
+ * when nothing belongs to the product — an empty deletion should not look like
+ * it has consequences it does not have.
+ *
+ * LEAVING THEM UNASSIGNED IS OFFERED, NOT ASSUMED. Unassigning silently is the
+ * behaviour a delete button without a dialog would have, and it drops data the
+ * user may not know they had: an unassigned flow shows only under All products,
+ * which is triage rather than deletion, but it is still somewhere a node gets
+ * lost. *Rejected* for the same reason: blocking deletion while members exist,
+ * which forces exactly the tedium the bulk-move tool exists to remove.
+ *
+ * BOTH BRANCHES ARE ONE PLAN. This dialog reports a destination and nothing
+ * more — `planProductDeletion` decides what that means and `applyProductPlan`
+ * executes it as two ordered writes. A loop of single-node patches here would
+ * be N chances to half-fail with no way to say what happened.
+ *
+ * THE COUNT IS LIVE, NOT CAPTURED. `memberCount` is derived by the panel from
+ * the node list it is currently rendering, so a refetch while this dialog sits
+ * open moves the number rather than leaving a stale one on screen — and the
+ * plan the confirm builds is computed at that moment from the same list, never
+ * from a snapshot taken at open. The remaining seam (a node changing between
+ * the click and the write) is closed one layer down: `planToOps` drops a
+ * reassignment for a node the map no longer knows rather than patching it from
+ * no prior metadata.
+ */
+
+/** Radix reserves `""` for no-selection, so "leave unassigned" needs a sentinel. */
+const UNASSIGNED = "__unassigned__";
+
+interface ProductDeleteDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  product: ProductDefinition | null;
+  /** How many nodes store this product's id, as of the current node list. */
+  memberCount: number;
+  /** Every other declared product, as reassignment targets. */
+  otherProducts: readonly ProductDefinition[];
+  onConfirm: (reassignTo: string | null) => void;
+  busy?: boolean;
+}
+
+export function ProductDeleteDialog({
+  open,
+  onOpenChange,
+  product,
+  memberCount,
+  otherProducts,
+  onConfirm,
+  busy,
+}: ProductDeleteDialogProps) {
+  const [reassignTo, setReassignTo] = useState<string>(UNASSIGNED);
+
+  /**
+   * Default to unassigned every time the dialog opens. A destination remembered
+   * from the previous deletion is exactly the state that moves forty nodes
+   * somewhere nobody chose, and the safe default is the one whose consequence
+   * is visible in the list rather than buried in another product.
+   */
+  useEffect(() => {
+    if (open) setReassignTo(UNASSIGNED);
+  }, [open, product]);
+
+  const title = displayTitle(product);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete product</DialogTitle>
+          <DialogDescription>
+            {memberCount === 0
+              ? `Nothing belongs to "${title}", so deleting it changes nothing else.`
+              : `${memberCount} node${memberCount === 1 ? "" : "s"} belong${
+                  memberCount === 1 ? "s" : ""
+                } to "${title}".`}
+          </DialogDescription>
+        </DialogHeader>
+
+        {memberCount > 0 && (
+          <div className="flex flex-col gap-1.5">
+            <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Move them to
+            </span>
+            <Select value={reassignTo} onValueChange={setReassignTo} disabled={busy}>
+              <SelectTrigger aria-label="Move nodes to">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={UNASSIGNED}>Leave them unassigned</SelectItem>
+                {otherProducts.map((other) => (
+                  <SelectItem key={other.id} value={other.id}>
+                    {displayTitle(other)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {reassignTo === UNASSIGNED && (
+              <p className="text-xs text-muted-foreground">
+                Unassigned nodes still exist &mdash; they appear under All products until someone
+                gives them a home.
+              </p>
+            )}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="ghost"
+            className="cursor-pointer"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            className="cursor-pointer"
+            disabled={busy}
+            onClick={() => onConfirm(reassignTo === UNASSIGNED ? null : reassignTo)}
+          >
+            {busy ? "Deleting…" : "Delete product"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * The same title-or-id fallback the manager list and `ProductScopeSelector`
+ * use, so a product with no stored `title` is named identically in the dialog
+ * that deletes it and the row it was deleted from.
+ */
+function displayTitle(product: ProductDefinition | null): string {
+  if (!product) return "";
+  return typeof product.title === "string" && product.title.trim() !== ""
+    ? product.title
+    : product.id;
+}

--- a/components/settings/ProductFormDialog.tsx
+++ b/components/settings/ProductFormDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import type { ProductDefinition } from "@arkaik/schema";
 
 import { Button } from "@/components/ui/button";
@@ -72,35 +72,37 @@ export function ProductFormDialog({
   onSave,
   busy,
 }: ProductFormDialogProps) {
-  const [title, setTitle] = useState("");
-  const [description, setDescription] = useState("");
-  const [platforms, setPlatforms] = useState<PlatformId[]>([]);
-
   /**
-   * Re-seed whenever the dialog opens, keyed on `open` as well as on the
-   * product: reopening on the *same* product then discards an abandoned edit
-   * rather than resuming it, and opening "Add product" straight after an edit
-   * cannot inherit the edited title.
+   * Seeded once per opening, from the props the dialog was mounted with.
+   *
+   * Freshness comes from the **caller**, which keys this component on both the
+   * product and the open flag, so every opening is a mount: reopening on the
+   * same product discards an abandoned edit rather than resuming it, and
+   * opening "Add product" straight after an edit cannot inherit the edited
+   * title. *Rejected:* an effect re-seeding on `open` — a `setState` in an
+   * effect body, which paints once with the previous product's values before
+   * correcting itself, and which `react-hooks/set-state-in-effect` rejects. It
+   * also had to depend on `product?.id` rather than on the product object, with
+   * a lint suppression, because a definition is re-derived on every project
+   * write and an identity dependency would clear whatever the user had typed.
+   * A mount has neither problem and needs no suppression.
    *
    * Every read is defensive because a stored definition is only as well-formed
    * as whoever wrote the bundle — `resolveProducts` drops blank and duplicate
    * ids but does not repair a `title` that is a number or a missing `platforms`
    * array, and this form must render it, not crash on it.
    */
-  useEffect(() => {
-    if (!open) return;
-    setTitle(typeof product?.title === "string" ? product.title : "");
-    setDescription(typeof product?.description === "string" ? product.description : "");
-    setPlatforms(
-      Array.isArray(product?.platforms) ? (product.platforms as PlatformId[]).filter(isKnownPlatform) : [],
-    );
-    // Depends on the product's **id**, not on the product object: a definition
-    // is re-derived from `project` on every project write, so an identity
-    // dependency would re-seed — clearing whatever the user had typed — on a
-    // concurrent write to unrelated project metadata. Harmless today only
-    // because the one writer batches its write with this dialog's close.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, product?.id]);
+  const [title, setTitle] = useState(() =>
+    typeof product?.title === "string" ? product.title : "",
+  );
+  const [description, setDescription] = useState(() =>
+    typeof product?.description === "string" ? product.description : "",
+  );
+  const [platforms, setPlatforms] = useState<PlatformId[]>(() =>
+    Array.isArray(product?.platforms)
+      ? (product.platforms as PlatformId[]).filter(isKnownPlatform)
+      : [],
+  );
 
   const editing = product !== null;
   const id = editing ? product.id : deriveProductId(title, existingIds);

--- a/components/settings/ProductFormDialog.tsx
+++ b/components/settings/ProductFormDialog.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { ProductDefinition } from "@arkaik/schema";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { PLATFORMS, type PlatformId } from "@/lib/config/platforms";
+import { deriveProductId, type ProductDraft } from "@/lib/utils/product-editing";
+
+/**
+ * Create or edit one product — title, description, platforms, and nothing else.
+ *
+ * THE IDENTIFIER IS DERIVED ONCE AND FROZEN (§ D2). It is the key every member
+ * node stores in `metadata.product`, so an editable id is not a text field, it
+ * is a multi-node rewrite spanning two stores — and one that can half-fail,
+ * leaving some members pointing at the old key and some at the new. Every node
+ * carrying the old key then resolves to *unassigned* on every read surface,
+ * silently, because a membership naming nothing is indistinguishable from no
+ * membership. Renaming therefore changes `title` alone.
+ *
+ * It is SHOWN rather than hidden, for the same reason `resolveProducts` is
+ * lenient: bundles are hand-editable and agent-editable, and someone writing
+ * `"product": "admin-dashboard"` into a node by hand needs to be able to read
+ * the spelling somewhere. A field they can see but not type into says both
+ * things at once.
+ *
+ * THE JOURNEY ANCHOR IS NOT HERE (§ D7). `root_node_id` picks a node, which is a
+ * graph-picker this dialog has no business growing, and leaving it out is only
+ * safe because {@link upsertProduct} spreads the existing definition first. That
+ * is why this dialog emits a {@link ProductDraft} — a description of the edit —
+ * instead of a `ProductDefinition` it built itself: a fresh object would drop
+ * the anchor, and the user would have no way to notice or to put it back.
+ *
+ * NARROWING PLATFORMS IS ALLOWED (§ D4). The containment rule is a validator
+ * *warning*, never an error, because narrowing a product's platforms is a
+ * product decision that must not fail CI or be blocked by a form. So the
+ * dropped-platform notice below reports and names, and the Save button stays
+ * enabled. *Rejected:* disabling Save until members are cleaned up first, which
+ * makes the manager demand exactly the tedium the bulk-move tool exists to
+ * remove — and makes an honest product decision unexpressible.
+ */
+
+interface ProductFormDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** The product being edited, or `null` to create a new one. */
+  product: ProductDefinition | null;
+  /** Every id already taken, so a derived slug never collides. */
+  existingIds: readonly string[];
+  /** The platforms this product's members actually claim, for the § D4 notice. */
+  memberPlatforms: readonly PlatformId[];
+  onSave: (draft: ProductDraft) => void;
+  /** True while the save is in flight, so the dialog cannot be double-submitted. */
+  busy?: boolean;
+}
+
+export function ProductFormDialog({
+  open,
+  onOpenChange,
+  product,
+  existingIds,
+  memberPlatforms,
+  onSave,
+  busy,
+}: ProductFormDialogProps) {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [platforms, setPlatforms] = useState<PlatformId[]>([]);
+
+  /**
+   * Re-seed whenever the dialog opens, keyed on `open` as well as on the
+   * product: reopening on the *same* product then discards an abandoned edit
+   * rather than resuming it, and opening "Add product" straight after an edit
+   * cannot inherit the edited title.
+   *
+   * Every read is defensive because a stored definition is only as well-formed
+   * as whoever wrote the bundle — `resolveProducts` drops blank and duplicate
+   * ids but does not repair a `title` that is a number or a missing `platforms`
+   * array, and this form must render it, not crash on it.
+   */
+  useEffect(() => {
+    if (!open) return;
+    setTitle(typeof product?.title === "string" ? product.title : "");
+    setDescription(typeof product?.description === "string" ? product.description : "");
+    setPlatforms(
+      Array.isArray(product?.platforms) ? (product.platforms as PlatformId[]).filter(isKnownPlatform) : [],
+    );
+  }, [open, product]);
+
+  const editing = product !== null;
+  const id = editing ? product.id : deriveProductId(title, existingIds);
+
+  /**
+   * The platforms members use that this edit would stop showing. Computed from
+   * what is *stored*, so it names real consequences: `effectiveNodePlatforms`
+   * intersects a node's platforms with its product's, so these nodes keep their
+   * platform data and simply stop displaying it. Saying "keeps them, but they
+   * stop showing" is the whole difference between a reversible decision and one
+   * the user reads as data loss.
+   */
+  const dropped = memberPlatforms.filter((platform) => !platforms.includes(platform));
+
+  function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    if (!title.trim() || busy) return;
+    onSave({ id, title: title.trim(), description, platforms });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{editing ? "Edit product" : "New product"}</DialogTitle>
+          <DialogDescription>
+            A product is one app in this project&rsquo;s family &mdash; an end-user app, an admin
+            dashboard, a public API. They share one graph.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form id="product-form" onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Title
+            </span>
+            <Input
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              placeholder="Admin dashboard"
+              required
+              aria-label="Product title"
+            />
+            <p className="text-xs text-muted-foreground">
+              Identifier: <code>{id || "—"}</code>
+              {editing
+                ? " — fixed once created, because every node in this product stores it."
+                : " — derived from the title, and fixed once created."}
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Description
+            </span>
+            <Input
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              placeholder="What this app is for"
+              aria-label="Product description"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Platforms
+            </span>
+            <div className="flex flex-wrap items-center gap-2">
+              {PLATFORMS.map((platform) => {
+                const selected = platforms.includes(platform.id);
+                return (
+                  <button
+                    key={platform.id}
+                    type="button"
+                    aria-pressed={selected}
+                    onClick={() =>
+                      setPlatforms((previous) =>
+                        previous.includes(platform.id)
+                          ? previous.filter((entry) => entry !== platform.id)
+                          : [...previous, platform.id],
+                      )
+                    }
+                    className={`cursor-pointer rounded-md border px-3 py-1.5 text-sm ${
+                      selected
+                        ? "border-primary bg-primary/10 text-foreground"
+                        : "text-muted-foreground"
+                    }`}
+                  >
+                    {platform.label}
+                  </button>
+                );
+              })}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {platforms.length === 0
+                ? "No platforms: availability is not tracked for this product, and its nodes carry a single status."
+                : "Nodes in this product can only claim these platforms."}
+            </p>
+            {dropped.length > 0 && (
+              <p className="text-xs text-amber-600 dark:text-amber-500">
+                Nodes in this product currently use{" "}
+                {dropped.map((platform) => platformLabel(platform)).join(", ")}. Saving this keeps
+                them, but they stop showing.
+              </p>
+            )}
+          </div>
+        </form>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="ghost"
+            className="cursor-pointer"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            form="product-form"
+            className="cursor-pointer"
+            disabled={!title.trim() || busy}
+          >
+            {busy ? "Saving…" : editing ? "Save" : "Create product"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/** A stored platform this build recognises — anything else is not a toggle. */
+function isKnownPlatform(platform: unknown): platform is PlatformId {
+  return PLATFORMS.some((entry) => entry.id === platform);
+}
+
+/** The human label for a platform id, falling back to the id itself. */
+function platformLabel(platform: PlatformId): string {
+  return PLATFORMS.find((entry) => entry.id === platform)?.label ?? platform;
+}

--- a/components/settings/ProductFormDialog.tsx
+++ b/components/settings/ProductFormDialog.tsx
@@ -13,7 +13,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
-import { PLATFORMS, type PlatformId } from "@/lib/config/platforms";
+import { PLATFORMS, platformLabel, type PlatformId } from "@/lib/config/platforms";
 import { deriveProductId, type ProductDraft } from "@/lib/utils/product-editing";
 
 /**
@@ -94,7 +94,13 @@ export function ProductFormDialog({
     setPlatforms(
       Array.isArray(product?.platforms) ? (product.platforms as PlatformId[]).filter(isKnownPlatform) : [],
     );
-  }, [open, product]);
+    // Depends on the product's **id**, not on the product object: a definition
+    // is re-derived from `project` on every project write, so an identity
+    // dependency would re-seed — clearing whatever the user had typed — on a
+    // concurrent write to unrelated project metadata. Harmless today only
+    // because the one writer batches its write with this dialog's close.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, product?.id]);
 
   const editing = product !== null;
   const id = editing ? product.id : deriveProductId(title, existingIds);
@@ -229,9 +235,4 @@ export function ProductFormDialog({
 /** A stored platform this build recognises — anything else is not a toggle. */
 function isKnownPlatform(platform: unknown): platform is PlatformId {
   return PLATFORMS.some((entry) => entry.id === platform);
-}
-
-/** The human label for a platform id, falling back to the id itself. */
-function platformLabel(platform: PlatformId): string {
-  return PLATFORMS.find((entry) => entry.id === platform)?.label ?? platform;
 }

--- a/components/settings/ProductManagerPanel.tsx
+++ b/components/settings/ProductManagerPanel.tsx
@@ -180,7 +180,28 @@ export function ProductManagerPanel({ projectId, project, updateProject }: Produ
     if (!deleting || deleteBusy || nodesLoading) return;
     const target = deleting;
     setDeleteBusy(true);
-    const plan = planProductDeletion(products, nodes, target.id, reassignTo);
+    /**
+     * Planned against the **stored** array, exactly as `handleSave` is and for
+     * exactly its reason. `plan.products` is written back verbatim, so planning
+     * against `resolveProducts`' output would make deleting product A also drop
+     * the shadowed second copy of a duplicated B — clearing a
+     * `product-duplicate-id` warning by deletion rather than by fix, which is
+     * the harm the save path was hardened against. Two write paths in one
+     * component must not disagree about what the stored array is.
+     *
+     * The plan's own guards are unaffected: a duplicate shares the surviving
+     * entry's id, so `declared` and the destination check read the same answer
+     * from either array. `products` stays the source for the rows, the counts
+     * and the reassignment targets, which are all display of what the app can
+     * actually address.
+     */
+    const stored = project?.project.metadata?.products;
+    const plan = planProductDeletion(
+      Array.isArray(stored) ? stored : [],
+      nodes,
+      target.id,
+      reassignTo,
+    );
     /**
      * Did the membership half commit? `applyProductPlan` reports success or
      * failure for the pair, and the two failures need different sentences: the

--- a/components/settings/ProductManagerPanel.tsx
+++ b/components/settings/ProductManagerPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { PlusIcon } from "lucide-react";
 import { toast } from "sonner";
 import { resolveProducts, type ProductDefinition } from "@arkaik/schema";
@@ -9,7 +9,7 @@ import { ProductDeleteDialog } from "@/components/settings/ProductDeleteDialog";
 import { ProductFormDialog } from "@/components/settings/ProductFormDialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { PLATFORMS, type PlatformId } from "@/lib/config/platforms";
+import { PLATFORMS, platformLabel, type PlatformId } from "@/lib/config/platforms";
 import type { ProjectBundle, ProjectMetadata } from "@/lib/data/types";
 import { useNodes } from "@/lib/hooks/useNodes";
 import { applyProductPlan } from "@/lib/utils/apply-product-plan";
@@ -19,7 +19,7 @@ import {
   upsertProduct,
   type ProductDraft,
 } from "@/lib/utils/product-editing";
-import { platformCountLabel } from "@/lib/utils/product-scope";
+import { platformCountLabel, productDisplayTitle } from "@/lib/utils/product-scope";
 
 /**
  * The Products section of project settings — where a human can finally do what
@@ -58,7 +58,7 @@ interface ProductManagerPanelProps {
 }
 
 export function ProductManagerPanel({ projectId, project, updateProject }: ProductManagerPanelProps) {
-  const { nodes, applyMutations } = useNodes(projectId);
+  const { nodes, loading: nodesLoading, applyMutations } = useNodes(projectId);
 
   const [formOpen, setFormOpen] = useState(false);
   const [editing, setEditing] = useState<ProductDefinition | null>(null);
@@ -67,11 +67,23 @@ export function ProductManagerPanel({ projectId, project, updateProject }: Produ
   const [deleteBusy, setDeleteBusy] = useState(false);
 
   /**
-   * The resolved definitions, which is also what an edit is written back from.
-   * `resolveProducts` drops entries with a blank or duplicate id, so saving here
-   * normalizes those out of the stored array — deliberate, because an entry it
-   * drops is one the whole app already cannot see, and leaving it in the bundle
-   * only preserves something no surface can address or delete.
+   * How many members a *failed* deletion already moved, per product id.
+   *
+   * `applyProductPlan` writes memberships before definitions, so the likely
+   * failure — the project write — leaves the nodes moved and the product still
+   * there. A retry then recomputes the plan, finds no members left, and moves
+   * zero, so without this the success toast would say the product was deleted
+   * and never mention the nodes that changed hands on the first attempt. A ref
+   * rather than state because nothing renders from it; it only makes the final
+   * sentence true.
+   */
+  const alreadyMoved = useRef<Map<string, number>>(new Map());
+
+  /**
+   * The definitions as **resolved**, for everything that reads: rows, counts,
+   * ids, reassignment targets. What an edit is written *back* from is the raw
+   * stored array (see {@link handleSave}) — resolving drops entries, and a save
+   * must not delete one as a side effect of an unrelated rename.
    */
   const products = useMemo(() => resolveProducts(project?.project), [project]);
 
@@ -89,7 +101,12 @@ export function ProductManagerPanel({ projectId, project, updateProject }: Produ
     if (!editing) return [];
     const used = new Set<PlatformId>();
     for (const node of membersOfProduct(nodes, editing.id)) {
-      for (const platform of node.platforms ?? []) used.add(platform);
+      // `Array.isArray` rather than `?? []`: a node's `platforms` is required by
+      // the schema, but this panel reads whatever the store holds, and a bundle
+      // that carries a string or an object there must render the same leniency
+      // every product read gets — not throw and take the settings page with it.
+      if (!Array.isArray(node.platforms)) continue;
+      for (const platform of node.platforms) used.add(platform);
     }
     return PLATFORMS.map((platform) => platform.id).filter((platform) => used.has(platform));
   }, [editing, nodes]);
@@ -97,15 +114,40 @@ export function ProductManagerPanel({ projectId, project, updateProject }: Produ
   /** `planToOps`' input — the freshest node list, never a snapshot taken at open. */
   const nodesById = useMemo(() => new Map(nodes.map((node) => [node.id, node])), [nodes]);
 
+  /**
+   * Create or rename, written back onto the **stored** array rather than the
+   * resolved one.
+   *
+   * Resolving drops entries — blank ids, and every copy after the first of a
+   * duplicated id — so writing the resolved list back would delete them. The
+   * blank-id half of that is harmless (an entry the app cannot address is not
+   * data anyone can lose), but the duplicate half is not: renaming product A
+   * would silently delete the shadowed second copy of B, clearing the
+   * `product-duplicate-id` validator warning by *rename* rather than by fix. A
+   * warning that self-clears is worse than one that stays, because the second
+   * definition is gone and nothing ever said so.
+   *
+   * `upsertProduct` handles the raw array unchanged: it replaces the **first**
+   * match by index, which is exactly `resolveProducts`' first-wins reading, and
+   * its own doc comment already covers the duplicated case. `existingIds` still
+   * comes from the resolved list, which is safe in both directions — a
+   * duplicate shares its id with the entry that shadowed it, and a blank id can
+   * never collide with a derived one.
+   */
   async function handleSave(draft: ProductDraft) {
     if (saving) return;
     setSaving(true);
+    const stored = project?.project.metadata?.products;
     try {
       await updateProject({
-        metadata: { ...(project?.project.metadata ?? {}), products: upsertProduct(products, draft) },
+        metadata: {
+          ...(project?.project.metadata ?? {}),
+          products: upsertProduct(Array.isArray(stored) ? stored : [], draft),
+        },
       });
       toast.success(editing ? `"${draft.title}" was updated.` : `"${draft.title}" was created.`);
       setFormOpen(false);
+      setEditing(null);
     } catch (err) {
       console.error("[ProductManagerPanel] Failed to save product:", err);
       toast.error(err instanceof Error ? err.message : "Could not save this product.");
@@ -120,31 +162,78 @@ export function ProductManagerPanel({ projectId, project, updateProject }: Produ
    * so a refetch in between is reflected instead of overwritten — and
    * `applyProductPlan` owns the ordering of the two writes it spans, which is
    * why neither store is touched directly in this function.
+   *
+   * **IT REFUSES TO RUN BEFORE THE NODES ARE READ.** `useNodes` starts at `[]`
+   * and fills in from an effect, so on a cold settings page there is a window
+   * where every row says "0 nodes" and a deletion confirmed inside it plans
+   * against an empty list: no reassignments, `applyMutations` skipped entirely,
+   * and only the definition removed. That strands every member holding
+   * `metadata.product` for a product nobody declares — verbatim the state
+   * apply-product-plan.ts reorders its two writes to avoid, and the one it calls
+   * worse precisely because every read surface survives it silently. One fast
+   * click reaches it, and nothing undoes it. Confirm-time derivation is no help:
+   * the list is empty at confirm time too. So the guard is the load flag, and it
+   * is mirrored in the button and in the count each row shows, so the UI never
+   * asserts a number it has not read.
    */
   async function handleDelete(reassignTo: string | null) {
-    if (!deleting || deleteBusy) return;
+    if (!deleting || deleteBusy || nodesLoading) return;
     const target = deleting;
     setDeleteBusy(true);
     const plan = planProductDeletion(products, nodes, target.id, reassignTo);
+    /**
+     * Did the membership half commit? `applyProductPlan` reports success or
+     * failure for the pair, and the two failures need different sentences: the
+     * memberships failing changed nothing, while the definitions failing left
+     * the nodes moved. Wrapping the callback is the only way to learn which
+     * from the outside, and it is honest — the wrapper adds no behaviour, it
+     * only records that the call it forwards returned.
+     */
+    let membershipsWritten = false;
     try {
       await applyProductPlan(plan, {
         nodesById,
         projectMetadata: project?.project.metadata,
         updateProject,
-        applyMutations,
+        applyMutations: async (ops) => {
+          const result = await applyMutations(ops);
+          membershipsWritten = true;
+          return result;
+        },
       });
-      const moved = plan.reassignments.length;
+      // Members moved on an earlier failed attempt count towards what the user
+      // is told happened — see `alreadyMoved`.
+      const moved = plan.reassignments.length + (alreadyMoved.current.get(target.id) ?? 0);
+      alreadyMoved.current.delete(target.id);
       toast.success(
         moved === 0
-          ? `"${displayTitle(target)}" was deleted.`
-          : `"${displayTitle(target)}" was deleted; ${moved} node${moved === 1 ? "" : "s"} ${
+          ? `"${productDisplayTitle(target)}" was deleted.`
+          : `"${productDisplayTitle(target)}" was deleted; ${moved} node${moved === 1 ? "" : "s"} ${
               reassignTo === null ? "are now unassigned" : "moved"
             }.`,
       );
       setDeleting(null);
     } catch (err) {
       console.error("[ProductManagerPanel] Failed to delete product:", err);
-      toast.error(err instanceof Error ? err.message : "Could not delete this product.");
+      /**
+       * Memberships are written first, so the failure the user is most likely
+       * to hit — the project write — has already moved the nodes. Reporting
+       * that as "could not delete this product" is true about the product and
+       * false about everything else that just changed. Naming the half that
+       * landed is what makes the retry safe to offer: it recomputes the plan,
+       * finds no members left, and retries the project write alone.
+       */
+      const moved = membershipsWritten ? plan.reassignments.length : 0;
+      if (moved > 0) {
+        alreadyMoved.current.set(target.id, moved + (alreadyMoved.current.get(target.id) ?? 0));
+        toast.error(
+          `"${productDisplayTitle(target)}" was not deleted, but ${moved} node${
+            moved === 1 ? " has" : "s have"
+          } already moved out of it. Try again to finish.`,
+        );
+      } else {
+        toast.error(err instanceof Error ? err.message : "Could not delete this product.");
+      }
     } finally {
       setDeleteBusy(false);
     }
@@ -168,7 +257,7 @@ export function ProductManagerPanel({ projectId, project, updateProject }: Produ
                   className="flex flex-col gap-3 rounded-lg border p-4 sm:flex-row sm:items-center sm:justify-between"
                 >
                   <div className="min-w-0">
-                    <p className="text-sm font-medium">{displayTitle(product)}</p>
+                    <p className="text-sm font-medium">{productDisplayTitle(product)}</p>
                     {typeof product.description === "string" && product.description.trim() !== "" ? (
                       <p className="text-sm text-muted-foreground">{product.description}</p>
                     ) : null}
@@ -178,9 +267,12 @@ export function ProductManagerPanel({ projectId, project, updateProject }: Produ
                           {platformLabel(platform)}
                         </Badge>
                       ))}
+                      {/* "counting…" rather than 0 while the nodes load: a row
+                          that asserts a number it has not read is the same lie
+                          the delete guard exists to stop, one line earlier. */}
                       <span className="text-xs text-muted-foreground">
-                        {platformCountLabel(product.platforms)} &middot; {count} node
-                        {count === 1 ? "" : "s"}
+                        {platformCountLabel(product.platforms)} &middot;{" "}
+                        {nodesLoading ? "counting…" : `${count} node${count === 1 ? "" : "s"}`}
                       </span>
                     </div>
                   </div>
@@ -188,6 +280,7 @@ export function ProductManagerPanel({ projectId, project, updateProject }: Produ
                     <Button
                       variant="outline"
                       className="cursor-pointer"
+                      disabled={saving || deleteBusy}
                       onClick={() => {
                         setEditing(product);
                         setFormOpen(true);
@@ -195,9 +288,13 @@ export function ProductManagerPanel({ projectId, project, updateProject }: Produ
                     >
                       Edit
                     </Button>
+                    {/* Held back until the node list has arrived: a deletion
+                        planned against the empty initial list moves nobody and
+                        strands every member (see `handleDelete`). */}
                     <Button
                       variant="ghost"
                       className="cursor-pointer text-destructive"
+                      disabled={saving || deleteBusy || nodesLoading}
                       onClick={() => setDeleting(product)}
                     >
                       Delete
@@ -233,6 +330,10 @@ export function ProductManagerPanel({ projectId, project, updateProject }: Produ
         onOpenChange={(open) => {
           if (!open && saving) return;
           setFormOpen(open);
+          // Clear the subject with the dialog. `editing` is the panel's "am I
+          // editing?" flag and `handleSave`'s toast reads it, so leaving it set
+          // after a cancel means the flag outlives the dialog it describes.
+          if (!open) setEditing(null);
         }}
         product={editing}
         existingIds={products.map((product) => product.id)}
@@ -256,21 +357,4 @@ export function ProductManagerPanel({ projectId, project, updateProject }: Produ
       />
     </>
   );
-}
-
-/**
- * What to call a product on screen. A stored definition may carry no `title` at
- * all — `resolveProducts` requires an id and nothing else — and falling back to
- * the id is what `ProductScopeSelector` and `productScopeOptions` already do, so
- * the same malformed product reads the same way everywhere.
- */
-function displayTitle(product: ProductDefinition): string {
-  return typeof product.title === "string" && product.title.trim() !== ""
-    ? product.title
-    : product.id;
-}
-
-/** The human label for a stored platform id, echoing an unknown one verbatim. */
-function platformLabel(platform: unknown): string {
-  return PLATFORMS.find((entry) => entry.id === platform)?.label ?? String(platform);
 }

--- a/components/settings/ProductManagerPanel.tsx
+++ b/components/settings/ProductManagerPanel.tsx
@@ -5,13 +5,20 @@ import { PlusIcon } from "lucide-react";
 import { toast } from "sonner";
 import { resolveProducts, type ProductDefinition } from "@arkaik/schema";
 
+import { ProductDeleteDialog } from "@/components/settings/ProductDeleteDialog";
 import { ProductFormDialog } from "@/components/settings/ProductFormDialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { PLATFORMS, type PlatformId } from "@/lib/config/platforms";
 import type { ProjectBundle, ProjectMetadata } from "@/lib/data/types";
 import { useNodes } from "@/lib/hooks/useNodes";
-import { membersOfProduct, upsertProduct, type ProductDraft } from "@/lib/utils/product-editing";
+import { applyProductPlan } from "@/lib/utils/apply-product-plan";
+import {
+  membersOfProduct,
+  planProductDeletion,
+  upsertProduct,
+  type ProductDraft,
+} from "@/lib/utils/product-editing";
 import { platformCountLabel } from "@/lib/utils/product-scope";
 
 /**
@@ -51,11 +58,13 @@ interface ProductManagerPanelProps {
 }
 
 export function ProductManagerPanel({ projectId, project, updateProject }: ProductManagerPanelProps) {
-  const { nodes } = useNodes(projectId);
+  const { nodes, applyMutations } = useNodes(projectId);
 
   const [formOpen, setFormOpen] = useState(false);
   const [editing, setEditing] = useState<ProductDefinition | null>(null);
   const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState<ProductDefinition | null>(null);
+  const [deleteBusy, setDeleteBusy] = useState(false);
 
   /**
    * The resolved definitions, which is also what an edit is written back from.
@@ -85,6 +94,9 @@ export function ProductManagerPanel({ projectId, project, updateProject }: Produ
     return PLATFORMS.map((platform) => platform.id).filter((platform) => used.has(platform));
   }, [editing, nodes]);
 
+  /** `planToOps`' input — the freshest node list, never a snapshot taken at open. */
+  const nodesById = useMemo(() => new Map(nodes.map((node) => [node.id, node])), [nodes]);
+
   async function handleSave(draft: ProductDraft) {
     if (saving) return;
     setSaving(true);
@@ -99,6 +111,42 @@ export function ProductManagerPanel({ projectId, project, updateProject }: Produ
       toast.error(err instanceof Error ? err.message : "Could not save this product.");
     } finally {
       setSaving(false);
+    }
+  }
+
+  /**
+   * Deletion, as ONE plan (§ D3). The plan is computed here at confirm time
+   * from the current `products` and `nodes` rather than when the dialog opened,
+   * so a refetch in between is reflected instead of overwritten — and
+   * `applyProductPlan` owns the ordering of the two writes it spans, which is
+   * why neither store is touched directly in this function.
+   */
+  async function handleDelete(reassignTo: string | null) {
+    if (!deleting || deleteBusy) return;
+    const target = deleting;
+    setDeleteBusy(true);
+    const plan = planProductDeletion(products, nodes, target.id, reassignTo);
+    try {
+      await applyProductPlan(plan, {
+        nodesById,
+        projectMetadata: project?.project.metadata,
+        updateProject,
+        applyMutations,
+      });
+      const moved = plan.reassignments.length;
+      toast.success(
+        moved === 0
+          ? `"${displayTitle(target)}" was deleted.`
+          : `"${displayTitle(target)}" was deleted; ${moved} node${moved === 1 ? "" : "s"} ${
+              reassignTo === null ? "are now unassigned" : "moved"
+            }.`,
+      );
+      setDeleting(null);
+    } catch (err) {
+      console.error("[ProductManagerPanel] Failed to delete product:", err);
+      toast.error(err instanceof Error ? err.message : "Could not delete this product.");
+    } finally {
+      setDeleteBusy(false);
     }
   }
 
@@ -147,6 +195,13 @@ export function ProductManagerPanel({ projectId, project, updateProject }: Produ
                     >
                       Edit
                     </Button>
+                    <Button
+                      variant="ghost"
+                      className="cursor-pointer text-destructive"
+                      onClick={() => setDeleting(product)}
+                    >
+                      Delete
+                    </Button>
                   </div>
                 </li>
               );
@@ -184,6 +239,20 @@ export function ProductManagerPanel({ projectId, project, updateProject }: Produ
         memberPlatforms={memberPlatforms}
         onSave={(draft) => void handleSave(draft)}
         busy={saving}
+      />
+
+      <ProductDeleteDialog
+        open={deleting !== null}
+        onOpenChange={(open) => {
+          if (!open && !deleteBusy) setDeleting(null);
+        }}
+        product={deleting}
+        // Read from the live counts, so the number moves with a refetch rather
+        // than freezing at whatever it was when the dialog opened.
+        memberCount={deleting ? memberCounts[deleting.id] ?? 0 : 0}
+        otherProducts={products.filter((product) => product.id !== deleting?.id)}
+        onConfirm={(reassignTo) => void handleDelete(reassignTo)}
+        busy={deleteBusy}
       />
     </>
   );

--- a/components/settings/ProductManagerPanel.tsx
+++ b/components/settings/ProductManagerPanel.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { PlusIcon } from "lucide-react";
+import { toast } from "sonner";
+import { resolveProducts, type ProductDefinition } from "@arkaik/schema";
+
+import { ProductFormDialog } from "@/components/settings/ProductFormDialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { PLATFORMS, type PlatformId } from "@/lib/config/platforms";
+import type { ProjectBundle, ProjectMetadata } from "@/lib/data/types";
+import { useNodes } from "@/lib/hooks/useNodes";
+import { membersOfProduct, upsertProduct, type ProductDraft } from "@/lib/utils/product-editing";
+import { platformCountLabel } from "@/lib/utils/product-scope";
+
+/**
+ * The Products section of project settings — where a human can finally do what
+ * only an agent could before: name the apps this project describes.
+ *
+ * Definitions are project metadata, so creating or renaming one is a single
+ * `updateProject`. Only *deletion* touches nodes, and only deletion goes through
+ * `applyProductPlan`.
+ *
+ * THE EMPTY STATE IS THE DEGENERATE-CASE GUARANTEE. A project that declares no
+ * products must look and behave exactly as it did before products existed, so
+ * this section is present (it is how the first product gets created) but
+ * introduces no vocabulary until one exists: no scope selector, no product
+ * column, no membership field anywhere else in the app. The prose here is the
+ * only place a user with zero products meets the word.
+ *
+ * IT READS NODES, WHICH THE SETTINGS PAGE OTHERWISE DOES NOT. The member count
+ * on each row and the reassignment a deletion offers are both about stored
+ * `metadata.product`, so this panel needs the node list — but nothing else on
+ * the settings page does, and threading `nodes` plus `applyMutations` through
+ * the page would make an otherwise node-free route look like a graph surface.
+ * So the hook is called here. *Rejected:* counting members lazily when the
+ * delete dialog opens, which is the same fetch a moment later and leaves the
+ * list unable to say which products are actually in use.
+ */
+
+interface ProductManagerPanelProps {
+  projectId: string;
+  project: ProjectBundle | undefined;
+  /**
+   * `useProject`'s updater, narrowed to the one patch this panel sends. The hook
+   * accepts any project-level field; naming only `metadata` here documents that
+   * a product edit never touches anything else about the project.
+   */
+  updateProject: (patch: { metadata: ProjectMetadata }) => Promise<unknown>;
+}
+
+export function ProductManagerPanel({ projectId, project, updateProject }: ProductManagerPanelProps) {
+  const { nodes } = useNodes(projectId);
+
+  const [formOpen, setFormOpen] = useState(false);
+  const [editing, setEditing] = useState<ProductDefinition | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  /**
+   * The resolved definitions, which is also what an edit is written back from.
+   * `resolveProducts` drops entries with a blank or duplicate id, so saving here
+   * normalizes those out of the stored array — deliberate, because an entry it
+   * drops is one the whole app already cannot see, and leaving it in the bundle
+   * only preserves something no surface can address or delete.
+   */
+  const products = useMemo(() => resolveProducts(project?.project), [project]);
+
+  /** Stored membership only — the count a deletion would have to answer for. */
+  const memberCounts = useMemo<Record<string, number>>(
+    () =>
+      Object.fromEntries(
+        products.map((product) => [product.id, membersOfProduct(nodes, product.id).length]),
+      ),
+    [nodes, products],
+  );
+
+  /** The platforms the edited product's members claim — the § D4 notice's input. */
+  const memberPlatforms = useMemo<PlatformId[]>(() => {
+    if (!editing) return [];
+    const used = new Set<PlatformId>();
+    for (const node of membersOfProduct(nodes, editing.id)) {
+      for (const platform of node.platforms ?? []) used.add(platform);
+    }
+    return PLATFORMS.map((platform) => platform.id).filter((platform) => used.has(platform));
+  }, [editing, nodes]);
+
+  async function handleSave(draft: ProductDraft) {
+    if (saving) return;
+    setSaving(true);
+    try {
+      await updateProject({
+        metadata: { ...(project?.project.metadata ?? {}), products: upsertProduct(products, draft) },
+      });
+      toast.success(editing ? `"${draft.title}" was updated.` : `"${draft.title}" was created.`);
+      setFormOpen(false);
+    } catch (err) {
+      console.error("[ProductManagerPanel] Failed to save product:", err);
+      toast.error(err instanceof Error ? err.message : "Could not save this product.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <>
+      <div className="flex flex-col gap-3">
+        {products.length === 0 ? (
+          <p className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
+            This project describes one product. Add another &mdash; an admin dashboard, a public
+            API, a CLI &mdash; and every page gains a scope selector for moving between them.
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {products.map((product) => {
+              const count = memberCounts[product.id] ?? 0;
+              return (
+                <li
+                  key={product.id}
+                  className="flex flex-col gap-3 rounded-lg border p-4 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium">{displayTitle(product)}</p>
+                    {typeof product.description === "string" && product.description.trim() !== "" ? (
+                      <p className="text-sm text-muted-foreground">{product.description}</p>
+                    ) : null}
+                    <div className="mt-2 flex flex-wrap items-center gap-1.5">
+                      {(Array.isArray(product.platforms) ? product.platforms : []).map((platform) => (
+                        <Badge key={String(platform)} variant="secondary">
+                          {platformLabel(platform)}
+                        </Badge>
+                      ))}
+                      <span className="text-xs text-muted-foreground">
+                        {platformCountLabel(product.platforms)} &middot; {count} node
+                        {count === 1 ? "" : "s"}
+                      </span>
+                    </div>
+                  </div>
+                  <div className="flex shrink-0 items-center gap-2">
+                    <Button
+                      variant="outline"
+                      className="cursor-pointer"
+                      onClick={() => {
+                        setEditing(product);
+                        setFormOpen(true);
+                      }}
+                    >
+                      Edit
+                    </Button>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+
+        <div>
+          <Button
+            variant="outline"
+            className="cursor-pointer"
+            // Disabled until the bundle is loaded: `updateProject` throws
+            // outright before then, and a create that cannot be written is
+            // better refused than reported as an error the user caused.
+            disabled={!project || saving}
+            onClick={() => {
+              setEditing(null);
+              setFormOpen(true);
+            }}
+          >
+            <PlusIcon className="size-4" />
+            Add product
+          </Button>
+        </div>
+      </div>
+
+      <ProductFormDialog
+        open={formOpen}
+        onOpenChange={(open) => {
+          if (!open && saving) return;
+          setFormOpen(open);
+        }}
+        product={editing}
+        existingIds={products.map((product) => product.id)}
+        memberPlatforms={memberPlatforms}
+        onSave={(draft) => void handleSave(draft)}
+        busy={saving}
+      />
+    </>
+  );
+}
+
+/**
+ * What to call a product on screen. A stored definition may carry no `title` at
+ * all — `resolveProducts` requires an id and nothing else — and falling back to
+ * the id is what `ProductScopeSelector` and `productScopeOptions` already do, so
+ * the same malformed product reads the same way everywhere.
+ */
+function displayTitle(product: ProductDefinition): string {
+  return typeof product.title === "string" && product.title.trim() !== ""
+    ? product.title
+    : product.id;
+}
+
+/** The human label for a stored platform id, echoing an unknown one verbatim. */
+function platformLabel(platform: unknown): string {
+  return PLATFORMS.find((entry) => entry.id === platform)?.label ?? String(platform);
+}

--- a/components/settings/ProductManagerPanel.tsx
+++ b/components/settings/ProductManagerPanel.tsx
@@ -347,6 +347,11 @@ export function ProductManagerPanel({ projectId, project, updateProject }: Produ
       </div>
 
       <ProductFormDialog
+        // Keyed on the subject AND on the open flag, so every opening is a
+        // mount and the fields seed themselves from the product being edited.
+        // Including `formOpen` is what makes reopening on the *same* product
+        // discard an abandoned edit instead of resuming it.
+        key={`${editing?.id ?? "new"}:${formOpen}`}
         open={formOpen}
         onOpenChange={(open) => {
           if (!open && saving) return;
@@ -364,6 +369,9 @@ export function ProductManagerPanel({ projectId, project, updateProject }: Produ
       />
 
       <ProductDeleteDialog
+        // Keyed on the product, so opening the dialog mounts it fresh — that
+        // mount is what resets the destination select to Unassigned.
+        key={deleting?.id ?? "none"}
         open={deleting !== null}
         onOpenChange={(open) => {
           if (!open && !deleteBusy) setDeleting(null);

--- a/docs/rfcs/products.md
+++ b/docs/rfcs/products.md
@@ -6,17 +6,26 @@ order: 91
 
 # RFC: Products — multi-product projects and per-product platform availability
 
-> Status: **Decided and shipped through P2.** [Option A](#a-products-as-project-level-definitions-nodes-carry-membership-platforms-constrained-by-product--recommended)
+> Status: **Decided and shipped through P3.** [Option A](#a-products-as-project-level-definitions-nodes-carry-membership-platforms-constrained-by-product--recommended)
 > was adopted as recommended — products as project-level definitions, membership
 > stored on flows and views, derived for acceptances and the system layer,
 > platform-less products per decision 2, and the degenerate-case guarantee.
 > P0 (spec), P1 (schema package) and P2 (every read surface) have shipped, along
 > with P4's dogfood half — the Pebbles seed carries a web-only Admin product, and
-> the plugin skill teaches the membership rules. **P3 (editing UI) and the
-> per-surface override have not**, so products remain authorable only by an agent
-> or by hand-editing a bundle.
-> Design spec: [`docs/superpowers/specs/2026-08-02-multi-product-projects-design.md`](../superpowers/specs/2026-08-02-multi-product-projects-design.md).
-> Implementation plan: [`docs/superpowers/plans/2026-08-02-multi-product-projects.md`](../superpowers/plans/2026-08-02-multi-product-projects.md).
+> the plugin skill teaches the membership rules. **P3 (editing UI) has now
+> shipped too**: products are created, renamed, re-platformed and deleted from
+> project settings, assigned from the node and acceptance forms, and moved in
+> bulk from the Library. Products no longer require an agent or a hand-edited
+> bundle.
+>
+> **Two things remain.** The per-surface product override is still deferred, and
+> there is no UI for a product's `root_node_id` — a product created in the app
+> therefore has no journey anchor until one is set by hand, and its Journey page
+> says so rather than borrowing the project's front door.
+> Design spec: [`docs/superpowers/specs/2026-08-02-multi-product-projects-design.md`](../superpowers/specs/2026-08-02-multi-product-projects-design.md);
+> P3's own: [`docs/superpowers/specs/2026-08-02-product-management-ui-design.md`](../superpowers/specs/2026-08-02-product-management-ui-design.md).
+> Implementation plan: [`docs/superpowers/plans/2026-08-02-multi-product-projects.md`](../superpowers/plans/2026-08-02-multi-product-projects.md);
+> P3's own: [`docs/superpowers/plans/2026-08-02-product-management-ui.md`](../superpowers/plans/2026-08-02-product-management-ui.md).
 > Normative format: [`docs/spec/bundle-format.md`](../spec/bundle-format.md) § Products;
 > model overview: [`docs/graph-model.md`](../graph-model.md) § Products.
 >
@@ -238,9 +247,10 @@ Sizes as in vision.md (S/M/L).
   platforms; product badge + filter in Library; product grouping/filter on
   Delivery, Pyramid, Acceptances matrix; `MapDefinition.product` scope;
   per-product journey anchors.
-- **P3 — Editing (M)**: product manager in project settings (create, rename,
-  set platforms, delete-with-reassign); product picker in node forms; bulk
-  "move to product".
+- **P3 — Editing (M)** — *shipped.* Product manager in project settings (create,
+  rename, set platforms, delete-with-reassign); product picker in node forms;
+  bulk "move to product". A product's `root_node_id` was left out and is the one
+  piece still only reachable by hand.
 - **P4 — Toolchain & dogfood (S)**: CLI surfaces products in `validate`/`log`;
   plugin skill teaches membership rules; seed Pebbles gains an Admin product
   (web-only) so the degenerate and constrained paths are both exercised by

--- a/docs/superpowers/plans/2026-08-02-product-management-ui.md
+++ b/docs/superpowers/plans/2026-08-02-product-management-ui.md
@@ -958,7 +958,7 @@ In the JSX, insert the picker immediately after the Species field and before the
 - [ ] **Step 6: Verify types compile**
 
 Run: `npx tsc --noEmit -p tsconfig.json`
-Expected: no new errors. The five call sites still compile because `products` and `defaultProductId` are optional and default to the pre-products behaviour.
+Expected: no new errors. The four call sites still compile because `products` and `defaultProductId` are optional and default to the pre-products behaviour.
 
 - [ ] **Step 7: Commit**
 
@@ -969,7 +969,7 @@ git commit -m "feat: create a node into the product you are standing in"
 
 ---
 
-## Task 4: Thread products into all five call sites
+## Task 4: Thread products into all four call sites
 
 **Files:**
 - Modify: `app/project/[id]/library/page.tsx`

--- a/docs/superpowers/plans/2026-08-02-product-management-ui.md
+++ b/docs/superpowers/plans/2026-08-02-product-management-ui.md
@@ -1,0 +1,2148 @@
+# Product Management UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make products creatable, editable, deletable and assignable from the UI, so a human never has to edit bundle JSON to use them.
+
+**Architecture:** A pure rules module (`lib/utils/product-editing.ts`) owns every product-editing rule and returns *plans*; one thin async executor (`lib/utils/apply-product-plan.ts`) runs a plan against the two stores; three UI surfaces (settings manager, node-form picker, Library bulk bar) compute nothing. This mirrors `lib/utils/product-scope.ts`, and is what makes the logic testable on a machine with no local Postgres.
+
+**Tech Stack:** Next.js 15 App Router, React 19, TypeScript, Tailwind + shadcn/Radix primitives, `@arkaik/schema` workspace package, plain-Node test scripts (`node tests/app/*.test.js`) with a TypeScript-transpiling loader.
+
+**Spec:** [`docs/superpowers/specs/2026-08-02-product-management-ui-design.md`](../specs/2026-08-02-product-management-ui-design.md). Decisions are referenced as **D1**–**D7** throughout.
+
+---
+
+## Background the engineer needs
+
+**What a product is.** A project can describe a family of apps sharing one graph. Definitions live in `project.metadata.products` as `ProductDefinition[]` (`{ id, title, description?, platforms: PlatformId[], root_node_id? }`). Membership lives on the node as `node.metadata.product: string`.
+
+**Only three species store membership** — `flow`, `view`, `acceptance` (the constant `PRODUCT_MEMBERSHIP_SPECIES` in `packages/schema/src/products.ts`). Data models and API endpoints *derive* theirs from who consumes them and must never be offered the control.
+
+**Everything is lenient.** `resolveProducts()` drops blank and duplicate ids rather than throwing. The validator emits *warnings*, never errors, for product problems. Nothing in this plan may make a malformed product fail anything.
+
+**The degenerate-case guarantee.** A project that declares no products must look and behave exactly as it did before products existed. Every new control in this plan is therefore conditional on `products.length > 0`. This is asserted, not eyeballed.
+
+**Reading order before you start:** `packages/schema/src/products.ts`, then `lib/utils/product-scope.ts`, then `tests/app/product-scope.test.js` and its loader `tests/app/load-product-scope.js`.
+
+## File Structure
+
+**Create:**
+
+| Path | Responsibility |
+|---|---|
+| `lib/utils/product-editing.ts` | Every product-editing rule, pure. Slugs, upsert/remove, plans, platform menus. No React, no provider, no zod. |
+| `lib/utils/apply-product-plan.ts` | The one write that spans `updateProject` and `applyMutations`. |
+| `tests/app/load-product-editing.js` | Transpiles the two modules above into a plain Node process. |
+| `tests/app/product-editing.test.js` | The DB-free suite for the rules. |
+| `components/panels/ProductPicker.tsx` | One product `<Select>`, used by three forms. |
+| `components/settings/ProductManagerPanel.tsx` | The Products section of project settings: list, create, edit, delete. |
+| `components/settings/ProductFormDialog.tsx` | Create/edit dialog (title, description, platforms). |
+| `components/settings/ProductDeleteDialog.tsx` | Delete-with-reassign confirmation. |
+| `components/library/LibrarySelectionBar.tsx` | The bulk action bar. |
+
+**Modify:**
+
+| Path | Change |
+|---|---|
+| `components/panels/NewNodeForm.tsx` | Product field + platform constraint (D1, D4). |
+| `app/project/[id]/library/page.tsx` | Thread products into the form; selection state; bulk bar. |
+| `app/project/[id]/delivery/page.tsx`, `app/project/[id]/acceptances/page.tsx`, `components/maps/JourneyMap.tsx`, `components/maps/SystemMap.tsx` | Thread `products` / `defaultProductId` into `NewNodeForm`. |
+| `components/panels/NodeDetailPanel.tsx` | Product picker on the edit path. |
+| `components/panels/AcceptanceEditor.tsx` | Product picker with anchor explanation (D5). |
+| `components/library/NodeCard.tsx`, `components/library/NodeTable.tsx` | Optional selection checkbox. |
+| `app/project/[id]/settings/page.tsx` | Render `ProductManagerPanel`. |
+| `package.json`, `.github/workflows/ci.yml` | Wire `test:product-editing`. |
+| `docs/rfcs/products.md` | Mark P3 shipped. |
+
+---
+
+## Task 1: The rules module
+
+**Files:**
+- Create: `lib/utils/product-editing.ts`
+- Create: `tests/app/load-product-editing.js`
+- Create: `tests/app/product-editing.test.js`
+- Modify: `package.json`, `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Write the test loader**
+
+Create `tests/app/load-product-editing.js`. This follows the `tests/app/load-*.js` idiom exactly — transpile TypeScript to CommonJS, rewrite the `@/` alias, point `@arkaik/schema` at the schema package's own test build.
+
+```js
+/**
+ * Loads lib/utils/product-editing.ts and lib/utils/apply-product-plan.ts into a
+ * plain Node process, following the tests/app/load-*.js idiom.
+ *
+ * Both modules are deliberately React-free and provider-free, which is the
+ * whole reason the product-editing rules live there rather than inside the
+ * components that call them: this repo has no component test runner, and a rule
+ * inside a dialog is a rule nothing can assert.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const ts = require("typescript");
+const { loadSchema, BUILD_DIR: SCHEMA_BUILD_DIR } = require("../schema/load-schema");
+
+const ROOT = path.join(__dirname, "..", "..");
+const BUILD_DIR = path.join(__dirname, ".test-build-product-editing");
+
+const MODULES = [
+  // PLATFORMS is imported as a *value* (it is the canonical platform order), so
+  // the config module has to exist on disk for the require to resolve.
+  ["lib/config/platforms.ts", "platforms"],
+  ["lib/utils/product-editing.ts", "product-editing"],
+  ["lib/utils/apply-product-plan.ts", "apply-product-plan"],
+];
+
+function loadProductEditing() {
+  loadSchema();
+
+  fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+  fs.mkdirSync(BUILD_DIR, { recursive: true });
+  fs.writeFileSync(path.join(BUILD_DIR, "package.json"), JSON.stringify({ type: "commonjs" }));
+
+  const schemaIndex = path.join(SCHEMA_BUILD_DIR, "index.js");
+
+  for (const [srcRel, outName] of MODULES) {
+    const source = fs.readFileSync(path.join(ROOT, srcRel), "utf8");
+    const { outputText } = ts.transpileModule(source, {
+      fileName: path.basename(srcRel),
+      compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2020, esModuleInterop: true },
+    });
+
+    const rewritten = outputText
+      .replace(/require\((['"])@arkaik\/schema\1\)/g, `require(${JSON.stringify(schemaIndex)})`)
+      .replace(/require\((['"])@\/lib\/config\/platforms\1\)/g, `require("./platforms.js")`)
+      .replace(/require\((['"])\.\/product-editing\1\)/g, `require("./product-editing.js")`);
+    fs.writeFileSync(path.join(BUILD_DIR, `${outName}.js`), rewritten);
+  }
+
+  for (const [, outName] of MODULES) {
+    delete require.cache[path.join(BUILD_DIR, `${outName}.js`)];
+  }
+
+  return {
+    ...require(path.join(BUILD_DIR, "product-editing.js")),
+    ...require(path.join(BUILD_DIR, "apply-product-plan.js")),
+  };
+}
+
+module.exports = { loadProductEditing, BUILD_DIR };
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/app/product-editing.test.js`. Match the house style of `tests/app/product-scope.test.js`: a `#!/usr/bin/env node` shebang, a doc comment explaining what is load-bearing, `node:assert/strict`, and a small `test()` harness. Copy the harness shape from the existing file — read it first.
+
+```js
+#!/usr/bin/env node
+
+/**
+ * Product editing rules (lib/utils/product-editing.ts).
+ *
+ * The load-bearing assertions are the two that a component could not be made to
+ * make: that `planProductMove` silently skips the species which *derive*
+ * membership (moving a data model would write a key every read surface ignores),
+ * and that with no products declared no plan changes anything — the degenerate
+ * case guarantee, which is the whole reason products stayed opt-in.
+ */
+
+const assert = require("node:assert/strict");
+const { loadProductEditing } = require("./load-product-editing");
+
+const {
+  deriveProductId,
+  upsertProduct,
+  removeProduct,
+  membersOfProduct,
+  planProductDeletion,
+  planProductMove,
+  planToOps,
+  platformMenuFor,
+  constrainPlatforms,
+  withProductMembership,
+} = loadProductEditing();
+
+let failures = 0;
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ok - ${name}`);
+  } catch (err) {
+    failures += 1;
+    console.error(`  not ok - ${name}`);
+    console.error(`    ${err.message}`);
+  }
+}
+
+const PRODUCTS = [
+  { id: "app", title: "End-user app", platforms: ["web", "ios", "android"], root_node_id: "F-onboarding" },
+  { id: "admin", title: "Admin", platforms: ["web"] },
+  { id: "api", title: "Public API", platforms: [] },
+];
+
+const NODES = [
+  { id: "V-home", species: "view", metadata: { product: "admin", note: "keep me" } },
+  { id: "V-list", species: "view", metadata: { product: "admin" } },
+  { id: "F-signup", species: "flow", metadata: { product: "app" } },
+  { id: "D-user", species: "data-model", metadata: {} },
+  { id: "A-loads", species: "acceptance", metadata: {} },
+];
+
+console.log("product-editing");
+
+test("deriveProductId slugifies a title", () => {
+  assert.equal(deriveProductId("Admin dashboard", []), "admin-dashboard");
+});
+
+test("deriveProductId strips accents and punctuation", () => {
+  assert.equal(deriveProductId("Créateur (bêta)!", []), "createur-beta");
+});
+
+test("deriveProductId suffixes a collision rather than colliding", () => {
+  assert.equal(deriveProductId("Admin", ["admin"]), "admin-2");
+  assert.equal(deriveProductId("Admin", ["admin", "admin-2"]), "admin-3");
+});
+
+test("deriveProductId never returns a blank id", () => {
+  // resolveProducts DROPS blank ids, so a blank slug is not a product at all.
+  assert.equal(deriveProductId("!!!", []), "product");
+  assert.equal(deriveProductId("", ["product"]), "product-2");
+});
+
+test("upsertProduct appends a new product in declaration order", () => {
+  const next = upsertProduct(PRODUCTS, { id: "cli", title: "CLI", platforms: [] });
+  assert.deepEqual(next.map((p) => p.id), ["app", "admin", "api", "cli"]);
+});
+
+test("upsertProduct edits in place and preserves root_node_id", () => {
+  // D7 does not expose the anchor, which makes destroying it the live risk.
+  const next = upsertProduct(PRODUCTS, { id: "app", title: "The app", platforms: ["web"] });
+  assert.deepEqual(next.map((p) => p.id), ["app", "admin", "api"]);
+  assert.equal(next[0].title, "The app");
+  assert.equal(next[0].root_node_id, "F-onboarding");
+  assert.deepEqual(next[0].platforms, ["web"]);
+});
+
+test("upsertProduct orders platforms canonically and drops a blank description", () => {
+  const next = upsertProduct([], { id: "x", title: "X", description: "   ", platforms: ["android", "web"] });
+  assert.deepEqual(next[0].platforms, ["web", "android"]);
+  assert.equal("description" in next[0], false);
+});
+
+test("membersOfProduct sees stored membership only", () => {
+  assert.deepEqual(membersOfProduct(NODES, "admin").map((n) => n.id), ["V-home", "V-list"]);
+});
+
+test("planProductDeletion reassigns every member", () => {
+  const plan = planProductDeletion(PRODUCTS, NODES, "admin", "app");
+  assert.deepEqual(plan.products.map((p) => p.id), ["app", "api"]);
+  assert.deepEqual(plan.reassignments, [
+    { nodeId: "V-home", product: "app" },
+    { nodeId: "V-list", product: "app" },
+  ]);
+});
+
+test("planProductDeletion can leave members unassigned", () => {
+  const plan = planProductDeletion(PRODUCTS, NODES, "admin", null);
+  assert.deepEqual(plan.reassignments.map((r) => r.product), [null, null]);
+});
+
+test("planProductDeletion of an empty product touches no node", () => {
+  const plan = planProductDeletion(PRODUCTS, NODES, "api", null);
+  assert.deepEqual(plan.reassignments, []);
+});
+
+test("planProductMove skips the species that derive membership", () => {
+  const plan = planProductMove(NODES, ["V-home", "D-user", "A-loads"], "app");
+  assert.deepEqual(plan.reassignments, [
+    { nodeId: "V-home", product: "app" },
+    { nodeId: "A-loads", product: "app" },
+  ]);
+  assert.equal(plan.products, null);
+});
+
+test("planProductMove skips nodes already in the target", () => {
+  const plan = planProductMove(NODES, ["V-home", "V-list", "F-signup"], "admin");
+  assert.deepEqual(plan.reassignments, [{ nodeId: "F-signup", product: "admin" }]);
+});
+
+test("planProductMove to null unassigns", () => {
+  const plan = planProductMove(NODES, ["V-home"], null);
+  assert.deepEqual(plan.reassignments, [{ nodeId: "V-home", product: null }]);
+});
+
+test("withProductMembership removes the key rather than blanking it", () => {
+  assert.deepEqual(withProductMembership({ product: "admin", note: "keep me" }, null), { note: "keep me" });
+  assert.deepEqual(withProductMembership(undefined, "app"), { product: "app" });
+});
+
+test("planToOps patches metadata and preserves the rest of it", () => {
+  const nodesById = new Map(NODES.map((n) => [n.id, n]));
+  const ops = planToOps(planProductMove(NODES, ["V-home"], null), nodesById);
+  assert.deepEqual(ops, [
+    { op: "update_node", node_id: "V-home", patch: { metadata: { note: "keep me" } } },
+  ]);
+});
+
+test("platformMenuFor: a product's own menu, canonically ordered", () => {
+  assert.deepEqual(platformMenuFor({ id: "a", title: "A", platforms: ["android", "web"] }), ["web", "android"]);
+});
+
+test("platformMenuFor: a platform-less product has an empty menu", () => {
+  // Arity 0 — availability is not a tracked dimension. The form shows no toggles.
+  assert.deepEqual(platformMenuFor(PRODUCTS[2]), []);
+});
+
+test("platformMenuFor: unassigned means every platform", () => {
+  assert.deepEqual(platformMenuFor(null), ["web", "ios", "android"]);
+  assert.deepEqual(platformMenuFor({ id: "junk", title: "Junk" }), ["web", "ios", "android"]);
+});
+
+test("constrainPlatforms prunes a selection the product forbids", () => {
+  assert.deepEqual(constrainPlatforms(["web", "ios"], ["web"]), ["web"]);
+  assert.deepEqual(constrainPlatforms(["ios", "web"], ["web", "ios", "android"]), ["web", "ios"]);
+  assert.deepEqual(constrainPlatforms(["web"], []), []);
+});
+
+test("degenerate case: with no products declared, no plan changes anything", () => {
+  const plan = planProductDeletion([], NODES, "nope", null);
+  assert.deepEqual(plan.products, []);
+  assert.deepEqual(plan.reassignments, []);
+  assert.deepEqual(planToOps(plan, new Map()), []);
+});
+
+console.log(failures === 0 ? "\nAll product-editing tests passed" : `\n${failures} failing`);
+process.exit(failures === 0 ? 0 : 1);
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `node tests/app/product-editing.test.js`
+Expected: FAIL — `Cannot find module` for `lib/utils/product-editing.ts`, because the module does not exist yet.
+
+- [ ] **Step 4: Write `lib/utils/product-editing.ts`**
+
+```ts
+/**
+ * The rules for *editing* products, as pure functions over plain data.
+ *
+ * The read side already works this way (lib/utils/product-scope.ts) and this is
+ * its mirror: the schema package owns what a product *means*, this module owns
+ * what an edit to one *does*, and no component here computes either.
+ *
+ * Every destructive operation returns a **plan** rather than performing itself.
+ * That is not ceremony — a product deletion touches the project's metadata and
+ * an arbitrary number of nodes across two different stores, and a plan is the
+ * only form of that operation which can be asserted on a machine with no
+ * database and no component test runner.
+ *
+ * Deliberately React-free and provider-free for the same reason.
+ */
+
+import { PLATFORMS, type PlatformId } from "@/lib/config/platforms";
+import type { Node, NodeMetadata } from "@/lib/data/types";
+import {
+  PRODUCT_MEMBERSHIP_SPECIES,
+  productOf,
+  type ProductDefinition,
+} from "@arkaik/schema";
+
+/** The canonical platform order, which every list this module emits follows. */
+const PLATFORM_ORDER: readonly PlatformId[] = PLATFORMS.map((platform) => platform.id);
+
+/** The minimum shape this module needs of a node — never the whole thing. */
+type NodeLike = Pick<Node, "id" | "species" | "metadata">;
+
+/**
+ * Kebab-case, ASCII, no leading or trailing dash. Accents are folded rather
+ * than dropped so that "Créateur" becomes "createur" and not "cr-ateur".
+ */
+export function slugifyProductTitle(title: string): string {
+  return title
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * The durable key a product is known by, derived once at create time and never
+ * changed afterwards (§ D2).
+ *
+ * **It can never be blank.** `resolveProducts` treats a blank id as *not a
+ * declaration* and drops the entry, so a title of "!!!" slugging to "" would
+ * produce a product that the app cannot see and the user cannot delete. The
+ * `product` fallback is what keeps that unreachable.
+ */
+export function deriveProductId(title: string, existingIds: readonly string[]): string {
+  const taken = new Set(existingIds);
+  const base = slugifyProductTitle(title) || "product";
+  if (!taken.has(base)) return base;
+
+  let suffix = 2;
+  while (taken.has(`${base}-${suffix}`)) suffix += 1;
+  return `${base}-${suffix}`;
+}
+
+/** What the create/edit dialog collects. The id is derived, never typed. */
+export interface ProductDraft {
+  id: string;
+  title: string;
+  description?: string;
+  platforms: PlatformId[];
+}
+
+/**
+ * The draft written into the definitions array — appended when new, replaced in
+ * place when it already exists, so declaration order (which is the order the
+ * scope selector renders) never shuffles under an edit.
+ *
+ * The existing definition is **spread first**, which is what preserves
+ * `root_node_id`. The manager does not expose the journey anchor (§ D7), so an
+ * edit that dropped it would silently un-anchor a product's journey and the user
+ * would have no way to tell, let alone put it back.
+ */
+export function upsertProduct(
+  products: readonly ProductDefinition[],
+  draft: ProductDraft,
+): ProductDefinition[] {
+  const existing = products.find((product) => product.id === draft.id);
+  const description = draft.description?.trim();
+
+  const next: ProductDefinition = {
+    ...(existing ?? {}),
+    id: draft.id,
+    title: draft.title.trim(),
+    platforms: PLATFORM_ORDER.filter((platform) => draft.platforms.includes(platform)),
+  };
+
+  if (description) next.description = description;
+  else delete next.description;
+
+  if (!existing) return [...products, next];
+  return products.map((product) => (product.id === draft.id ? next : product));
+}
+
+/** The definitions without this one. Membership is {@link planProductDeletion}'s job. */
+export function removeProduct(
+  products: readonly ProductDefinition[],
+  id: string,
+): ProductDefinition[] {
+  return products.filter((product) => product.id !== id);
+}
+
+/**
+ * Nodes whose **stored** `metadata.product` names this product.
+ *
+ * Stored, never derived, and the distinction matters: an acceptance covering an
+ * admin view *reads* as admin everywhere, but its membership is its anchors'
+ * and deleting the product cannot orphan a key it never had. Only a stored key
+ * can go stale, so only stored keys are what a deletion has to answer for.
+ */
+export function membersOfProduct<N extends NodeLike>(
+  nodes: readonly N[],
+  productId: string,
+): N[] {
+  return nodes.filter((node) => productOf(node) === productId);
+}
+
+/** One node's membership changing. `null` means "unassign". */
+export interface ProductReassignment {
+  nodeId: string;
+  product: string | null;
+}
+
+/**
+ * A complete product edit, computed before anything is written.
+ *
+ * `products: null` means "the definitions are unchanged" — a bulk move touches
+ * memberships only, and passing the unchanged array would make the executor
+ * write the project for no reason.
+ */
+export interface ProductPlan {
+  products: ProductDefinition[] | null;
+  reassignments: ProductReassignment[];
+}
+
+/** Delete a product and say what happens to its members (§ D3). */
+export function planProductDeletion(
+  products: readonly ProductDefinition[],
+  nodes: readonly NodeLike[],
+  id: string,
+  reassignTo: string | null,
+): ProductPlan {
+  return {
+    products: removeProduct(products, id),
+    reassignments: membersOfProduct(nodes, id).map((node) => ({ nodeId: node.id, product: reassignTo })),
+  };
+}
+
+/**
+ * Move the selected nodes into a product, or out of every product (§ D6).
+ *
+ * Two filters, both load-bearing. Species that **derive** membership are
+ * skipped, because writing `metadata.product` on a data model produces a key
+ * every read surface ignores and the validator warns about
+ * (`product-membership-wrong-species`) — the bulk bar tells the user how many of
+ * their selection this drops. Nodes already in the target are skipped so a
+ * re-application is a no-op rather than a pile of empty writes.
+ */
+export function planProductMove(
+  nodes: readonly NodeLike[],
+  nodeIds: readonly string[],
+  productId: string | null,
+): ProductPlan {
+  const wanted = new Set(nodeIds);
+  return {
+    products: null,
+    reassignments: nodes
+      .filter((node) => wanted.has(node.id))
+      .filter((node) => PRODUCT_MEMBERSHIP_SPECIES.includes(node.species))
+      .filter((node) => productOf(node) !== productId)
+      .map((node) => ({ nodeId: node.id, product: productId })),
+  };
+}
+
+/**
+ * This node's metadata with its membership set, or **removed**.
+ *
+ * Removed rather than blanked: `productOf` reads any string, so `product: ""`
+ * would be a membership naming a product that cannot exist, and
+ * `resolveProducts` would never match it. Unassigned has to mean *absent*.
+ *
+ * The rest of the metadata is carried through untouched — `platformStatuses`,
+ * notes and screenshots all live in the same object, and a patch that replaced
+ * it wholesale would take a view's per-platform statuses with it.
+ */
+export function withProductMembership(
+  metadata: NodeMetadata | undefined,
+  product: string | null,
+): NodeMetadata {
+  const next: Record<string, unknown> = { ...(metadata ?? {}) };
+  if (product === null) delete next.product;
+  else next.product = product;
+  return next as NodeMetadata;
+}
+
+/**
+ * A plan's reassignments as mutation ops, so the whole membership half commits
+ * as one atomic write (`applyMutations`) rather than as N racing patches.
+ *
+ * Pure, and here rather than in the executor deliberately: this is where the
+ * "preserve the rest of the metadata" rule is actually applied, and it is worth
+ * an assertion.
+ */
+export function planToOps(
+  plan: ProductPlan,
+  nodesById: ReadonlyMap<string, NodeLike>,
+): { op: "update_node"; node_id: string; patch: { metadata: NodeMetadata } }[] {
+  return plan.reassignments.map(({ nodeId, product }) => ({
+    op: "update_node" as const,
+    node_id: nodeId,
+    patch: { metadata: withProductMembership(nodesById.get(nodeId)?.metadata, product) },
+  }));
+}
+
+/**
+ * The platforms a node in this product may claim — the containment rule as the
+ * node form enforces it (§ D4).
+ *
+ * Three distinct answers, and the empty one is not an error. A product with
+ * `platforms: []` says availability is not a tracked dimension here (a CLI, a
+ * public API), so the form shows no platform toggles at all and a single
+ * lifecycle status — RFC decision 2, arriving in the editor exactly as it
+ * already arrives in the read surfaces. `null` — unassigned, or a project that
+ * declares no products — means every platform, which is today's behaviour
+ * unchanged.
+ *
+ * An unrecognised or malformed definition degrades to every platform rather than
+ * to none: `resolveProducts` is lenient by contract, and a stored product with
+ * no `platforms` array must never leave a user unable to tick anything.
+ */
+export function platformMenuFor(product: ProductDefinition | null | undefined): PlatformId[] {
+  if (!product || !Array.isArray(product.platforms)) return [...PLATFORM_ORDER];
+  const menu = new Set<string>(product.platforms as string[]);
+  return PLATFORM_ORDER.filter((platform) => menu.has(platform));
+}
+
+/** `selected ∩ menu`, canonically ordered — what a product change prunes to. */
+export function constrainPlatforms(
+  selected: readonly PlatformId[],
+  menu: readonly PlatformId[],
+): PlatformId[] {
+  return PLATFORM_ORDER.filter((platform) => selected.includes(platform) && menu.includes(platform));
+}
+```
+
+- [ ] **Step 5: Write `lib/utils/apply-product-plan.ts`**
+
+```ts
+/**
+ * The one write in the app that spans both stores.
+ *
+ * Product definitions live on the project (`updateProject`) and memberships live
+ * on nodes (`applyMutations`), so every product edit that touches members is two
+ * writes that cannot be made one. Both callers — the delete dialog and the
+ * Library's bulk bar — go through here so the ordering below is decided once.
+ *
+ * Takes its stores as arguments rather than calling hooks, which keeps it a
+ * plain async function the test suite can drive with two spies.
+ */
+
+import type { NodeMetadata, ProjectMetadata } from "@/lib/data/types";
+import { planToOps, type ProductPlan } from "./product-editing";
+
+type UpdateNodeOp = { op: "update_node"; node_id: string; patch: { metadata: NodeMetadata } };
+
+export interface ProductPlanStores {
+  nodesById: ReadonlyMap<string, { id: string; metadata?: NodeMetadata }>;
+  projectMetadata: ProjectMetadata | undefined;
+  updateProject: (patch: { metadata: ProjectMetadata }) => Promise<unknown>;
+  applyMutations: (ops: UpdateNodeOp[]) => Promise<unknown>;
+}
+
+/**
+ * Memberships first, definitions second — and if the second write fails the
+ * result is a product that still exists whose members have already moved out of
+ * it. That is a *visible* half-state the user can finish by hand.
+ *
+ * The other order fails worse: deleting the definition first and then losing the
+ * membership write leaves nodes pointing at a product nobody declares. Every
+ * read surface survives that (a stale key resolves to unassigned), which is
+ * precisely the problem — nothing would tell the user it happened.
+ *
+ * `products: null` means the definitions are untouched, so the project write is
+ * skipped entirely rather than saved unchanged.
+ */
+export async function applyProductPlan(plan: ProductPlan, stores: ProductPlanStores): Promise<void> {
+  const ops = planToOps(plan, stores.nodesById as ReadonlyMap<string, never>) as UpdateNodeOp[];
+
+  if (ops.length > 0) await stores.applyMutations(ops);
+
+  if (plan.products !== null) {
+    await stores.updateProject({
+      metadata: { ...(stores.projectMetadata ?? {}), products: plan.products },
+    });
+  }
+}
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `node tests/app/product-editing.test.js`
+Expected: PASS — every line prints `ok - …` and the script exits `0` with `All product-editing tests passed`.
+
+If `planToOps`'s cast in `apply-product-plan.ts` fights the type checker, fix it by widening `ProductPlanStores["nodesById"]` to `ReadonlyMap<string, Pick<Node, "id" | "species" | "metadata">>` and importing `Node` — do not weaken `planToOps`.
+
+- [ ] **Step 7: Verify types compile**
+
+Run: `npx tsc --noEmit -p tsconfig.json`
+Expected: no errors introduced by the two new files. (Pre-existing errors elsewhere, if any, are not yours — compare against `git stash` output if unsure.)
+
+- [ ] **Step 8: Wire the suite into npm and CI**
+
+In `package.json`, add directly after the `"test:product-scope"` line:
+
+```json
+    "test:product-editing": "node tests/app/product-editing.test.js",
+```
+
+In `.github/workflows/ci.yml`, find the step running `npm run test:product-scope` (around line 119) and add an identically-shaped step immediately after it, matching the surrounding `- name:` / `run:` formatting exactly:
+
+```yaml
+      - name: Product editing tests
+        run: npm run test:product-editing
+```
+
+- [ ] **Step 9: Verify the npm script works**
+
+Run: `npm run test:product-editing`
+Expected: PASS, same output as Step 6.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add lib/utils/product-editing.ts lib/utils/apply-product-plan.ts \
+        tests/app/load-product-editing.js tests/app/product-editing.test.js \
+        package.json .github/workflows/ci.yml
+git commit -m "feat: the rules for editing products, as pure plans"
+```
+
+Note: `tests/app/.test-build-product-editing/` is a build artefact. Check `.gitignore` covers `tests/app/.test-build-*` — the existing `.test-build-product-scope` directory is already handled, so match whatever pattern covers it. If it is not covered, add `tests/app/.test-build-*/` to `.gitignore` in this commit.
+
+---
+
+## Task 2: The product picker component
+
+**Files:**
+- Create: `components/panels/ProductPicker.tsx`
+
+There is no component test runner in this repo, so this task has no automated test. Verification is `npx tsc --noEmit` plus the manual checklist in Task 9.
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+"use client";
+
+import type { ProductDefinition } from "@arkaik/schema";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+/**
+ * The one control that assigns a node to a product.
+ *
+ * One component, three forms (the create form, the node detail panel, the
+ * acceptance editor), for the same reason `ProductScopeSelector` is one
+ * control: the rules about what "unassigned" means are subtle enough that three
+ * copies would diverge, and the third copy would be the one that stored `""`.
+ *
+ * **The caller decides whether to render it at all.** This component does not
+ * check whether the project declares products — its callers do, because a form
+ * that has no products to offer must not render an empty field, a label, or the
+ * word "product" anywhere. That is the degenerate-case guarantee, and it lives
+ * at the call site because only the call site knows what layout to omit.
+ */
+
+/**
+ * Radix reserves the empty string for "no selection", so "Unassigned" — a real
+ * choice, not an absence — needs a sentinel. It never leaves this file; the
+ * value handed back is `null`.
+ */
+const UNASSIGNED = "__unassigned__";
+
+interface ProductPickerProps {
+  products: readonly ProductDefinition[];
+  value: string | null;
+  onChange: (productId: string | null) => void;
+  /** Defaults to "Product". The acceptance editor overrides it. */
+  label?: string;
+  /** Secondary line under the control — the caller's explanation, if any. */
+  hint?: string;
+  disabled?: boolean;
+}
+
+/** The product's `title`, or its id when the definition carries none. */
+function productLabel(product: ProductDefinition): string {
+  return typeof product.title === "string" && product.title.trim() !== "" ? product.title : product.id;
+}
+
+export function ProductPicker({
+  products,
+  value,
+  onChange,
+  label = "Product",
+  hint,
+  disabled,
+}: ProductPickerProps) {
+  // A stored membership naming a product this project no longer declares
+  // degrades to Unassigned in the trigger, matching `ProductScopeSelector`. It
+  // is displayed, not healed — writing state as a side effect of rendering
+  // would make a half-synced bundle permanently forget a real assignment.
+  const selected = products.find((product) => product.id === value) ?? null;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">{label}</span>
+      <Select
+        value={selected ? selected.id : UNASSIGNED}
+        onValueChange={(next) => onChange(next === UNASSIGNED ? null : next)}
+        disabled={disabled}
+      >
+        <SelectTrigger aria-label={label}>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={UNASSIGNED}>Unassigned</SelectItem>
+          {products.map((product) => (
+            <SelectItem key={product.id} value={product.id}>
+              {productLabel(product)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {hint ? <p className="text-xs text-muted-foreground">{hint}</p> : null}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify types compile**
+
+Run: `npx tsc --noEmit -p tsconfig.json`
+Expected: no new errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/panels/ProductPicker.tsx
+git commit -m "feat: one product picker for the three forms that assign membership"
+```
+
+---
+
+## Task 3: Product field in the create form
+
+**Files:**
+- Modify: `components/panels/NewNodeForm.tsx`
+
+- [ ] **Step 1: Extend the form's data and props**
+
+Read `components/panels/NewNodeForm.tsx` first. Add these imports beside the existing ones:
+
+```tsx
+import { PRODUCT_MEMBERSHIP_SPECIES, type ProductDefinition } from "@arkaik/schema";
+import { ProductPicker } from "@/components/panels/ProductPicker";
+import { constrainPlatforms, platformMenuFor, withProductMembership } from "@/lib/utils/product-editing";
+```
+
+Extend the props interface (leave `NewNodeFormData` unchanged — membership travels in `metadata`, which the type already carries):
+
+```tsx
+interface NewNodeFormProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (data: NewNodeFormData) => void;
+  /** Pre-fill species when opening from an "Add child" action. */
+  defaultValues?: Partial<Pick<NewNodeFormData, "species">>;
+  /**
+   * The project's declared products. **Empty means the picker never renders** —
+   * a project that has never heard of products must see no new field, no new
+   * label, and no new word (§ degenerate-case guarantee).
+   */
+  products?: readonly ProductDefinition[];
+  /**
+   * The scope the user is standing in, pre-filled into the picker (§ D1).
+   *
+   * Visible and editable, never silent: creating a node under a named scope
+   * without this produced a node that vanished from the scope the moment it was
+   * created, because an unassigned flow or view shows under All products only.
+   */
+  defaultProductId?: string | null;
+}
+```
+
+- [ ] **Step 2: Add the product state and the platform constraint**
+
+Inside the component, after the existing `useState` calls:
+
+```tsx
+export function NewNodeForm({
+  open,
+  onOpenChange,
+  onSubmit,
+  defaultValues,
+  products = [],
+  defaultProductId = null,
+}: NewNodeFormProps) {
+  const [title, setTitle] = useState("");
+  const [species, setSpecies] = useState<SpeciesId>(defaultValues?.species ?? "view");
+  const [status, setStatus] = useState<StatusId>("idea");
+  const [platforms, setPlatforms] = useState<PlatformId[]>([]);
+  const [product, setProduct] = useState<string | null>(defaultProductId);
+
+  const usesSingleStatusField = species === "data-model" || species === "api-endpoint";
+  const usesPlatformDefaultStatus = species === "view";
+
+  // Only three species *store* membership; the system layer derives it from who
+  // consumes it and must never be offered the control.
+  const storesProduct = PRODUCT_MEMBERSHIP_SPECIES.includes(species);
+  const showsProductPicker = products.length > 0 && storesProduct;
+
+  // The containment rule at its source (§ D4): a node may only claim platforms
+  // its product ships on. An unassigned node — or a project with no products —
+  // gets every platform, which is today's behaviour unchanged.
+  const platformMenu = platformMenuFor(
+    storesProduct && product !== null ? products.find((p) => p.id === product) ?? null : null,
+  );
+
+  // A platform-less product means availability is not a tracked dimension here
+  // (a CLI, a public API), so there is nothing to toggle — RFC decision 2.
+  const allowsPlatformEditing = species !== "flow" && platformMenu.length > 0;
+```
+
+- [ ] **Step 3: Prune the selection when the product changes**
+
+Add this handler next to `handlePlatformToggle`:
+
+```tsx
+  /**
+   * Switching to a narrower product drops the platforms it does not ship on,
+   * rather than storing a claim the product forbids and letting
+   * `effectiveNodePlatforms` silently hide it at render time.
+   */
+  function handleProductChange(nextProduct: string | null) {
+    setProduct(nextProduct);
+    const nextMenu = platformMenuFor(
+      nextProduct === null ? null : products.find((p) => p.id === nextProduct) ?? null,
+    );
+    setPlatforms((previous) => constrainPlatforms(previous, nextMenu));
+  }
+```
+
+- [ ] **Step 4: Reset and submit correctly**
+
+Update `resetForm` to restore the scoped default rather than clearing it — reopening the dialog under a named scope must pre-fill again:
+
+```tsx
+  function resetForm() {
+    setTitle("");
+    setSpecies(defaultValues?.species ?? "view");
+    setStatus("idea");
+    setPlatforms([]);
+    setProduct(defaultProductId);
+  }
+```
+
+Replace the body of `handleSubmit` with this. The two metadata contributions are merged rather than one overwriting the other, and membership is dropped entirely when the species does not store it — changing species from `view` to `data-model` mid-form must not leave a key the validator warns about:
+
+```tsx
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!title.trim()) return;
+
+    const platformStatuses = species === "view"
+      ? {
+          platformStatuses: Object.fromEntries(
+            platforms.map((platformId) => [platformId, status]),
+          ) as Record<PlatformId, StatusId>,
+        }
+      : {};
+
+    // Membership only for the species that store it, and only when the project
+    // has products at all. `withProductMembership` removes the key for null
+    // rather than blanking it — unassigned has to mean absent.
+    const base = storesProduct && products.length > 0
+      ? withProductMembership(undefined, product)
+      : {};
+
+    const metadata: NodeMetadata = { ...base, ...platformStatuses };
+
+    onSubmit({
+      title: title.trim(),
+      species,
+      status,
+      platforms,
+      metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+    });
+    resetForm();
+  }
+```
+
+- [ ] **Step 5: Render the picker**
+
+In the JSX, insert the picker immediately after the Species field and before the status field, so it reads product-then-platforms — the order the constraint flows in:
+
+```tsx
+          {showsProductPicker && (
+            <ProductPicker
+              products={products}
+              value={product}
+              onChange={handleProductChange}
+              hint={
+                product === null
+                  ? "Unassigned nodes appear under All products only."
+                  : undefined
+              }
+            />
+          )}
+```
+
+- [ ] **Step 6: Verify types compile**
+
+Run: `npx tsc --noEmit -p tsconfig.json`
+Expected: no new errors. The five call sites still compile because `products` and `defaultProductId` are optional and default to the pre-products behaviour.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add components/panels/NewNodeForm.tsx
+git commit -m "feat: create a node into the product you are standing in"
+```
+
+---
+
+## Task 4: Thread products into all five call sites
+
+**Files:**
+- Modify: `app/project/[id]/library/page.tsx`
+- Modify: `app/project/[id]/delivery/page.tsx`
+- Modify: `app/project/[id]/acceptances/page.tsx`
+- Modify: `components/maps/JourneyMap.tsx`
+- Modify: `components/maps/SystemMap.tsx`
+
+Every one of these already resolves a scope through `useEffectiveProduct` (or receives one as a prop) and already renders `<NewNodeForm …/>`. The change at each site is the same two props.
+
+- [ ] **Step 1: Find every call site**
+
+Run: `grep -rn "<NewNodeForm" --include='*.tsx' app components`
+Expected: five results, one per file listed above. If there are more, every one gets the same treatment.
+
+- [ ] **Step 2: Add the products list at each site**
+
+At each call site the scope is already in scope as `scope` (pages) or as a `scope` prop (maps). `ProductScope` carries `productsById`, so the array comes from it with no extra resolution and no new import:
+
+```tsx
+      <NewNodeForm
+        open={newNodeOpen}
+        onOpenChange={setNewNodeOpen}
+        onSubmit={handleCreateNode}
+        products={[...scope.productsById.values()]}
+        defaultProductId={scope.productId}
+      />
+```
+
+Keep every other prop already present at that site (`defaultValues`, etc.) exactly as it is. In `JourneyMap.tsx` and `SystemMap.tsx` the local variable may be named differently — read the file and use whatever holds the `ProductScope`.
+
+Hoist the array into a `useMemo` where the file already memoizes similar derivations, so the form is not handed a new array identity every render:
+
+```tsx
+  const productList = useMemo(() => [...scope.productsById.values()], [scope.productsById]);
+```
+
+- [ ] **Step 3: Verify no call site was missed**
+
+Run: `grep -rn "<NewNodeForm" -A6 --include='*.tsx' app components | grep -c "products="`
+Expected: `5`
+
+- [ ] **Step 4: Verify types compile**
+
+Run: `npx tsc --noEmit -p tsconfig.json`
+Expected: no new errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/project components/maps
+git commit -m "feat: every create form knows the project's products"
+```
+
+---
+
+## Task 5: Product picker on the edit paths
+
+**Files:**
+- Modify: `components/panels/NodeDetailPanel.tsx`
+- Modify: `components/panels/AcceptanceEditor.tsx`
+
+- [ ] **Step 1: Read both files**
+
+Both already receive `scope: ProductScope`. Find how each persists an edit — `NodeDetailPanel` calls an `onUpdate`-style prop with a node patch; `AcceptanceEditor` does the equivalent for its acceptance. Use whatever mechanism is already there; do not add a new save path.
+
+- [ ] **Step 2: Add the picker to `NodeDetailPanel`**
+
+Add the imports:
+
+```tsx
+import { PRODUCT_MEMBERSHIP_SPECIES } from "@arkaik/schema";
+import { productOf } from "@arkaik/schema";
+import { ProductPicker } from "@/components/panels/ProductPicker";
+import { withProductMembership } from "@/lib/utils/product-editing";
+```
+
+Render it in the panel's editable metadata area, guarded exactly as the create form is:
+
+```tsx
+        {scope.productsById.size > 0 && PRODUCT_MEMBERSHIP_SPECIES.includes(node.species) && (
+          <ProductPicker
+            products={[...scope.productsById.values()]}
+            value={productOf(node)}
+            onChange={(nextProduct) =>
+              onUpdate(node.id, { metadata: withProductMembership(node.metadata, nextProduct) })
+            }
+            hint={
+              productOf(node) === null
+                ? "Unassigned nodes appear under All products only."
+                : undefined
+            }
+          />
+        )}
+```
+
+Substitute the panel's real update callback for `onUpdate(node.id, patch)` — read the file and match its signature.
+
+- [ ] **Step 3: Add the picker to `AcceptanceEditor`**
+
+An acceptance's membership is **derived from its `covers` anchors**; the stored key is the answer only when it covers nothing (§ D5). The control is always present, but when anchors exist it says who is actually deciding. Imports:
+
+```tsx
+import { ProductPicker } from "@/components/panels/ProductPicker";
+import { coveredAnchorIds, productsOfAcceptance } from "@/lib/utils/product-scope";
+import { withProductMembership } from "@/lib/utils/product-editing";
+import { productOf } from "@arkaik/schema";
+```
+
+The editor needs `edges` and a `nodesById` map to answer the derivation. If it does not already receive them, add them as props and pass them from the call site — the pages that render it already hold both. Then:
+
+```tsx
+  const anchorCount = coveredAnchorIds(acceptance.id, edges).length;
+  const derivedProducts = productsOfAcceptance(acceptance, edges, nodesById);
+  const derivedLabels = [...derivedProducts]
+    .map((id) => scope.productsById.get(id)?.title ?? id)
+    .join(", ");
+```
+
+```tsx
+        {scope.productsById.size > 0 && (
+          <ProductPicker
+            products={[...scope.productsById.values()]}
+            value={productOf(acceptance)}
+            onChange={(nextProduct) =>
+              onUpdate(acceptance.id, {
+                metadata: withProductMembership(acceptance.metadata, nextProduct),
+              })
+            }
+            label={anchorCount > 0 ? "Product (from what it covers)" : "Product"}
+            hint={
+              anchorCount > 0
+                ? derivedLabels
+                  ? `This acceptance belongs to ${derivedLabels}, taken from the ${anchorCount} node${anchorCount === 1 ? "" : "s"} it covers. The value below applies only if it stops covering anything.`
+                  : `The ${anchorCount} node${anchorCount === 1 ? "" : "s"} this covers have no product yet, so it appears under All products. The value below applies only if it stops covering anything.`
+                : "This acceptance covers nothing, so its product is whatever you set here."
+            }
+          />
+        )}
+```
+
+Substitute the editor's real update callback, as in Step 2.
+
+- [ ] **Step 4: Verify types compile**
+
+Run: `npx tsc --noEmit -p tsconfig.json`
+Expected: no new errors.
+
+- [ ] **Step 5: Verify the read-side suite still passes**
+
+Run: `npm run test:product-scope && npm run test:product-editing`
+Expected: both PASS. Nothing in this task changes their inputs, so a failure here means an import cycle or a signature drift — fix it before committing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add components/panels/NodeDetailPanel.tsx components/panels/AcceptanceEditor.tsx
+git commit -m "feat: change a node's product without leaving the panel"
+```
+
+---
+
+## Task 6: The product manager — list, create, edit
+
+**Files:**
+- Create: `components/settings/ProductFormDialog.tsx`
+- Create: `components/settings/ProductManagerPanel.tsx`
+- Modify: `app/project/[id]/settings/page.tsx`
+
+- [ ] **Step 1: Write the create/edit dialog**
+
+```tsx
+"use client";
+
+import { useEffect, useState } from "react";
+import type { ProductDefinition } from "@arkaik/schema";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { PLATFORMS, type PlatformId } from "@/lib/config/platforms";
+import { PLATFORM_LABELS } from "@/components/graph/nodes/node-styles";
+import { deriveProductId, type ProductDraft } from "@/lib/utils/product-editing";
+
+/**
+ * Create or edit one product.
+ *
+ * The id is derived from the title on create and **frozen thereafter** (§ D2).
+ * It is the key every member node stores, and the alternative — an editable id —
+ * needs a multi-node rewrite that can half-fail, leaving some members pointing
+ * at the old key and some at the new. The id is shown, not hidden: a user who
+ * hand-edits a bundle later needs to know what it is.
+ */
+
+interface ProductFormDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** The product being edited, or `null` to create a new one. */
+  product: ProductDefinition | null;
+  /** Every id already taken, so a derived slug never collides. */
+  existingIds: readonly string[];
+  /** Members of the product being edited, for the narrowing warning (§ D4). */
+  memberPlatforms: readonly PlatformId[];
+  onSave: (draft: ProductDraft) => void;
+}
+
+export function ProductFormDialog({
+  open,
+  onOpenChange,
+  product,
+  existingIds,
+  memberPlatforms,
+  onSave,
+}: ProductFormDialogProps) {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [platforms, setPlatforms] = useState<PlatformId[]>([]);
+
+  // Re-seed whenever the dialog opens on a different product. Keying off `open`
+  // as well means reopening on the same product discards an abandoned edit.
+  useEffect(() => {
+    if (!open) return;
+    setTitle(typeof product?.title === "string" ? product.title : "");
+    setDescription(typeof product?.description === "string" ? product.description : "");
+    setPlatforms(Array.isArray(product?.platforms) ? [...(product.platforms as PlatformId[])] : []);
+  }, [open, product]);
+
+  const editing = product !== null;
+  const id = editing ? product.id : deriveProductId(title, existingIds);
+
+  // Narrowing below what members already claim is *allowed* — the containment
+  // rule is a validator warning, never an error, because narrowing a product's
+  // platforms is a product decision and must not fail CI. So this reports
+  // rather than blocks, and says exactly which platforms would stop showing.
+  const dropped = memberPlatforms.filter((platform) => !platforms.includes(platform));
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!title.trim()) return;
+    onSave({ id, title: title.trim(), description, platforms });
+    onOpenChange(false);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{editing ? "Edit product" : "New product"}</DialogTitle>
+          <DialogDescription>
+            A product is one app in this project&rsquo;s family &mdash; an end-user app, an admin
+            dashboard, a public API. They share one graph.
+          </DialogDescription>
+        </DialogHeader>
+        <form id="product-form" onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Title</span>
+            <Input
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Admin dashboard"
+              required
+              aria-label="Product title"
+            />
+            <p className="text-xs text-muted-foreground">
+              Identifier: <code>{id || "—"}</code>
+              {editing ? " — fixed once created." : " — derived from the title, and fixed once created."}
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+              Description
+            </span>
+            <Input
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="What this app is for"
+              aria-label="Product description"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+              Platforms
+            </span>
+            <div className="flex items-center gap-2 flex-wrap">
+              {PLATFORMS.map((platform) => {
+                const selected = platforms.includes(platform.id);
+                return (
+                  <button
+                    key={platform.id}
+                    type="button"
+                    aria-pressed={selected}
+                    onClick={() =>
+                      setPlatforms((previous) =>
+                        previous.includes(platform.id)
+                          ? previous.filter((p) => p !== platform.id)
+                          : [...previous, platform.id],
+                      )
+                    }
+                    className={`cursor-pointer rounded-md border px-3 py-1.5 text-sm ${
+                      selected ? "border-primary bg-primary/10 text-foreground" : "text-muted-foreground"
+                    }`}
+                  >
+                    {PLATFORM_LABELS[platform.id]}
+                  </button>
+                );
+              })}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {platforms.length === 0
+                ? "No platforms: availability is not tracked for this product, and its nodes carry a single status."
+                : "Nodes in this product can only claim these platforms."}
+            </p>
+            {dropped.length > 0 && (
+              <p className="text-xs text-amber-600 dark:text-amber-500">
+                Nodes in this product currently use{" "}
+                {dropped.map((platform) => PLATFORM_LABELS[platform]).join(", ")}. Saving this keeps
+                them, but they stop showing.
+              </p>
+            )}
+          </div>
+        </form>
+        <DialogFooter>
+          <Button type="button" variant="ghost" className="cursor-pointer" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button type="submit" form="product-form" className="cursor-pointer" disabled={!title.trim()}>
+            {editing ? "Save" : "Create product"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+Check `PLATFORM_LABELS` is exported from `components/graph/nodes/node-styles` before relying on it — `NewNodeForm.tsx` already imports it from there, so it is.
+
+- [ ] **Step 2: Write the manager panel (list + create/edit wiring)**
+
+The delete dialog arrives in Task 7; for now the Delete button is rendered and wired to a `onRequestDelete` callback that Task 7 fills in.
+
+```tsx
+"use client";
+
+import { useMemo, useState } from "react";
+import { PlusIcon } from "lucide-react";
+import { toast } from "sonner";
+import { resolveProducts, type ProductDefinition } from "@arkaik/schema";
+import type { Node, ProjectBundle, ProjectMetadata } from "@/lib/data/types";
+import type { PlatformId } from "@/lib/config/platforms";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { PLATFORM_LABELS } from "@/components/graph/nodes/node-styles";
+import { ProductFormDialog } from "@/components/settings/ProductFormDialog";
+import {
+  membersOfProduct,
+  upsertProduct,
+  type ProductDraft,
+} from "@/lib/utils/product-editing";
+import { platformCountLabel } from "@/lib/utils/product-scope";
+
+/**
+ * The Products section of project settings — where a human can finally do what
+ * only an agent could before: name the apps this project describes.
+ *
+ * Definitions are project metadata, so a create or a rename is a single
+ * `updateProject`. Only deletion touches nodes, and only deletion goes through
+ * `applyProductPlan` (Task 7).
+ */
+
+interface ProductManagerPanelProps {
+  project: ProjectBundle | undefined;
+  nodes: readonly Node[];
+  updateProject: (patch: { metadata: ProjectMetadata }) => Promise<unknown>;
+  /** Task 7 opens the delete-with-reassign dialog from here. */
+  onRequestDelete: (product: ProductDefinition) => void;
+}
+
+export function ProductManagerPanel({
+  project,
+  nodes,
+  updateProject,
+  onRequestDelete,
+}: ProductManagerPanelProps) {
+  const [formOpen, setFormOpen] = useState(false);
+  const [editing, setEditing] = useState<ProductDefinition | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const products = useMemo(() => resolveProducts(project?.project), [project]);
+
+  // Stored membership only — the count a deletion would have to answer for.
+  const memberCounts = useMemo(
+    () => Object.fromEntries(products.map((p) => [p.id, membersOfProduct(nodes, p.id).length])),
+    [nodes, products],
+  );
+
+  /** The platforms this product's members actually claim — the narrowing warning's input. */
+  const memberPlatforms = useMemo<PlatformId[]>(() => {
+    if (!editing) return [];
+    const used = new Set<PlatformId>();
+    for (const node of membersOfProduct(nodes, editing.id)) {
+      for (const platform of node.platforms ?? []) used.add(platform);
+    }
+    return [...used];
+  }, [editing, nodes]);
+
+  async function handleSave(draft: ProductDraft) {
+    if (saving) return;
+    setSaving(true);
+    try {
+      await updateProject({
+        metadata: { ...(project?.project.metadata ?? {}), products: upsertProduct(products, draft) },
+      });
+      toast.success(editing ? `"${draft.title}" was updated.` : `"${draft.title}" was created.`);
+    } catch (err) {
+      console.error("[ProductManagerPanel] Failed to save product:", err);
+      toast.error(err instanceof Error ? err.message : "Could not save this product.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <>
+      <div className="flex flex-col gap-3">
+        {products.length === 0 ? (
+          <p className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
+            This project describes one product. Add another &mdash; an admin dashboard, a public
+            API, a CLI &mdash; and every page gains a scope selector for moving between them.
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {products.map((product) => (
+              <li
+                key={product.id}
+                className="flex flex-col gap-3 rounded-lg border p-4 sm:flex-row sm:items-center sm:justify-between"
+              >
+                <div className="min-w-0">
+                  <p className="text-sm font-medium">
+                    {typeof product.title === "string" && product.title.trim() !== ""
+                      ? product.title
+                      : product.id}
+                  </p>
+                  {typeof product.description === "string" && product.description.trim() !== "" ? (
+                    <p className="text-sm text-muted-foreground">{product.description}</p>
+                  ) : null}
+                  <div className="mt-2 flex flex-wrap items-center gap-1.5">
+                    {(Array.isArray(product.platforms) ? product.platforms : []).map((platform) => (
+                      <Badge key={platform} variant="secondary">
+                        {PLATFORM_LABELS[platform as PlatformId] ?? platform}
+                      </Badge>
+                    ))}
+                    <span className="text-xs text-muted-foreground">
+                      {platformCountLabel(product.platforms)} &middot; {memberCounts[product.id] ?? 0}{" "}
+                      node{(memberCounts[product.id] ?? 0) === 1 ? "" : "s"}
+                    </span>
+                  </div>
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  <Button
+                    variant="outline"
+                    className="cursor-pointer"
+                    onClick={() => {
+                      setEditing(product);
+                      setFormOpen(true);
+                    }}
+                  >
+                    Edit
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    className="cursor-pointer text-destructive"
+                    onClick={() => onRequestDelete(product)}
+                  >
+                    Delete
+                  </Button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <div>
+          <Button
+            variant="outline"
+            className="cursor-pointer"
+            disabled={!project || saving}
+            onClick={() => {
+              setEditing(null);
+              setFormOpen(true);
+            }}
+          >
+            <PlusIcon className="size-4" />
+            Add product
+          </Button>
+        </div>
+      </div>
+
+      <ProductFormDialog
+        open={formOpen}
+        onOpenChange={setFormOpen}
+        product={editing}
+        existingIds={products.map((p) => p.id)}
+        memberPlatforms={memberPlatforms}
+        onSave={(draft) => void handleSave(draft)}
+      />
+    </>
+  );
+}
+```
+
+- [ ] **Step 3: Render the section in settings**
+
+In `app/project/[id]/settings/page.tsx`, add the imports:
+
+```tsx
+import { ProductManagerPanel } from "@/components/settings/ProductManagerPanel";
+import { useNodes } from "@/lib/hooks/useNodes";
+```
+
+Take `updateProject` from the existing `useProject` call and add `useNodes`:
+
+```tsx
+  const { project, loading, updateProject } = useProject(id);
+  const { nodes } = useNodes(id);
+```
+
+Insert a new `<section>` **between** the Linked repositories section and the Danger zone section:
+
+```tsx
+            <section className="flex flex-col gap-3">
+              <div className="flex flex-col gap-1">
+                <h2 className="text-lg font-semibold">Products</h2>
+                <p className="text-sm text-muted-foreground">
+                  A project can describe a family of apps sharing one graph. Naming them lets every
+                  page scope to one &mdash; and lets a web-only dashboard stop dragging down your
+                  Android numbers.
+                </p>
+              </div>
+              <ProductManagerPanel
+                project={project}
+                nodes={nodes}
+                updateProject={updateProject}
+                onRequestDelete={() => {}}
+              />
+            </section>
+```
+
+The `onRequestDelete` no-op is replaced in Task 7.
+
+- [ ] **Step 4: Verify types compile**
+
+Run: `npx tsc --noEmit -p tsconfig.json`
+Expected: no new errors. If `updateProject`'s parameter type rejects `{ metadata }`, widen `ProductManagerPanelProps["updateProject"]` to match `useProject`'s actual signature rather than casting at the call site.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/settings/ProductFormDialog.tsx components/settings/ProductManagerPanel.tsx \
+        'app/project/[id]/settings/page.tsx'
+git commit -m "feat: name your project's products without editing JSON"
+```
+
+---
+
+## Task 7: Delete a product, and say where its nodes go
+
+**Files:**
+- Create: `components/settings/ProductDeleteDialog.tsx`
+- Modify: `components/settings/ProductManagerPanel.tsx`
+
+- [ ] **Step 1: Write the dialog**
+
+```tsx
+"use client";
+
+import { useEffect, useState } from "react";
+import type { ProductDefinition } from "@arkaik/schema";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+/**
+ * Delete a product, and decide what happens to the nodes that named it (§ D3).
+ *
+ * The count is stated before the choice because it is the whole reason there is
+ * a choice: deleting an empty product is a one-click nothing, and deleting one
+ * with forty views is a decision. Leaving them unassigned is offered rather than
+ * assumed — an unassigned flow shows under All products only, which is triage,
+ * not deletion, but it is still a place a node can get lost.
+ */
+
+/** Radix reserves "" for no-selection, so "leave unassigned" needs a sentinel. */
+const UNASSIGNED = "__unassigned__";
+
+interface ProductDeleteDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  product: ProductDefinition | null;
+  /** How many nodes store this product's id. */
+  memberCount: number;
+  /** Every other product, as reassignment targets. */
+  otherProducts: readonly ProductDefinition[];
+  onConfirm: (reassignTo: string | null) => void;
+  busy?: boolean;
+}
+
+export function ProductDeleteDialog({
+  open,
+  onOpenChange,
+  product,
+  memberCount,
+  otherProducts,
+  onConfirm,
+  busy,
+}: ProductDeleteDialogProps) {
+  const [reassignTo, setReassignTo] = useState<string>(UNASSIGNED);
+
+  // Default to unassigned every time the dialog opens: a remembered target from
+  // the previous deletion is exactly the kind of state that moves forty nodes
+  // somewhere nobody chose.
+  useEffect(() => {
+    if (open) setReassignTo(UNASSIGNED);
+  }, [open, product]);
+
+  const title = typeof product?.title === "string" && product.title.trim() !== ""
+    ? product.title
+    : product?.id ?? "";
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete product</DialogTitle>
+          <DialogDescription>
+            {memberCount === 0
+              ? `Nothing belongs to "${title}", so deleting it changes nothing else.`
+              : `${memberCount} node${memberCount === 1 ? "" : "s"} belong${memberCount === 1 ? "s" : ""} to "${title}".`}
+          </DialogDescription>
+        </DialogHeader>
+
+        {memberCount > 0 && (
+          <div className="flex flex-col gap-1.5">
+            <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+              Move them to
+            </span>
+            <Select value={reassignTo} onValueChange={setReassignTo}>
+              <SelectTrigger aria-label="Move nodes to">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={UNASSIGNED}>Leave them unassigned</SelectItem>
+                {otherProducts.map((other) => (
+                  <SelectItem key={other.id} value={other.id}>
+                    {typeof other.title === "string" && other.title.trim() !== "" ? other.title : other.id}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {reassignTo === UNASSIGNED && (
+              <p className="text-xs text-muted-foreground">
+                Unassigned nodes still exist &mdash; they appear under All products until someone
+                gives them a home.
+              </p>
+            )}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button type="button" variant="ghost" className="cursor-pointer" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            className="cursor-pointer"
+            disabled={busy}
+            onClick={() => onConfirm(reassignTo === UNASSIGNED ? null : reassignTo)}
+          >
+            {busy ? "Deleting…" : "Delete product"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+- [ ] **Step 2: Own the delete state inside the manager panel**
+
+Move deletion into `ProductManagerPanel` rather than the settings page — the panel already holds `products`, `nodes` and `updateProject`, which is everything a plan needs. Replace the `onRequestDelete` prop with an `applyMutations` prop.
+
+Change the props interface:
+
+```tsx
+import type { MutationOp } from "@arkaik/schema";
+
+interface ProductManagerPanelProps {
+  project: ProjectBundle | undefined;
+  nodes: readonly Node[];
+  updateProject: (patch: { metadata: ProjectMetadata }) => Promise<unknown>;
+  applyMutations: (ops: MutationOp[]) => Promise<unknown>;
+}
+```
+
+Add the imports and the state:
+
+```tsx
+import { ProductDeleteDialog } from "@/components/settings/ProductDeleteDialog";
+import { applyProductPlan } from "@/lib/utils/apply-product-plan";
+import { planProductDeletion } from "@/lib/utils/product-editing";
+```
+
+```tsx
+  const [deleting, setDeleting] = useState<ProductDefinition | null>(null);
+  const [deleteBusy, setDeleteBusy] = useState(false);
+
+  const nodesById = useMemo(() => new Map(nodes.map((node) => [node.id, node])), [nodes]);
+
+  async function handleDelete(reassignTo: string | null) {
+    if (!deleting || deleteBusy) return;
+    setDeleteBusy(true);
+    const plan = planProductDeletion(products, nodes, deleting.id, reassignTo);
+    try {
+      await applyProductPlan(plan, {
+        nodesById,
+        projectMetadata: project?.project.metadata,
+        updateProject,
+        applyMutations: applyMutations as ProductPlanApply,
+      });
+      const moved = plan.reassignments.length;
+      toast.success(
+        moved === 0
+          ? `"${deleting.title ?? deleting.id}" was deleted.`
+          : `"${deleting.title ?? deleting.id}" was deleted; ${moved} node${moved === 1 ? "" : "s"} ${reassignTo === null ? "are now unassigned" : "moved"}.`,
+      );
+      setDeleting(null);
+    } catch (err) {
+      console.error("[ProductManagerPanel] Failed to delete product:", err);
+      toast.error(err instanceof Error ? err.message : "Could not delete this product.");
+    } finally {
+      setDeleteBusy(false);
+    }
+  }
+```
+
+`ProductPlanApply` is whatever `applyProductPlan` declares its `applyMutations` to be; import the type from `@/lib/utils/apply-product-plan` and export it there if it is not already exported. Do not use `any`.
+
+Wire the Delete button to `setDeleting(product)` and render the dialog beside the form dialog:
+
+```tsx
+      <ProductDeleteDialog
+        open={deleting !== null}
+        onOpenChange={(open) => {
+          if (!open && !deleteBusy) setDeleting(null);
+        }}
+        product={deleting}
+        memberCount={deleting ? memberCounts[deleting.id] ?? 0 : 0}
+        otherProducts={products.filter((p) => p.id !== deleting?.id)}
+        onConfirm={(reassignTo) => void handleDelete(reassignTo)}
+        busy={deleteBusy}
+      />
+```
+
+- [ ] **Step 3: Update the settings page call site**
+
+```tsx
+  const { nodes, applyMutations } = useNodes(id);
+```
+
+```tsx
+              <ProductManagerPanel
+                project={project}
+                nodes={nodes}
+                updateProject={updateProject}
+                applyMutations={applyMutations}
+              />
+```
+
+- [ ] **Step 4: Verify types compile and the suites pass**
+
+Run: `npx tsc --noEmit -p tsconfig.json && npm run test:product-editing && npm run test:product-scope`
+Expected: no type errors, both suites PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/settings/ProductDeleteDialog.tsx components/settings/ProductManagerPanel.tsx \
+        'app/project/[id]/settings/page.tsx'
+git commit -m "feat: deleting a product asks where its nodes should go"
+```
+
+---
+
+## Task 8: Library selection and bulk move
+
+**Files:**
+- Create: `components/library/LibrarySelectionBar.tsx`
+- Modify: `components/library/NodeCard.tsx`
+- Modify: `components/library/NodeTable.tsx`
+- Modify: `app/project/[id]/library/page.tsx`
+
+There is no `@radix-ui/react-checkbox` in this repo and no `components/ui/checkbox.tsx`. Use a styled native `<input type="checkbox">` — one control does not justify a new dependency.
+
+- [ ] **Step 1: Add an optional checkbox to `NodeCard`**
+
+Add to `NodeCardProps`:
+
+```tsx
+  /**
+   * Selection state, or `undefined` when the surface has no selection at all.
+   *
+   * `undefined` rather than `false` so the card renders exactly as it did before
+   * selection existed — no checkbox, no gutter, no layout shift.
+   */
+  selected?: boolean;
+  onToggleSelected?: (nodeId: string) => void;
+```
+
+Render it as the first child of `CardHeader`, stopping propagation so ticking a box never opens the node:
+
+```tsx
+        {selected !== undefined && (
+          <input
+            type="checkbox"
+            checked={selected}
+            aria-label={`Select ${node.title}`}
+            className="size-4 shrink-0 cursor-pointer accent-primary"
+            onClick={(e) => e.stopPropagation()}
+            onChange={() => onToggleSelected?.(node.id)}
+          />
+        )}
+```
+
+- [ ] **Step 2: Add an optional checkbox column to `NodeTable`**
+
+Add to `NodeTableProps`:
+
+```tsx
+  /** Selected node ids, or `undefined` when the surface has no selection. */
+  selectedIds?: ReadonlySet<string>;
+  onToggleSelected?: (nodeId: string) => void;
+  /** Ticks or clears every visible row. */
+  onToggleAll?: () => void;
+```
+
+Add a leading `<TableHead>` and a leading `<TableCell>` per row, both rendered only when `selectedIds !== undefined`. The header checkbox is checked when every visible row is selected:
+
+```tsx
+            {selectedIds !== undefined && (
+              <TableHead className="w-8">
+                <input
+                  type="checkbox"
+                  aria-label="Select all visible nodes"
+                  className="size-4 cursor-pointer accent-primary"
+                  checked={nodes.length > 0 && nodes.every((node) => selectedIds.has(node.id))}
+                  onChange={() => onToggleAll?.()}
+                />
+              </TableHead>
+            )}
+```
+
+```tsx
+              {selectedIds !== undefined && (
+                <TableCell className="w-8" onClick={(e) => e.stopPropagation()}>
+                  <input
+                    type="checkbox"
+                    aria-label={`Select ${node.title}`}
+                    className="size-4 cursor-pointer accent-primary"
+                    checked={selectedIds.has(node.id)}
+                    onChange={() => onToggleSelected?.(node.id)}
+                  />
+                </TableCell>
+              )}
+```
+
+- [ ] **Step 3: Write the selection bar**
+
+```tsx
+"use client";
+
+import { PRODUCT_MEMBERSHIP_SPECIES, type ProductDefinition } from "@arkaik/schema";
+import type { Node } from "@/lib/data/types";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+/**
+ * The Library's bulk action bar. Selection is a **general** mechanism whose
+ * first action happens to be moving nodes between products (§ D6).
+ *
+ * Data models and API endpoints derive their membership from who consumes them,
+ * so a move cannot touch them — but their checkboxes are not disabled. Disabling
+ * them would tie a general selection mechanism to one action, and would answer
+ * "why can't I tick this?" with silence. Naming the subset instead is both
+ * honest and short.
+ */
+
+/** Radix reserves "" for no-selection; "Unassigned" is a real choice. */
+const UNASSIGNED = "__unassigned__";
+
+interface LibrarySelectionBarProps {
+  selected: readonly Node[];
+  products: readonly ProductDefinition[];
+  onClear: () => void;
+  onMove: (productId: string | null) => void;
+  busy?: boolean;
+}
+
+export function LibrarySelectionBar({
+  selected,
+  products,
+  onClear,
+  onMove,
+  busy,
+}: LibrarySelectionBarProps) {
+  if (selected.length === 0) return null;
+
+  const movable = selected.filter((node) => PRODUCT_MEMBERSHIP_SPECIES.includes(node.species)).length;
+  const derived = selected.length - movable;
+
+  return (
+    <div className="flex flex-wrap items-center gap-3 border-b bg-muted/40 px-4 py-2">
+      <span className="text-sm font-medium">
+        {selected.length} selected
+      </span>
+      {products.length > 0 && (
+        <div className="flex items-center gap-2">
+          <Select
+            value=""
+            disabled={busy || movable === 0}
+            onValueChange={(next) => onMove(next === UNASSIGNED ? null : next)}
+          >
+            <SelectTrigger aria-label="Move to product" className="h-8 w-56">
+              <SelectValue placeholder="Move to product…" />
+            </SelectTrigger>
+            <SelectContent>
+              {products.map((product) => (
+                <SelectItem key={product.id} value={product.id}>
+                  {typeof product.title === "string" && product.title.trim() !== ""
+                    ? product.title
+                    : product.id}
+                </SelectItem>
+              ))}
+              <SelectItem value={UNASSIGNED}>Unassigned</SelectItem>
+            </SelectContent>
+          </Select>
+          <span className="text-xs text-muted-foreground">
+            {movable === 0
+              ? "None of these can hold a product — data models and endpoints derive theirs."
+              : derived > 0
+                ? `Moves ${movable} of ${selected.length}; data models and endpoints derive their product.`
+                : null}
+          </span>
+        </div>
+      )}
+      <Button variant="ghost" className="ml-auto h-8 cursor-pointer" onClick={onClear} disabled={busy}>
+        Clear
+      </Button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Wire selection into the Library page**
+
+In `app/project/[id]/library/page.tsx`, add the imports:
+
+```tsx
+import { LibrarySelectionBar } from "@/components/library/LibrarySelectionBar";
+import { applyProductPlan } from "@/lib/utils/apply-product-plan";
+import { planProductMove } from "@/lib/utils/product-editing";
+```
+
+Take `applyMutations` from the existing `useNodes` call and `updateProject` from `useProject`:
+
+```tsx
+  const { nodes: dataNodes, loading: nodesLoading, updateNode, addNode, applyMutations } = useNodes(id);
+  const { project: projectBundle, updateProject } = useProject(id);
+```
+
+Add the state and handlers next to the other page state:
+
+```tsx
+  const [selectedIds, setSelectedIds] = useState<ReadonlySet<string>>(new Set());
+  const [moving, setMoving] = useState(false);
+
+  function toggleSelected(nodeId: string) {
+    setSelectedIds((previous) => {
+      const next = new Set(previous);
+      if (next.has(nodeId)) next.delete(nodeId);
+      else next.add(nodeId);
+      return next;
+    });
+  }
+
+  /**
+   * Selection is scoped to what is on screen. Ticking "all" while a species
+   * filter or a search is active must not quietly select the nodes the filter
+   * is hiding — a bulk move is exactly where an invisible selection does damage.
+   */
+  function toggleAllVisible() {
+    setSelectedIds((previous) =>
+      visibleNodes.every((node) => previous.has(node.id))
+        ? new Set()
+        : new Set(visibleNodes.map((node) => node.id)),
+    );
+  }
+
+  const selectedNodes = useMemo(
+    () => dataNodes.filter((node) => selectedIds.has(node.id)),
+    [dataNodes, selectedIds],
+  );
+
+  async function handleMoveToProduct(productId: string | null) {
+    if (moving) return;
+    setMoving(true);
+    const plan = planProductMove(dataNodes, [...selectedIds], productId);
+    try {
+      if (plan.reassignments.length === 0) {
+        toast.info("Those nodes are already there.");
+      } else {
+        await applyProductPlan(plan, {
+          nodesById,
+          projectMetadata: projectBundle?.project.metadata,
+          updateProject,
+          applyMutations,
+        });
+        const moved = plan.reassignments.length;
+        toast.success(
+          productId === null
+            ? `${moved} node${moved === 1 ? "" : "s"} unassigned.`
+            : `${moved} node${moved === 1 ? "" : "s"} moved.`,
+        );
+      }
+      setSelectedIds(new Set());
+    } catch (err) {
+      console.error("[LibraryPage] Failed to move nodes:", err);
+      toast.error(err instanceof Error ? err.message : "Could not move those nodes.");
+    } finally {
+      setMoving(false);
+    }
+  }
+```
+
+Import `toast` from `sonner` if the page does not already.
+
+Render the bar directly above the node list/table, and pass the selection props down:
+
+```tsx
+        <LibrarySelectionBar
+          selected={selectedNodes}
+          products={[...scope.productsById.values()]}
+          onClear={() => setSelectedIds(new Set())}
+          onMove={(productId) => void handleMoveToProduct(productId)}
+          busy={moving}
+        />
+```
+
+For the cards, pass `selected={selectedIds.has(node.id)}` and `onToggleSelected={toggleSelected}`. For the table, pass `selectedIds={selectedIds}`, `onToggleSelected={toggleSelected}` and `onToggleAll={toggleAllVisible}`.
+
+- [ ] **Step 5: Verify types compile and the suites pass**
+
+Run: `npx tsc --noEmit -p tsconfig.json && npm run test:product-editing && npm run test:product-scope`
+Expected: no type errors, both suites PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add components/library 'app/project/[id]/library/page.tsx'
+git commit -m "feat: move a shelf of nodes into a product at once"
+```
+
+---
+
+## Task 9: Verification, docs, and the manual pass
+
+**Files:**
+- Modify: `docs/rfcs/products.md`
+
+- [ ] **Step 1: Run every suite this work could have touched**
+
+Run:
+
+```bash
+npm run test:product-editing && \
+npm run test:product-scope && \
+npm run test:delivery && \
+npm run test:acceptance-matrix && \
+npm run test:pyramid && \
+npm run test:products
+```
+
+Expected: all six PASS. Report the actual output; do not summarise it as "tests pass" without it.
+
+- [ ] **Step 2: Verify the build**
+
+Run: `npm run build`
+Expected: a successful Next.js build. Note: `npm run lint` already fails on `main` with pre-existing react-hooks problems and CI does not gate on it — do not attempt to make lint clean, but do not add new problems either.
+
+- [ ] **Step 3: Verify the degenerate case by hand**
+
+Open a project that declares **no** products and confirm, on Library and in the create form:
+- no product picker in the New node dialog;
+- no scope selector in the sidebar;
+- no checkbox gutter change beyond the new selection column;
+- platform toggles behave exactly as before.
+
+This is the guarantee the whole feature rests on. If any of it fails, the guard is `products.length > 0` and it is missing somewhere.
+
+- [ ] **Step 4: Update the RFC**
+
+In `docs/rfcs/products.md`, amend the status block at the top. Replace the sentence beginning "**P3 (editing UI) and the per-surface override have not**" with:
+
+```markdown
+> **P3 (editing UI) has now shipped** — products are created, renamed,
+> re-platformed and deleted from project settings, assigned from the node forms,
+> and moved in bulk from the Library. The per-surface override has not, and
+> neither has a UI for a product's `root_node_id` (a product created in the UI
+> therefore has no journey anchor until one is set by hand).
+```
+
+In the § Phased plan list, change the `**P3 — Editing (M)**` bullet to begin with `**P3 — Editing (M)** — *shipped.*`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/rfcs/products.md
+git commit -m "docs: P3 shipped — products are editable from the app"
+```
+
+- [ ] **Step 6: Hand the visual pass to Alexis**
+
+There is no browser driver in this environment, so the visual check is a handover, not an assertion. Produce this checklist in the PR body or the final message:
+
+1. Settings → Products: create "Admin", web only. It appears with a `Web only` badge and `0 nodes`.
+2. Sidebar: the product scope selector now exists. Switch to Admin.
+3. Library → New node → View: the Product field is pre-filled with **Admin**, and only the **Web** platform toggle is offered. Create it. **It stays visible** — this is the dead end the issue reports.
+4. Library: tick two views and a data model. The bar reads `3 selected` and `Moves 2 of 3; data models and endpoints derive their product.` Move them to Admin.
+5. Settings → Products → Edit Admin → untick Web. The amber warning names the platforms its members use. Cancel.
+6. Settings → Products → Delete Admin. The dialog reports the member count; choose "Leave them unassigned" and confirm. The nodes survive and show under All products.
+7. Journey, under Admin: the empty state says the product has no anchor. **This is expected** — see Known gaps.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** D1 → Task 3; D2 → Task 1 (`deriveProductId`) + Task 6 (frozen id); D3 → Task 7; D4 → Task 1 (`platformMenuFor`/`constrainPlatforms`) + Task 3 + Task 6 (narrowing warning); D5 → Task 5; D6 → Task 8; D7 → Task 6 (`upsertProduct` preserves `root_node_id`) + Task 9 Step 4 (recorded as a gap). Architecture §1 → Task 1, §2 → Task 1 Step 5, §3 → Tasks 6–7, §4 → Tasks 2–5, §5 → Task 8. Testing § → Task 1 Step 2.
+- **Naming consistency:** `ProductPlan`, `ProductReassignment`, `ProductDraft`, `planProductDeletion`, `planProductMove`, `planToOps`, `withProductMembership`, `platformMenuFor`, `constrainPlatforms`, `applyProductPlan` are used identically in every task that references them.
+- **Known deviation:** `slugifyProductTitle` is exported but not asserted directly — it is covered through `deriveProductId`, which is the only caller.

--- a/docs/superpowers/plans/2026-08-02-product-management-ui.md
+++ b/docs/superpowers/plans/2026-08-02-product-management-ui.md
@@ -974,16 +974,17 @@ git commit -m "feat: create a node into the product you are standing in"
 **Files:**
 - Modify: `app/project/[id]/library/page.tsx`
 - Modify: `app/project/[id]/delivery/page.tsx`
-- Modify: `app/project/[id]/acceptances/page.tsx`
 - Modify: `components/maps/JourneyMap.tsx`
 - Modify: `components/maps/SystemMap.tsx`
 
 Every one of these already resolves a scope through `useEffectiveProduct` (or receives one as a prop) and already renders `<NewNodeForm …/>`. The change at each site is the same two props.
 
+**The Acceptances page is not one of them, and that is not an oversight.** It creates through a dialog of its own (`components/panels/NewAcceptanceForm.tsx`) rather than through `NewNodeForm`, because an acceptance has no species, platforms or status to collect. It carries the scope's product by the same rule — do not "fix" its absence from this list.
+
 - [ ] **Step 1: Find every call site**
 
 Run: `grep -rn "<NewNodeForm" --include='*.tsx' app components`
-Expected: five results, one per file listed above. If there are more, every one gets the same treatment.
+Expected: four results, one per file listed above. If there are more, every one gets the same treatment.
 
 - [ ] **Step 2: Add the products list at each site**
 
@@ -1009,8 +1010,8 @@ Hoist the array into a `useMemo` where the file already memoizes similar derivat
 
 - [ ] **Step 3: Verify no call site was missed**
 
-Run: `grep -rn "<NewNodeForm" -A6 --include='*.tsx' app components | grep -c "products="`
-Expected: `5`
+Run: `grep -rn "<NewNodeForm" -A8 --include='*.tsx' app components | grep -c "products="`
+Expected: `4`
 
 - [ ] **Step 4: Verify types compile**
 

--- a/docs/superpowers/specs/2026-08-02-product-management-ui-design.md
+++ b/docs/superpowers/specs/2026-08-02-product-management-ui-design.md
@@ -157,19 +157,24 @@ offers **Add product**.
 
 ### 4. `components/panels/ProductPicker.tsx`
 
-One select, three consumers. It **renders only when the project declares
+One select, four consumers. It **renders only when the project declares
 products** and the species stores membership (`PRODUCT_MEMBERSHIP_SPECIES`). A
 project that never heard of products sees no new control anywhere — the same
 opt-in guarantee `ProductScopeSelector` already keeps, and the reason the
 degenerate case stays byte-identical to today.
 
 - **`NewNodeForm`** gains `products` and `defaultProductId`, threaded from
-  `scope` at all five call sites. Prefilled to the current scope (D1). Changing
+  `scope` at all four call sites. Prefilled to the current scope (D1). Changing
   species away from a membership-bearing one drops `metadata.product` from the
   payload; changing product runs `constrainPlatforms` over the toggles (D4).
 - **`NodeDetailPanel`** gets the same picker on its edit path, so membership is
   changeable per node.
 - **`AcceptanceEditor`** renders it per D5.
+- **`NewAcceptanceForm`** (added during implementation) replaces the Acceptances
+  page's `window.prompt`. The prompt could only ask for a title, so an acceptance
+  filed under a named scope silently landed outside it — the same vanishing-node
+  bug as the create form's, in the one species the original scan missed because
+  it never used `NewNodeForm` at all. A title field and a picker, nothing else.
 
 ### 5. Library bulk move
 

--- a/docs/superpowers/specs/2026-08-02-product-management-ui-design.md
+++ b/docs/superpowers/specs/2026-08-02-product-management-ui-design.md
@@ -1,0 +1,216 @@
+# Product management UI — design
+
+> Status: **approved**, 2026-08-02. Implements
+> [`docs/rfcs/products.md`](../../rfcs/products.md) § Phased plan, **P3** —
+> the editing half that P0–P2 deliberately left out.
+> Issue: [#314](https://github.com/alexisbohns/arkaik/issues/314).
+> Predecessor spec: [`2026-08-02-multi-product-projects-design.md`](2026-08-02-multi-product-projects-design.md).
+
+## Problem
+
+Products are already first-class in the schema and honoured by all eight read
+surfaces. They are also **unauthorable by a human**: a product definition lives
+in `project.metadata.products` and membership in `node.metadata.product`, so
+creating one means hand-editing bundle JSON. The Pebbles seed proves an agent
+can do it; a person cannot.
+
+The gap has a sharp edge, found while implementing P2 rather than imagined.
+Standing under a named product scope, the Library's "Create node" button opens
+`components/panels/NewNodeForm.tsx`, whose `NewNodeFormData` is
+`{ title, species, status, platforms, metadata? }` — nothing populates
+`metadata.product`. The created node has no membership, and per § Decision 5 an
+unassigned flow or view appears under "All products" only. **The node vanishes
+from the scope the user is standing in**, with no explanation. The same form
+serves the Delivery page, the Acceptances page, `JourneyMap` and `SystemMap`.
+
+**Acceptance criterion:** products are manageable without editing JSON.
+
+## Decisions
+
+Each was taken explicitly during brainstorming; the rejected alternative is
+recorded because the reasoning is the point.
+
+### D1 — The create form prefills to the current scope, visibly and editably
+
+The picker opens pre-filled with the scoped product, plainly shown, and the user
+may change or clear it. Ambient state becomes a **visible default** rather than a
+silent stamp.
+
+*Rejected:* leaving it empty and warning on submit adds friction to every create
+for a case the default handles. Prefilling and **locking** while scoped is a
+simpler mental model but makes it impossible to create an admin view while
+looking at the end-user app — a real thing to want, and there is no other way to
+do it.
+
+### D2 — `product.id` is auto-slugged on create and immutable thereafter
+
+The id derives from the title (kebab-case, de-duplicated); renaming changes only
+`title`. Nothing ever rewrites `metadata.product` across nodes.
+
+*Rejected:* an editable id needs a multi-node membership rewrite that can
+half-fail, leaving a graph where some members point at the old key and some at
+the new. The id is near-invisible to the user; the title is the thing they read.
+
+### D3 — Deleting a product reassigns in the confirmation dialog
+
+The dialog names how many nodes hold the membership and offers *move them to
+‹product›* or *leave unassigned*. Both branches are one computed plan.
+
+*Rejected:* always leaving members unassigned silently drops data the user may
+not know they had. Blocking deletion while members exist forces exactly the
+tedium the bulk-move tool exists to remove.
+
+### D4 — The node form constrains platform choice to the product's menu
+
+Once a product is chosen, platform toggles outside its `platforms` menu are
+unavailable, and switching product prunes a selection that no longer fits. This
+prevents *new* violations of the containment rule at the source.
+
+The rule stays a **warning** in the validator, not an error — narrowing a
+product's platforms is a product decision and must never fail CI — so the
+manager still permits narrowing below what members use, and says so inline.
+Existing violations are reported, never rewritten.
+
+*Rejected:* allowing silently means the user watches platforms disappear at
+render time (`effectiveNodePlatforms` drops them) with no explanation.
+
+### D5 — An acceptance's picker shows always, and explains when anchors override
+
+Membership for an acceptance is **derived from its `covers` anchors**; the stored
+`metadata.product` is the answer only when it covers nothing (the intake case).
+The editor therefore always shows the control, but when anchors exist it renders
+the derived product(s) as the live answer and marks the stored value as the
+fallback it is.
+
+*Rejected:* hiding the control the moment a `covers` edge appears makes a field
+materialise and vanish as edges change. Treating it as a plain editable field
+lets a user set a value the graph silently ignores — the exact confusion
+`productsOfAcceptance` was written to prevent.
+
+### D6 — Library selection is a general mechanism; the move acts on the subset it can
+
+Checkbox multi-select is built as a reusable Library affordance whose first
+action is "Move to product". Data models and API endpoints **derive** membership
+and cannot be moved, but their checkboxes are not disabled — that would tie a
+general selection mechanism to one action. Instead the bar names the subset:
+*"moves 3 of 5 selected; data models and endpoints derive their product"*.
+
+The move menu offers every declared product **plus Unassigned**, so pulling nodes
+back out of a product is possible without JSON — which the acceptance criterion
+implies.
+
+### D7 — The manager edits title, description and platforms only
+
+`root_node_id` is **not** exposed. See § Known gaps.
+
+## Architecture
+
+Rules live in a pure module; components stay thin. This is the doctrine
+[`lib/utils/product-scope.ts`](../../../lib/utils/product-scope.ts) already
+follows, and it is the only shape unit-testable on a machine with no local
+Postgres — the same reason `tests/app/product-scope.test.js` exists.
+
+### 1. `lib/utils/product-editing.ts` — the rules
+
+Pure, React-free, provider-free. Every rule written exactly once.
+
+| Function | Answers |
+|---|---|
+| `deriveProductId(title, existingIds)` | Kebab-case slug, de-duplicated with a numeric suffix. A blank or non-latin title falls back to `product-N`, because `resolveProducts` **drops blank ids** and a product that cannot be resolved is not a product. |
+| `upsertProduct(products, draft)` | The `metadata.products` array in, a new array out. Declaration order is preserved — it is the order `ProductScopeSelector` renders. |
+| `removeProduct(products, id)` | Same shape, definition removed. |
+| `membersOfProduct(nodes, productId)` | Nodes whose **stored** `metadata.product` names it. Stored, never derived: those are the only nodes a deletion could orphan. |
+| `planProductDeletion(products, nodes, id, reassignTo)` | `{ products, reassignments: [{ nodeId, product }] }`. |
+| `planProductMove(nodes, ids, productId \| null)` | The same reassignment shape, for the bulk bar. `null` **removes** the key rather than storing an empty string — a blank membership is not a declaration. |
+| `platformMenuFor(product)` | The product's `platforms`; all of `PLATFORM_IDS` when the node is unassigned or the project declares no products. |
+| `constrainPlatforms(selected, menu)` | `selected ∩ menu`, ordered by `PLATFORM_IDS`. |
+
+Computing a whole plan before any write is what makes the two-store execution a
+single reviewable step, and what lets the destructive path be tested without a
+DOM or a database.
+
+`platformMenuFor` returning `[]` for a platform-less product is load-bearing: the
+node form then shows **no platform toggles at all** and a single status field.
+That is RFC decision 2 — *no platforms → single status* — arriving in the editor
+the same way it already arrives in the read surfaces.
+
+### 2. `lib/utils/apply-product-plan.ts` — the one two-store write
+
+Takes a plan and executes it against `updateProject` (the definitions) and
+`applyMutations` (the memberships). Deletion and bulk move both go through it, so
+the ordering and failure handling of a write that spans both stores is written
+once rather than twice.
+
+### 3. `components/settings/ProductManagerPanel.tsx`
+
+A third `<section>` in [`app/project/[id]/settings/page.tsx`](../../../app/project/[id]/settings/page.tsx),
+above Danger zone. Rows carry title, description, platform chips and member
+count, each with Edit and Delete. The empty state explains what a product is and
+offers **Add product**.
+
+- **Create / edit dialog** — title, description, platform toggles. The derived
+  slug renders as muted secondary text and is fixed after create (D2).
+- **Delete dialog** — member count plus *move to ‹product›* / *leave unassigned*
+  (D3), executed as one plan.
+- **Narrowing platforms** below what members use is permitted and shows an inline
+  note naming the affected count (D4).
+
+### 4. `components/panels/ProductPicker.tsx`
+
+One select, three consumers. It **renders only when the project declares
+products** and the species stores membership (`PRODUCT_MEMBERSHIP_SPECIES`). A
+project that never heard of products sees no new control anywhere — the same
+opt-in guarantee `ProductScopeSelector` already keeps, and the reason the
+degenerate case stays byte-identical to today.
+
+- **`NewNodeForm`** gains `products` and `defaultProductId`, threaded from
+  `scope` at all five call sites. Prefilled to the current scope (D1). Changing
+  species away from a membership-bearing one drops `metadata.product` from the
+  payload; changing product runs `constrainPlatforms` over the toggles (D4).
+- **`NodeDetailPanel`** gets the same picker on its edit path, so membership is
+  changeable per node.
+- **`AcceptanceEditor`** renders it per D5.
+
+### 5. Library bulk move
+
+Selection state on [`app/project/[id]/library/page.tsx`](../../../app/project/[id]/library/page.tsx),
+a checkbox on `NodeCard` and `NodeTable` rows, and a selection bar with the
+count, Clear, and **Move to product** (D6). Executed via `applyProductPlan` in
+one write.
+
+## Data flow
+
+```
+ProductManagerPanel ─┐
+LibrarySelectionBar ─┼─► product-editing (pure plan) ─► apply-product-plan ─► updateProject
+ProductPicker ───────┘                                                     └► applyMutations
+```
+
+No component computes a rule; no rule touches a store.
+
+## Testing
+
+Everything in `product-editing.ts` is unit-tested beside
+`tests/app/product-scope.test.js` — DB-free by construction:
+
+- slug derivation, collision suffixing, and the blank-title fallback;
+- `planProductDeletion` for both branches, including a product with no members;
+- `planProductMove` clearing a key rather than blanking it;
+- `constrainPlatforms` at the arity-0 and arity-1 boundaries;
+- the degenerate case: with no products declared, no plan changes anything.
+
+Components get static review plus a manual checklist for Alexis — there is no
+browser driver in this environment, so a visual pass is handed over rather than
+asserted.
+
+## Known gaps
+
+**`root_node_id` stays JSON-only** (D7). `resolveJourneyAnchorId` deliberately
+refuses to fall back to `project.root_node_id` under a named scope — handing
+Admin the end-user app's front door would walk a foreign compose chain under
+Admin's name. So a product created through this UI has **no journey anchor**, and
+its Journey page renders the empty state saying so. That is a real hole in
+"manageable without editing JSON" and deserves its own follow-up issue: a node
+picker for the product's anchor, reusing `NodeSearchCombobox`.
+
+**Per-surface product override** remains deferred, as it was in P2.

--- a/lib/config/platforms.ts
+++ b/lib/config/platforms.ts
@@ -6,6 +6,27 @@ export const PLATFORMS = [
   { id: "android", label: "Android", icon: "Bot" },
 ] as const satisfies readonly { id: PlatformId; label: string; icon: string }[];
 
+/**
+ * The human label for a platform id, **taking `unknown`**.
+ *
+ * `PLATFORM_LABELS` (components/graph/nodes/node-styles.ts) already answers this
+ * for a value the compiler knows is a `PlatformId`, and its four importers are
+ * right to use it. This exists for the other case, which products introduced:
+ * a platform id read out of `project.metadata.products[].platforms` or a node's
+ * own array is `unknown` at runtime whatever the type says — bundles are
+ * hand-edited and agent-edited, and `resolveProducts` is lenient by contract —
+ * so a total `Record<PlatformId, string>` cannot be indexed by it without a cast
+ * that asserts the very thing in doubt.
+ *
+ * An unrecognised id is echoed back rather than blanked or dropped: the same
+ * reading `platformCountLabel` and `productLabels` take, because showing the
+ * junk is what tells the author their bundle says something this build does not
+ * understand. `undefined` in a label slot tells them nothing.
+ */
+export function platformLabel(platform: unknown): string {
+  return PLATFORMS.find((entry) => entry.id === platform)?.label ?? String(platform);
+}
+
 export type { PlatformId };
 /** @deprecated Use PlatformId */
 export type Platform = PlatformId;

--- a/lib/hooks/useProductScope.ts
+++ b/lib/hooks/useProductScope.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useMemo, useSyncExternalStore } from "react";
+import type { ProductDefinition } from "@arkaik/schema";
 import type { ProjectBundle } from "@/lib/data/types";
 import {
   getProductScopeId,
@@ -64,4 +65,22 @@ export function useEffectiveProduct(
   const { productId, setScope } = useProductScope(projectId);
   const scope = useMemo(() => resolveProductScope(project, productId), [project, productId]);
   return useMemo(() => ({ ...scope, setScope }), [scope, setScope]);
+}
+
+/**
+ * The project's declared products as an array, in declaration order — what the
+ * create forms hand to `ProductPicker`.
+ *
+ * A one-liner with a hook around it, because the alternative is the same
+ * `[...scope.productsById.values()]` written at every surface that can create a
+ * node: the array identity feeds a dialog's props, so an unmemoized spread hands
+ * it a new array on every render of the page behind it, and the memo is only
+ * correct if its dependency is `productsById` rather than `scope` (which
+ * `useEffectiveProduct` rebuilds whenever `setScope` changes identity).
+ *
+ * Empty when the project declares no products, which is the value every caller
+ * guards on to render nothing at all — the degenerate-case guarantee.
+ */
+export function useProductList(scope: ProductScope): ProductDefinition[] {
+  return useMemo(() => [...scope.productsById.values()], [scope.productsById]);
 }

--- a/lib/hooks/useSeedOnOpen.ts
+++ b/lib/hooks/useSeedOnOpen.ts
@@ -30,7 +30,16 @@ export function useSeedOnOpen<T>(open: boolean, value: T, seed: (value: T) => vo
   // every render does not turn this into an every-render effect. Only `open` is
   // allowed to decide when it runs.
   const seedRef = useRef(seed);
-  seedRef.current = seed;
+
+  // Refreshed in an effect, not during render: writing a ref while rendering is
+  // a side effect in the render phase, which `react-hooks/refs` rejects and
+  // which concurrent rendering may run more than once per commit. Declared
+  // *before* the seeding effect so that on an opening render the callback is
+  // already current by the time the effect below reads it — effects in one
+  // component run in declaration order.
+  useEffect(() => {
+    seedRef.current = seed;
+  });
 
   useEffect(() => {
     const opening = open && !wasOpen.current;

--- a/lib/hooks/useSeedOnOpen.ts
+++ b/lib/hooks/useSeedOnOpen.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+/**
+ * Seed a dialog's form state on the **closed → open transition only**.
+ *
+ * The obvious spelling — `useEffect(() => { if (open) seed(value) }, [open,
+ * value])` — is wrong in a way that is easy to miss and hard to see in use: it
+ * also fires whenever `value` changes *while the dialog is already open*, and
+ * silently replaces whatever the user had picked. That is reachable here rather
+ * than theoretical, because every caller seeds from the product scope and
+ * `useEffectiveProduct` resolves against a bundle `useProject` loads in an
+ * effect — so `scope.productId` is `null` on the first render and arrives a beat
+ * later. A dialog opened inside that window would have its picker yanked out
+ * from under the user.
+ *
+ * The latch is a ref rather than state on purpose: it must not cause a render,
+ * and it must be updated on *every* run of the effect, including the ones this
+ * hook deliberately does nothing on.
+ *
+ * `seed` is called rather than `setState` handed in, so the caller can run the
+ * same constraint logic its onChange handler runs — seeding a product without
+ * pruning the platforms it forbids would let the form submit the exact
+ * containment violation the picker exists to prevent.
+ */
+export function useSeedOnOpen<T>(open: boolean, value: T, seed: (value: T) => void): void {
+  const wasOpen = useRef(false);
+  // The seed callback is read through a ref so that a caller which rebuilds it
+  // every render does not turn this into an every-render effect. Only `open` is
+  // allowed to decide when it runs.
+  const seedRef = useRef(seed);
+  seedRef.current = seed;
+
+  useEffect(() => {
+    const opening = open && !wasOpen.current;
+    wasOpen.current = open;
+    if (opening) seedRef.current(value);
+  }, [open, value]);
+}

--- a/lib/utils/apply-product-plan.ts
+++ b/lib/utils/apply-product-plan.ts
@@ -40,6 +40,16 @@ export interface ProductPlanStores {
  *
  * `products: null` means the definitions are untouched, so the project write is
  * skipped entirely rather than saved unchanged.
+ *
+ * The project write sends `{ ...projectMetadata, products }` built from the
+ * caller's **snapshot**, so another `metadata` field changed between that read
+ * and this write is reverted to its snapshot value. That is a last-write-wins
+ * seam this function cannot close on its own — but it is exactly the shape every
+ * other `updateProject` caller has, and `useProject`'s `updateProject`
+ * (lib/hooks/useProject.ts) narrows it deliberately: it re-reads the stored
+ * bundle and patches project-level fields onto the freshest copy, so concurrent
+ * *node and edge* edits survive. Only a concurrent edit to another
+ * `project.metadata` key loses, and settings is the one place that writes them.
  */
 export async function applyProductPlan(plan: ProductPlan, stores: ProductPlanStores): Promise<void> {
   const ops = planToOps(plan, stores.nodesById);

--- a/lib/utils/apply-product-plan.ts
+++ b/lib/utils/apply-product-plan.ts
@@ -1,0 +1,54 @@
+/**
+ * The one write in the app that spans both stores.
+ *
+ * Product definitions live on the project (`updateProject`) and memberships live
+ * on nodes (`applyMutations`), so every product edit that touches members is two
+ * writes that cannot be made one. Both callers — the delete dialog and the
+ * Library's bulk bar — go through here so the ordering below is decided once.
+ *
+ * Takes its stores as arguments rather than calling hooks, which keeps it a
+ * plain async function the test suite can drive with two spies.
+ */
+
+import type { Node, NodeMetadata, ProjectMetadata } from "@/lib/data/types";
+import { planToOps, type ProductPlan } from "./product-editing";
+
+type UpdateNodeOp = { op: "update_node"; node_id: string; patch: { metadata: NodeMetadata } };
+
+export interface ProductPlanStores {
+  /**
+   * The same node shape {@link planToOps} reads — `metadata` is what a patch has
+   * to carry through, and `species` is what the plan was filtered on, so the map
+   * is typed as the rules module's own input rather than as something narrower
+   * that would need a cast at the call below.
+   */
+  nodesById: ReadonlyMap<string, Pick<Node, "id" | "species" | "metadata">>;
+  projectMetadata: ProjectMetadata | undefined;
+  updateProject: (patch: { metadata: ProjectMetadata }) => Promise<unknown>;
+  applyMutations: (ops: UpdateNodeOp[]) => Promise<unknown>;
+}
+
+/**
+ * Memberships first, definitions second — and if the second write fails the
+ * result is a product that still exists whose members have already moved out of
+ * it. That is a *visible* half-state the user can finish by hand.
+ *
+ * The other order fails worse: deleting the definition first and then losing the
+ * membership write leaves nodes pointing at a product nobody declares. Every
+ * read surface survives that (a stale key resolves to unassigned), which is
+ * precisely the problem — nothing would tell the user it happened.
+ *
+ * `products: null` means the definitions are untouched, so the project write is
+ * skipped entirely rather than saved unchanged.
+ */
+export async function applyProductPlan(plan: ProductPlan, stores: ProductPlanStores): Promise<void> {
+  const ops = planToOps(plan, stores.nodesById);
+
+  if (ops.length > 0) await stores.applyMutations(ops);
+
+  if (plan.products !== null) {
+    await stores.updateProject({
+      metadata: { ...(stores.projectMetadata ?? {}), products: plan.products },
+    });
+  }
+}

--- a/lib/utils/product-editing.ts
+++ b/lib/utils/product-editing.ts
@@ -32,7 +32,7 @@ type NodeLike = Pick<Node, "id" | "species" | "metadata">;
  * Kebab-case, ASCII, no leading or trailing dash. Accents are folded rather
  * than dropped so that "Créateur" becomes "createur" and not "cr-ateur".
  */
-export function slugifyProductTitle(title: string): string {
+function slugifyProductTitle(title: string): string {
   return title
     .toLowerCase()
     .normalize("NFD")

--- a/lib/utils/product-editing.ts
+++ b/lib/utils/product-editing.ts
@@ -1,0 +1,250 @@
+/**
+ * The rules for *editing* products, as pure functions over plain data.
+ *
+ * The read side already works this way (lib/utils/product-scope.ts) and this is
+ * its mirror: the schema package owns what a product *means*, this module owns
+ * what an edit to one *does*, and no component here computes either.
+ *
+ * Every destructive operation returns a **plan** rather than performing itself.
+ * That is not ceremony — a product deletion touches the project's metadata and
+ * an arbitrary number of nodes across two different stores, and a plan is the
+ * only form of that operation which can be asserted on a machine with no
+ * database and no component test runner.
+ *
+ * Deliberately React-free and provider-free for the same reason.
+ */
+
+import { PLATFORMS, type PlatformId } from "@/lib/config/platforms";
+import type { Node, NodeMetadata } from "@/lib/data/types";
+import {
+  PRODUCT_MEMBERSHIP_SPECIES,
+  productOf,
+  type ProductDefinition,
+} from "@arkaik/schema";
+
+/** The canonical platform order, which every list this module emits follows. */
+const PLATFORM_ORDER: readonly PlatformId[] = PLATFORMS.map((platform) => platform.id);
+
+/** The minimum shape this module needs of a node — never the whole thing. */
+type NodeLike = Pick<Node, "id" | "species" | "metadata">;
+
+/**
+ * Kebab-case, ASCII, no leading or trailing dash. Accents are folded rather
+ * than dropped so that "Créateur" becomes "createur" and not "cr-ateur".
+ */
+export function slugifyProductTitle(title: string): string {
+  return title
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * The durable key a product is known by, derived once at create time and never
+ * changed afterwards (§ D2).
+ *
+ * **It can never be blank.** `resolveProducts` treats a blank id as *not a
+ * declaration* and drops the entry, so a title of "!!!" slugging to "" would
+ * produce a product that the app cannot see and the user cannot delete. The
+ * `product` fallback is what keeps that unreachable.
+ */
+export function deriveProductId(title: string, existingIds: readonly string[]): string {
+  const taken = new Set(existingIds);
+  const base = slugifyProductTitle(title) || "product";
+  if (!taken.has(base)) return base;
+
+  let suffix = 2;
+  while (taken.has(`${base}-${suffix}`)) suffix += 1;
+  return `${base}-${suffix}`;
+}
+
+/** What the create/edit dialog collects. The id is derived, never typed. */
+export interface ProductDraft {
+  id: string;
+  title: string;
+  description?: string;
+  platforms: PlatformId[];
+}
+
+/**
+ * The draft written into the definitions array — appended when new, replaced in
+ * place when it already exists, so declaration order (which is the order the
+ * scope selector renders) never shuffles under an edit.
+ *
+ * The existing definition is **spread first**, which is what preserves
+ * `root_node_id`. The manager does not expose the journey anchor (§ D7), so an
+ * edit that dropped it would silently un-anchor a product's journey and the user
+ * would have no way to tell, let alone put it back.
+ */
+export function upsertProduct(
+  products: readonly ProductDefinition[],
+  draft: ProductDraft,
+): ProductDefinition[] {
+  const existing = products.find((product) => product.id === draft.id);
+  const description = draft.description?.trim();
+
+  const next: ProductDefinition = {
+    ...(existing ?? {}),
+    id: draft.id,
+    title: draft.title.trim(),
+    platforms: PLATFORM_ORDER.filter((platform) => draft.platforms.includes(platform)),
+  };
+
+  if (description) next.description = description;
+  else delete next.description;
+
+  if (!existing) return [...products, next];
+  return products.map((product) => (product.id === draft.id ? next : product));
+}
+
+/** The definitions without this one. Membership is {@link planProductDeletion}'s job. */
+export function removeProduct(
+  products: readonly ProductDefinition[],
+  id: string,
+): ProductDefinition[] {
+  return products.filter((product) => product.id !== id);
+}
+
+/**
+ * Nodes whose **stored** `metadata.product` names this product.
+ *
+ * Stored, never derived, and the distinction matters: an acceptance covering an
+ * admin view *reads* as admin everywhere, but its membership is its anchors'
+ * and deleting the product cannot orphan a key it never had. Only a stored key
+ * can go stale, so only stored keys are what a deletion has to answer for.
+ */
+export function membersOfProduct<N extends NodeLike>(
+  nodes: readonly N[],
+  productId: string,
+): N[] {
+  return nodes.filter((node) => productOf(node) === productId);
+}
+
+/** One node's membership changing. `null` means "unassign". */
+export interface ProductReassignment {
+  nodeId: string;
+  product: string | null;
+}
+
+/**
+ * A complete product edit, computed before anything is written.
+ *
+ * `products: null` means "the definitions are unchanged" — a bulk move touches
+ * memberships only, and passing the unchanged array would make the executor
+ * write the project for no reason.
+ */
+export interface ProductPlan {
+  products: ProductDefinition[] | null;
+  reassignments: ProductReassignment[];
+}
+
+/** Delete a product and say what happens to its members (§ D3). */
+export function planProductDeletion(
+  products: readonly ProductDefinition[],
+  nodes: readonly NodeLike[],
+  id: string,
+  reassignTo: string | null,
+): ProductPlan {
+  return {
+    products: removeProduct(products, id),
+    reassignments: membersOfProduct(nodes, id).map((node) => ({ nodeId: node.id, product: reassignTo })),
+  };
+}
+
+/**
+ * Move the selected nodes into a product, or out of every product (§ D6).
+ *
+ * Two filters, both load-bearing. Species that **derive** membership are
+ * skipped, because writing `metadata.product` on a data model produces a key
+ * every read surface ignores and the validator warns about
+ * (`product-membership-wrong-species`) — the bulk bar tells the user how many of
+ * their selection this drops. Nodes already in the target are skipped so a
+ * re-application is a no-op rather than a pile of empty writes.
+ */
+export function planProductMove(
+  nodes: readonly NodeLike[],
+  nodeIds: readonly string[],
+  productId: string | null,
+): ProductPlan {
+  const wanted = new Set(nodeIds);
+  return {
+    products: null,
+    reassignments: nodes
+      .filter((node) => wanted.has(node.id))
+      .filter((node) => PRODUCT_MEMBERSHIP_SPECIES.includes(node.species))
+      .filter((node) => productOf(node) !== productId)
+      .map((node) => ({ nodeId: node.id, product: productId })),
+  };
+}
+
+/**
+ * This node's metadata with its membership set, or **removed**.
+ *
+ * Removed rather than blanked: `productOf` reads any string, so `product: ""`
+ * would be a membership naming a product that cannot exist, and
+ * `resolveProducts` would never match it. Unassigned has to mean *absent*.
+ *
+ * The rest of the metadata is carried through untouched — `platformStatuses`,
+ * notes and screenshots all live in the same object, and a patch that replaced
+ * it wholesale would take a view's per-platform statuses with it.
+ */
+export function withProductMembership(
+  metadata: NodeMetadata | undefined,
+  product: string | null,
+): NodeMetadata {
+  const next: Record<string, unknown> = { ...(metadata ?? {}) };
+  if (product === null) delete next.product;
+  else next.product = product;
+  return next as NodeMetadata;
+}
+
+/**
+ * A plan's reassignments as mutation ops, so the whole membership half commits
+ * as one atomic write (`applyMutations`) rather than as N racing patches.
+ *
+ * Pure, and here rather than in the executor deliberately: this is where the
+ * "preserve the rest of the metadata" rule is actually applied, and it is worth
+ * an assertion.
+ */
+export function planToOps(
+  plan: ProductPlan,
+  nodesById: ReadonlyMap<string, NodeLike>,
+): { op: "update_node"; node_id: string; patch: { metadata: NodeMetadata } }[] {
+  return plan.reassignments.map(({ nodeId, product }) => ({
+    op: "update_node" as const,
+    node_id: nodeId,
+    patch: { metadata: withProductMembership(nodesById.get(nodeId)?.metadata, product) },
+  }));
+}
+
+/**
+ * The platforms a node in this product may claim — the containment rule as the
+ * node form enforces it (§ D4).
+ *
+ * Three distinct answers, and the empty one is not an error. A product with
+ * `platforms: []` says availability is not a tracked dimension here (a CLI, a
+ * public API), so the form shows no platform toggles at all and a single
+ * lifecycle status — RFC decision 2, arriving in the editor exactly as it
+ * already arrives in the read surfaces. `null` — unassigned, or a project that
+ * declares no products — means every platform, which is today's behaviour
+ * unchanged.
+ *
+ * An unrecognised or malformed definition degrades to every platform rather than
+ * to none: `resolveProducts` is lenient by contract, and a stored product with
+ * no `platforms` array must never leave a user unable to tick anything.
+ */
+export function platformMenuFor(product: ProductDefinition | null | undefined): PlatformId[] {
+  if (!product || !Array.isArray(product.platforms)) return [...PLATFORM_ORDER];
+  const menu = new Set<string>(product.platforms as string[]);
+  return PLATFORM_ORDER.filter((platform) => menu.has(platform));
+}
+
+/** `selected ∩ menu`, canonically ordered — what a product change prunes to. */
+export function constrainPlatforms(
+  selected: readonly PlatformId[],
+  menu: readonly PlatformId[],
+): PlatformId[] {
+  return PLATFORM_ORDER.filter((platform) => selected.includes(platform) && menu.includes(platform));
+}

--- a/lib/utils/product-editing.ts
+++ b/lib/utils/product-editing.ts
@@ -96,7 +96,14 @@ export function upsertProduct(
   else delete next.description;
 
   if (!existing) return [...products, next];
-  return products.map((product) => (product.id === draft.id ? next : product));
+
+  // Only the **first** match is replaced. `resolveProducts` is first-wins, so in
+  // a bundle that somehow carries a duplicate id the first entry is the one the
+  // whole app sees and therefore the only one an edit means. Replacing both
+  // would leave two identical definitions and quietly launder a bundle the
+  // validator is supposed to keep warning about (`product-duplicate-id`).
+  const at = products.indexOf(existing);
+  return products.map((product, index) => (index === at ? next : product));
 }
 
 /** The definitions without this one. Membership is {@link planProductDeletion}'s job. */
@@ -140,16 +147,42 @@ export interface ProductPlan {
   reassignments: ProductReassignment[];
 }
 
-/** Delete a product and say what happens to its members (§ D3). */
+/**
+ * Delete a product and say what happens to its members (§ D3).
+ *
+ * Two guards, both about not manufacturing the exact stale key that
+ * `apply-product-plan.ts` reorders its two writes to avoid.
+ *
+ * **The destination must survive the deletion.** `reassignTo` is normalized to
+ * `null` when it names the product being deleted, or a product this project does
+ * not declare. The dialog offers neither, but the argument is a plain string and
+ * the cost of trusting it is a plan that rewrites every member to point at a
+ * product the very same plan removes — nodes carrying a key nobody declares,
+ * which every read surface silently degrades to unassigned. Unassigning them
+ * outright reaches the same place *visibly*.
+ *
+ * **An undeclared product has no members to answer for.** Deleting an id that is
+ * not in `products` is a no-op rather than a sweep of every node whose stored key
+ * happens to match: nodes can carry a key for a product that was never declared
+ * (a half-synced bundle, a hand-edited file), and a project that has never heard
+ * of products must not have its metadata rewritten by a deletion it did not
+ * declare. That is the degenerate-case guarantee, asserted below.
+ */
 export function planProductDeletion(
   products: readonly ProductDefinition[],
   nodes: readonly NodeLike[],
   id: string,
   reassignTo: string | null,
 ): ProductPlan {
+  const remaining = removeProduct(products, id);
+  const declared = products.some((product) => product.id === id);
+  const destination = remaining.some((product) => product.id === reassignTo) ? reassignTo : null;
+
   return {
-    products: removeProduct(products, id),
-    reassignments: membersOfProduct(nodes, id).map((node) => ({ nodeId: node.id, product: reassignTo })),
+    products: remaining,
+    reassignments: declared
+      ? membersOfProduct(nodes, id).map((node) => ({ nodeId: node.id, product: destination }))
+      : [],
   };
 }
 
@@ -169,14 +202,32 @@ export function planProductMove(
   productId: string | null,
 ): ProductPlan {
   const wanted = new Set(nodeIds);
+  // A blank target is the same request as "unassign" — see
+  // {@link withProductMembership}. Normalized here as well as there so that the
+  // "already in the target" filter compares against the value that will actually
+  // be written, rather than skipping a node whose membership is a stored "".
+  const target = normalizeMembership(productId);
+
   return {
     products: null,
     reassignments: nodes
       .filter((node) => wanted.has(node.id))
       .filter((node) => PRODUCT_MEMBERSHIP_SPECIES.includes(node.species))
-      .filter((node) => productOf(node) !== productId)
-      .map((node) => ({ nodeId: node.id, product: productId })),
+      .filter((node) => normalizeMembership(productOf(node)) !== target)
+      .map((node) => ({ nodeId: node.id, product: target })),
   };
+}
+
+/**
+ * A membership value as it will be stored: a real id, or `null`.
+ *
+ * `""` and `"   "` are not products. `resolveProducts` drops a definition whose
+ * id is blank, so a blank membership names something that cannot exist and can
+ * only ever resolve to unassigned — which makes it a slower, invisible spelling
+ * of `null`, and the one an empty text field or a cleared select produces.
+ */
+function normalizeMembership(product: string | null | undefined): string | null {
+  return typeof product === "string" && product.trim() !== "" ? product : null;
 }
 
 /**
@@ -184,7 +235,9 @@ export function planProductMove(
  *
  * Removed rather than blanked: `productOf` reads any string, so `product: ""`
  * would be a membership naming a product that cannot exist, and
- * `resolveProducts` would never match it. Unassigned has to mean *absent*.
+ * `resolveProducts` would never match it. Unassigned has to mean *absent*, so a
+ * blank or whitespace-only argument is treated exactly as `null` — otherwise
+ * this function would write the very value its own contract forbids.
  *
  * The rest of the metadata is carried through untouched — `platformStatuses`,
  * notes and screenshots all live in the same object, and a patch that replaced
@@ -194,9 +247,10 @@ export function withProductMembership(
   metadata: NodeMetadata | undefined,
   product: string | null,
 ): NodeMetadata {
+  const membership = normalizeMembership(product);
   const next: Record<string, unknown> = { ...(metadata ?? {}) };
-  if (product === null) delete next.product;
-  else next.product = product;
+  if (membership === null) delete next.product;
+  else next.product = membership;
   return next as NodeMetadata;
 }
 
@@ -207,16 +261,28 @@ export function withProductMembership(
  * Pure, and here rather than in the executor deliberately: this is where the
  * "preserve the rest of the metadata" rule is actually applied, and it is worth
  * an assertion.
+ *
+ * **A node the map does not know is dropped, not patched.** A plan is computed
+ * from one snapshot and executed against whatever the store holds a moment
+ * later — a delete dialog left open across a refetch, a bulk selection that
+ * outlives the list it was made in — so a missing id is reachable, not
+ * theoretical. Patching it anyway would send `withProductMembership(undefined,
+ * …)`, an object built from *no* prior metadata, and since a patch replaces
+ * `metadata` wholesale that op would delete the node's `platformStatuses`, notes
+ * and screenshots as a side effect of a product change. Emitting nothing loses
+ * only the membership edit, which the user can see did not happen.
  */
 export function planToOps(
   plan: ProductPlan,
   nodesById: ReadonlyMap<string, NodeLike>,
 ): { op: "update_node"; node_id: string; patch: { metadata: NodeMetadata } }[] {
-  return plan.reassignments.map(({ nodeId, product }) => ({
-    op: "update_node" as const,
-    node_id: nodeId,
-    patch: { metadata: withProductMembership(nodesById.get(nodeId)?.metadata, product) },
-  }));
+  return plan.reassignments
+    .filter(({ nodeId }) => nodesById.has(nodeId))
+    .map(({ nodeId, product }) => ({
+      op: "update_node" as const,
+      node_id: nodeId,
+      patch: { metadata: withProductMembership(nodesById.get(nodeId)?.metadata, product) },
+    }));
 }
 
 /**

--- a/lib/utils/product-scope.ts
+++ b/lib/utils/product-scope.ts
@@ -118,6 +118,40 @@ export function platformCountLabel(platforms: unknown): string {
 }
 
 /**
+ * **What to call ONE product on screen, written once.**
+ *
+ * `title` is not validated by `resolveProducts` — a definition needs only an id
+ * to resolve, and bundles are hand-edited and agent-edited, so at runtime the
+ * title can be absent, blank, or not a string whatever the type says. Falling
+ * back to the id keeps a real, clickable row instead of a blank one.
+ *
+ * It lives here rather than in each surface because the fallback has to be
+ * **identical everywhere**: the settings manager's row, the dialog that deletes
+ * that row, the scope selector and the node picker all name the same malformed
+ * product, and a user who reads `admin-dashboard` in one place and an empty pill
+ * in another cannot tell they are the same thing. Four copies of a one-line rule
+ * stay in sync exactly until one of them does not.
+ *
+ * It lives *next to* {@link productLabels} because that is the plural, ordered
+ * form of the same fallback — over ids and a scope rather than over a definition
+ * — and the two answers must never disagree. It is deliberately NOT in
+ * lib/utils/product-editing.ts, which would be the other natural home: that
+ * module is not part of this one's module graph, and importing it here would
+ * make every test loader that builds product-scope.ts (pyramid, delivery,
+ * coverage, acceptance-matrix, journey-graph) build product-editing.ts too, for
+ * a display rule none of them exercise.
+ *
+ * Tolerates `null` so a dialog rendering on its way out, with its subject
+ * already cleared, gets an empty string rather than a throw.
+ */
+export function productDisplayTitle(
+  product: Pick<ProductDefinition, "id" | "title"> | null | undefined,
+): string {
+  if (!product) return "";
+  return typeof product.title === "string" && product.title.trim() !== "" ? product.title : product.id;
+}
+
+/**
  * The selector's options, in declaration order. **Products only** — the "All
  * products" entry is the selector's own affordance, not a product, so an empty
  * result here means "this project has no products" and the control does not
@@ -129,17 +163,17 @@ export function platformCountLabel(platforms: unknown): string {
  * `metadata` of its own, and every caller that has to remember that is a caller
  * that can forget.
  *
- * `title` is not validated by `resolveProducts` — a definition missing one is a
- * shape fault owned by the parser and the JSON Schema, so at runtime it can be
- * absent whatever the type says. Falling back to the id keeps a real, clickable
- * row instead of a blank one.
+ * The title fallback is {@link productDisplayTitle}'s, not a copy of it — a
+ * definition missing a title is a shape fault the parser owns, so at runtime it
+ * can be absent whatever the type says, and the row the selector shows for it
+ * has to read identically to the row the settings manager shows.
  */
 export function productScopeOptions(
   bundle: { project?: Pick<Project, "metadata"> } | undefined | null,
 ): ProductScopeOption[] {
   return resolveProducts(bundle?.project).map((product) => ({
     id: product.id,
-    label: typeof product.title === "string" && product.title.trim() !== "" ? product.title : product.id,
+    label: productDisplayTitle(product),
     platformLabel: platformCountLabel(product.platforms),
   }));
 }
@@ -290,8 +324,9 @@ export function productLabels(ids: Iterable<string>, scope: ProductScope): strin
   const declared = [...scope.productsById.keys()].filter((id) => products.has(id));
   const undeclared = [...products].filter((id) => !scope.productsById.has(id));
   return [...declared, ...undeclared].map((id) => {
-    const title = scope.productsById.get(id)?.title;
-    return typeof title === "string" && title.trim() !== "" ? title : id;
+    // The singular fallback, not a copy of it — an id the project no longer
+    // declares has no definition to read a title from, and reads as itself.
+    return productDisplayTitle(scope.productsById.get(id) ?? { id, title: "" });
   });
 }
 

--- a/lib/utils/product-scope.ts
+++ b/lib/utils/product-scope.ts
@@ -237,22 +237,9 @@ export function productsOfNode(
  * The products this node belongs to, as **titles ready to render**, in the
  * project's declaration order.
  *
- * Display only — {@link productsOfNode} owns the membership answer and this adds
- * nothing to it but ordering and a label. Both are worth doing once rather than
- * per surface: a `Set`'s iteration order is insertion order, which for a data
- * model reached by three products is whatever the traversal happened to hit
- * first, and "Used by: Admin, End-user" flipping between renders of the same
- * graph reads as a change when nothing changed.
- *
- * Ids the project no longer declares sort last and render as themselves. They
- * are the stale-key case `ProductScopeSelector` also has to survive, and the
- * honest thing to show is the id — dropping it would silently under-report who
- * touches a data model.
- *
- * `title` is not validated by `resolveProducts` — a definition missing one is a
- * shape fault owned by the parser, so at runtime it can be absent whatever the
- * type says. Falling back to the id keeps a real badge instead of a blank one,
- * exactly as `productScopeOptions` does.
+ * Display only, and a composition of two functions that each own one half:
+ * {@link productsOfNode} answers the membership, {@link productLabels} owns the
+ * ordering and the title fallback. Neither rule is written here.
  *
  * An **empty result keeps both its meanings** and the caller resolves them, as
  * with {@link productsOfNode}: for a flow, view, or acceptance it is *nobody has
@@ -264,7 +251,42 @@ export function productLabelsOfNode(
   scope: ProductScope,
   graph: ProductGraph,
 ): string[] {
-  const products = productsOfNode(node, graph);
+  return productLabels(productsOfNode(node, graph), scope);
+}
+
+/**
+ * **The ordering and the title fallback, written once** — a set of product ids
+ * as titles ready to render. {@link productLabelsOfNode} is this function plus a
+ * membership answer, and holds no copy of either rule.
+ *
+ * It is separate from `productLabelsOfNode` for the caller that already *has*
+ * the ids: the acceptance editor derives its own membership through
+ * {@link productsOfAcceptance} (anchors, no traversal), and routing that through
+ * `productLabelsOfNode` would re-enter {@link productsOfNode} and demand a
+ * `usageIndex` — a full `buildProductUsageIndex` traversal — to answer a question
+ * about a species that never consults it. The editor duplicated both rules inline
+ * instead, which is exactly the drift this module exists to prevent.
+ *
+ * **Declaration order first, undeclared ids last.** A `Set` iterates in insertion
+ * order, which for a data model reached by three products is whatever the
+ * traversal happened to hit first; "Used by: Admin, End-user" flipping between
+ * renders of the same graph reads as a change when nothing changed. Ids the
+ * project no longer declares sort last and render as themselves — they are the
+ * stale-key case `ProductScopeSelector` also has to survive, and the honest thing
+ * to show is the id, since dropping it would silently under-report who touches a
+ * node.
+ *
+ * `title` is not validated by `resolveProducts` — a definition missing one is a
+ * shape fault owned by the parser, so at runtime it can be absent whatever the
+ * type says. Falling back to the id keeps a real badge instead of a blank one,
+ * exactly as `productScopeOptions` does.
+ *
+ * Takes an `Iterable` rather than a `Set` so a caller holding an array of ids
+ * need not build one; membership is tested against the *scope*, never against
+ * the argument, so order of iteration is the only thing read from it.
+ */
+export function productLabels(ids: Iterable<string>, scope: ProductScope): string[] {
+  const products = ids instanceof Set ? ids : new Set(ids);
   const declared = [...scope.productsById.keys()].filter((id) => products.has(id));
   const undeclared = [...products].filter((id) => !scope.productsById.has(id));
   return [...declared, ...undeclared].map((id) => {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test:value-icons": "node tests/app/value-icons.test.js",
     "test:acceptance-matrix": "node tests/app/acceptance-matrix.test.js",
     "test:product-scope": "node tests/app/product-scope.test.js",
+    "test:product-editing": "node tests/app/product-editing.test.js",
     "test:mcp": "npm run build -w arkaik && npm run build -w arkaik-mcp && node tests/mcp/run-mcp-tests.js && node tests/mcp/remote-store.test.js && node tests/mcp/version.test.js",
     "test:journal-projections": "node tests/data/journal-projections.test.js",
     "test:emit": "node tests/schema/emit.test.js",

--- a/tests/app/load-product-editing.js
+++ b/tests/app/load-product-editing.js
@@ -57,6 +57,10 @@ function loadProductEditing() {
   }
 
   return {
+    // Picked, not spread: PLATFORMS itself has no business shadowing anything
+    // here, but `platformLabel` is a rule this suite asserts — the unknown-id
+    // fallback every product surface leans on.
+    platformLabel: require(path.join(BUILD_DIR, "platforms.js")).platformLabel,
     ...require(path.join(BUILD_DIR, "product-editing.js")),
     ...require(path.join(BUILD_DIR, "apply-product-plan.js")),
   };

--- a/tests/app/load-product-editing.js
+++ b/tests/app/load-product-editing.js
@@ -1,0 +1,65 @@
+/**
+ * Loads lib/utils/product-editing.ts and lib/utils/apply-product-plan.ts into a
+ * plain Node process, following the tests/app/load-*.js idiom.
+ *
+ * Both modules are deliberately React-free and provider-free, which is the
+ * whole reason the product-editing rules live there rather than inside the
+ * components that call them: this repo has no component test runner, and a rule
+ * inside a dialog is a rule nothing can assert.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const ts = require("typescript");
+const { loadSchema, BUILD_DIR: SCHEMA_BUILD_DIR } = require("../schema/load-schema");
+
+const ROOT = path.join(__dirname, "..", "..");
+const BUILD_DIR = path.join(__dirname, ".test-build-product-editing");
+
+const MODULES = [
+  // PLATFORMS is imported as a *value* (it is the canonical platform order), so
+  // the config module has to exist on disk for the require to resolve.
+  ["lib/config/platforms.ts", "platforms"],
+  ["lib/utils/product-editing.ts", "product-editing"],
+  ["lib/utils/apply-product-plan.ts", "apply-product-plan"],
+];
+
+function loadProductEditing() {
+  loadSchema();
+
+  fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+  fs.mkdirSync(BUILD_DIR, { recursive: true });
+  fs.writeFileSync(path.join(BUILD_DIR, "package.json"), JSON.stringify({ type: "commonjs" }));
+
+  const schemaIndex = path.join(SCHEMA_BUILD_DIR, "index.js");
+
+  for (const [srcRel, outName] of MODULES) {
+    const source = fs.readFileSync(path.join(ROOT, srcRel), "utf8");
+    const { outputText } = ts.transpileModule(source, {
+      fileName: path.basename(srcRel),
+      compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2020, esModuleInterop: true },
+    });
+
+    // `@/lib/data/types` is imported type-only and is elided by the transpiler;
+    // `@arkaik/schema` and `@/lib/config/platforms` are real requires, pointed at
+    // the schema test build and the sibling output respectively. The relative
+    // `./product-editing` import is rewritten too so the emitted CommonJS
+    // resolves inside this flat build directory.
+    const rewritten = outputText
+      .replace(/require\((['"])@arkaik\/schema\1\)/g, `require(${JSON.stringify(schemaIndex)})`)
+      .replace(/require\((['"])@\/lib\/config\/platforms\1\)/g, `require("./platforms.js")`)
+      .replace(/require\((['"])\.\/product-editing\1\)/g, `require("./product-editing.js")`);
+    fs.writeFileSync(path.join(BUILD_DIR, `${outName}.js`), rewritten);
+  }
+
+  for (const [, outName] of MODULES) {
+    delete require.cache[path.join(BUILD_DIR, `${outName}.js`)];
+  }
+
+  return {
+    ...require(path.join(BUILD_DIR, "product-editing.js")),
+    ...require(path.join(BUILD_DIR, "apply-product-plan.js")),
+  };
+}
+
+module.exports = { loadProductEditing, BUILD_DIR };

--- a/tests/app/product-editing.test.js
+++ b/tests/app/product-editing.test.js
@@ -7,7 +7,19 @@
  * make: that `planProductMove` silently skips the species which *derive*
  * membership (moving a data model would write a key every read surface ignores),
  * and that with no products declared no plan changes anything — the degenerate
- * case guarantee, which is the whole reason products stayed opt-in.
+ * case guarantee, which is the whole reason products stayed opt-in. The latter
+ * runs against a node set that still carries stored membership keys, because an
+ * empty-in/empty-out version of it would pass an implementation that does
+ * nothing at all.
+ *
+ * Two more earn their place by being data-loss shaped rather than logic shaped:
+ * `planToOps` must emit NO op for a node its map has lost (a patch replaces
+ * `metadata` wholesale, so the op it would otherwise emit deletes the node's
+ * platform statuses and notes), and `planProductDeletion` must never reassign
+ * members into the product it is deleting.
+ *
+ * `applyProductPlan` is exercised with two recording spies — the ordering of its
+ * two writes is its entire reason for existing, and nothing else can observe it.
  */
 
 const assert = require("node:assert/strict");
@@ -25,6 +37,7 @@ const {
   platformMenuFor,
   constrainPlatforms,
   withProductMembership,
+  applyProductPlan,
 } = loadProductEditing();
 
 let failures = 0;
@@ -37,6 +50,40 @@ function test(name, fn) {
     console.error(`  not ok - ${name}`);
     console.error(`    ${err.message}`);
   }
+}
+
+/** The same harness for `applyProductPlan`, the one async export here. */
+async function asyncTest(name, fn) {
+  try {
+    await fn();
+    console.log(`  ok - ${name}`);
+  } catch (err) {
+    failures += 1;
+    console.error(`  not ok - ${name}`);
+    console.error(`    ${err.message}`);
+  }
+}
+
+/**
+ * Two recording spies standing in for the two stores. `calls` is shared and
+ * ordered, which is the point: the ordering of the membership write against the
+ * definition write is the whole reason `applyProductPlan` exists.
+ */
+function makeStores(projectMetadata) {
+  const calls = [];
+  return {
+    calls,
+    stores: {
+      nodesById: new Map(NODES.map((n) => [n.id, n])),
+      projectMetadata,
+      updateProject: async (patch) => {
+        calls.push(["updateProject", patch]);
+      },
+      applyMutations: async (ops) => {
+        calls.push(["applyMutations", ops]);
+      },
+    },
+  };
 }
 
 const PRODUCTS = [
@@ -94,6 +141,19 @@ test("upsertProduct orders platforms canonically and drops a blank description",
   assert.equal("description" in next[0], false);
 });
 
+test("upsertProduct replaces only the first of a duplicated id", () => {
+  // resolveProducts is first-wins, so the first entry is the one the app sees
+  // and the only one an edit can mean. The stale twin stays for the validator.
+  const duplicated = [
+    { id: "admin", title: "Admin", platforms: ["web"] },
+    { id: "admin", title: "Admin (stale twin)", platforms: [] },
+  ];
+  const next = upsertProduct(duplicated, { id: "admin", title: "Console", platforms: ["web"] });
+  assert.equal(next.length, 2);
+  assert.equal(next[0].title, "Console");
+  assert.equal(next[1].title, "Admin (stale twin)");
+});
+
 test("removeProduct drops only the named definition", () => {
   assert.deepEqual(removeProduct(PRODUCTS, "admin").map((p) => p.id), ["app", "api"]);
   assert.deepEqual(removeProduct(PRODUCTS, "nope").map((p) => p.id), ["app", "admin", "api"]);
@@ -122,6 +182,26 @@ test("planProductDeletion of an empty product touches no node", () => {
   assert.deepEqual(plan.reassignments, []);
 });
 
+test("planProductDeletion refuses to reassign into the product it deletes", () => {
+  // Otherwise every member ends up naming a product the same plan removes —
+  // the stale key apply-product-plan orders its two writes to avoid.
+  const plan = planProductDeletion(PRODUCTS, NODES, "admin", "admin");
+  assert.deepEqual(plan.products.map((p) => p.id), ["app", "api"]);
+  assert.deepEqual(plan.reassignments.map((r) => r.product), [null, null]);
+});
+
+test("planProductDeletion refuses a destination this project does not declare", () => {
+  const plan = planProductDeletion(PRODUCTS, NODES, "admin", "ghost");
+  assert.deepEqual(plan.reassignments.map((r) => r.product), [null, null]);
+});
+
+test("planProductDeletion of an undeclared product touches nothing", () => {
+  // Nodes can carry a key for a product nobody declares (a half-synced bundle).
+  // Deleting what was never declared must not sweep them.
+  const plan = planProductDeletion([], NODES, "admin", null);
+  assert.deepEqual(plan.reassignments, []);
+});
+
 test("planProductMove skips the species that derive membership", () => {
   const plan = planProductMove(NODES, ["V-home", "D-user", "A-loads"], "app");
   assert.deepEqual(plan.reassignments, [
@@ -141,9 +221,26 @@ test("planProductMove to null unassigns", () => {
   assert.deepEqual(plan.reassignments, [{ nodeId: "V-home", product: null }]);
 });
 
+test("planProductMove treats a blank target as unassign", () => {
+  const blank = [{ id: "V-blank", species: "view", metadata: { product: "   " } }];
+  assert.deepEqual(planProductMove(NODES, ["V-home"], "  ").reassignments, [
+    { nodeId: "V-home", product: null },
+  ]);
+  // And a node already storing a blank key is already unassigned, so moving it
+  // to Unassigned is a no-op rather than a write that changes nothing.
+  assert.deepEqual(planProductMove(blank, ["V-blank"], null).reassignments, []);
+});
+
 test("withProductMembership removes the key rather than blanking it", () => {
   assert.deepEqual(withProductMembership({ product: "admin", note: "keep me" }, null), { note: "keep me" });
   assert.deepEqual(withProductMembership(undefined, "app"), { product: "app" });
+});
+
+test("withProductMembership treats a blank product exactly as null", () => {
+  // `product: ""` names a product resolveProducts can never match — a slower,
+  // invisible spelling of unassigned, and the one a cleared field produces.
+  assert.deepEqual(withProductMembership({ product: "admin", note: "keep me" }, ""), { note: "keep me" });
+  assert.deepEqual(withProductMembership({ product: "admin" }, "   "), {});
 });
 
 test("planToOps patches metadata and preserves the rest of it", () => {
@@ -152,6 +249,21 @@ test("planToOps patches metadata and preserves the rest of it", () => {
   assert.deepEqual(ops, [
     { op: "update_node", node_id: "V-home", patch: { metadata: { note: "keep me" } } },
   ]);
+});
+
+test("planToOps emits nothing for a node the map does not know", () => {
+  // A plan is computed from one snapshot and executed against a possibly newer
+  // map. Patching a vanished node would send metadata built from `undefined`,
+  // and since a patch replaces `metadata` wholesale that op would take the
+  // node's platformStatuses, notes and screenshots with it.
+  const plan = planProductMove(NODES, ["V-home", "F-signup"], "api");
+  assert.equal(plan.reassignments.length, 2);
+
+  const stale = new Map([["F-signup", NODES[2]]]);
+  assert.deepEqual(planToOps(plan, stale), [
+    { op: "update_node", node_id: "F-signup", patch: { metadata: { product: "api" } } },
+  ]);
+  assert.deepEqual(planToOps(plan, new Map()), []);
 });
 
 test("platformMenuFor: a product's own menu, canonically ordered", () => {
@@ -175,16 +287,66 @@ test("constrainPlatforms prunes a selection the product forbids", () => {
 });
 
 test("degenerate case: with no products declared, no plan changes anything", () => {
-  const plan = planProductDeletion([], NODES, "nope", null);
-  assert.deepEqual(plan.products, []);
-  assert.deepEqual(plan.reassignments, []);
-  assert.deepEqual(planToOps(plan, new Map()), []);
+  // Deliberately run against a NON-empty node set that still carries stored
+  // `metadata.product` keys — a half-synced bundle, or a project whose products
+  // were removed. An emptiness-only assertion here would pass an implementation
+  // that does nothing at all, which is the opposite of what is being claimed:
+  // the guarantee is that a product-less project is *untouched*, not that the
+  // functions are inert.
+  const nodesById = new Map(NODES.map((n) => [n.id, n]));
+  assert.equal(NODES.filter((n) => n.metadata.product !== undefined).length, 3);
+
+  for (const id of ["admin", "app", "nope"]) {
+    const plan = planProductDeletion([], NODES, id, null);
+    assert.deepEqual(plan.products, [], `${id}: definitions`);
+    assert.deepEqual(plan.reassignments, [], `${id}: reassignments`);
+    assert.deepEqual(planToOps(plan, nodesById), [], `${id}: ops`);
+  }
+
+  // And the node form is unchanged: every platform stays on offer.
+  assert.deepEqual(platformMenuFor(null), ["web", "ios", "android"]);
 });
 
-// The transpiled CommonJS is a build artefact, not a fixture: leaving it behind
-// makes the next run's `require` cache and the working tree both dirtier than
-// they need to be. Matches tests/app/product-scope.test.js.
-fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+console.log("\napply-product-plan");
 
-console.log(failures === 0 ? "\nAll product-editing tests passed" : `\n${failures} failing`);
-process.exit(failures === 0 ? 0 : 1);
+async function main() {
+  await asyncTest("applyProductPlan writes memberships before definitions", async () => {
+    // If the definition write lands first and the membership write is then lost,
+    // nodes point at a product nobody declares and every read surface degrades
+    // silently. This order fails visibly instead.
+    const { calls, stores } = makeStores({ title: "Demo" });
+    await applyProductPlan(planProductDeletion(PRODUCTS, NODES, "admin", "app"), stores);
+
+    assert.deepEqual(calls.map(([name]) => name), ["applyMutations", "updateProject"]);
+    assert.deepEqual(calls[0][1], [
+      { op: "update_node", node_id: "V-home", patch: { metadata: { product: "app", note: "keep me" } } },
+      { op: "update_node", node_id: "V-list", patch: { metadata: { product: "app" } } },
+    ]);
+    // The rest of the project's metadata is carried through, not replaced.
+    assert.equal(calls[1][1].metadata.title, "Demo");
+    assert.deepEqual(calls[1][1].metadata.products.map((p) => p.id), ["app", "api"]);
+  });
+
+  await asyncTest("applyProductPlan skips the project write when products is null", async () => {
+    const { calls, stores } = makeStores({ title: "Demo" });
+    await applyProductPlan(planProductMove(NODES, ["V-home"], "app"), stores);
+    assert.deepEqual(calls.map(([name]) => name), ["applyMutations"]);
+  });
+
+  await asyncTest("applyProductPlan does not call applyMutations with no ops", async () => {
+    // An empty ops array is still a round trip, and a mutation journal entry.
+    const { calls, stores } = makeStores({ title: "Demo" });
+    await applyProductPlan(planProductDeletion(PRODUCTS, NODES, "api", null), stores);
+    assert.deepEqual(calls.map(([name]) => name), ["updateProject"]);
+  });
+
+  // The transpiled CommonJS is a build artefact, not a fixture: leaving it behind
+  // makes the next run's `require` cache and the working tree both dirtier than
+  // they need to be. Matches tests/app/product-scope.test.js.
+  fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+
+  console.log(failures === 0 ? "\nAll product-editing tests passed" : `\n${failures} failing`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main();

--- a/tests/app/product-editing.test.js
+++ b/tests/app/product-editing.test.js
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+
+/**
+ * Product editing rules (lib/utils/product-editing.ts).
+ *
+ * The load-bearing assertions are the two that a component could not be made to
+ * make: that `planProductMove` silently skips the species which *derive*
+ * membership (moving a data model would write a key every read surface ignores),
+ * and that with no products declared no plan changes anything — the degenerate
+ * case guarantee, which is the whole reason products stayed opt-in.
+ */
+
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const { loadProductEditing, BUILD_DIR } = require("./load-product-editing");
+
+const {
+  deriveProductId,
+  upsertProduct,
+  removeProduct,
+  membersOfProduct,
+  planProductDeletion,
+  planProductMove,
+  planToOps,
+  platformMenuFor,
+  constrainPlatforms,
+  withProductMembership,
+} = loadProductEditing();
+
+let failures = 0;
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ok - ${name}`);
+  } catch (err) {
+    failures += 1;
+    console.error(`  not ok - ${name}`);
+    console.error(`    ${err.message}`);
+  }
+}
+
+const PRODUCTS = [
+  { id: "app", title: "End-user app", platforms: ["web", "ios", "android"], root_node_id: "F-onboarding" },
+  { id: "admin", title: "Admin", platforms: ["web"] },
+  { id: "api", title: "Public API", platforms: [] },
+];
+
+const NODES = [
+  { id: "V-home", species: "view", metadata: { product: "admin", note: "keep me" } },
+  { id: "V-list", species: "view", metadata: { product: "admin" } },
+  { id: "F-signup", species: "flow", metadata: { product: "app" } },
+  { id: "D-user", species: "data-model", metadata: {} },
+  { id: "A-loads", species: "acceptance", metadata: {} },
+];
+
+console.log("product-editing");
+
+test("deriveProductId slugifies a title", () => {
+  assert.equal(deriveProductId("Admin dashboard", []), "admin-dashboard");
+});
+
+test("deriveProductId strips accents and punctuation", () => {
+  assert.equal(deriveProductId("Créateur (bêta)!", []), "createur-beta");
+});
+
+test("deriveProductId suffixes a collision rather than colliding", () => {
+  assert.equal(deriveProductId("Admin", ["admin"]), "admin-2");
+  assert.equal(deriveProductId("Admin", ["admin", "admin-2"]), "admin-3");
+});
+
+test("deriveProductId never returns a blank id", () => {
+  // resolveProducts DROPS blank ids, so a blank slug is not a product at all.
+  assert.equal(deriveProductId("!!!", []), "product");
+  assert.equal(deriveProductId("", ["product"]), "product-2");
+});
+
+test("upsertProduct appends a new product in declaration order", () => {
+  const next = upsertProduct(PRODUCTS, { id: "cli", title: "CLI", platforms: [] });
+  assert.deepEqual(next.map((p) => p.id), ["app", "admin", "api", "cli"]);
+});
+
+test("upsertProduct edits in place and preserves root_node_id", () => {
+  // D7 does not expose the anchor, which makes destroying it the live risk.
+  const next = upsertProduct(PRODUCTS, { id: "app", title: "The app", platforms: ["web"] });
+  assert.deepEqual(next.map((p) => p.id), ["app", "admin", "api"]);
+  assert.equal(next[0].title, "The app");
+  assert.equal(next[0].root_node_id, "F-onboarding");
+  assert.deepEqual(next[0].platforms, ["web"]);
+});
+
+test("upsertProduct orders platforms canonically and drops a blank description", () => {
+  const next = upsertProduct([], { id: "x", title: "X", description: "   ", platforms: ["android", "web"] });
+  assert.deepEqual(next[0].platforms, ["web", "android"]);
+  assert.equal("description" in next[0], false);
+});
+
+test("removeProduct drops only the named definition", () => {
+  assert.deepEqual(removeProduct(PRODUCTS, "admin").map((p) => p.id), ["app", "api"]);
+  assert.deepEqual(removeProduct(PRODUCTS, "nope").map((p) => p.id), ["app", "admin", "api"]);
+});
+
+test("membersOfProduct sees stored membership only", () => {
+  assert.deepEqual(membersOfProduct(NODES, "admin").map((n) => n.id), ["V-home", "V-list"]);
+});
+
+test("planProductDeletion reassigns every member", () => {
+  const plan = planProductDeletion(PRODUCTS, NODES, "admin", "app");
+  assert.deepEqual(plan.products.map((p) => p.id), ["app", "api"]);
+  assert.deepEqual(plan.reassignments, [
+    { nodeId: "V-home", product: "app" },
+    { nodeId: "V-list", product: "app" },
+  ]);
+});
+
+test("planProductDeletion can leave members unassigned", () => {
+  const plan = planProductDeletion(PRODUCTS, NODES, "admin", null);
+  assert.deepEqual(plan.reassignments.map((r) => r.product), [null, null]);
+});
+
+test("planProductDeletion of an empty product touches no node", () => {
+  const plan = planProductDeletion(PRODUCTS, NODES, "api", null);
+  assert.deepEqual(plan.reassignments, []);
+});
+
+test("planProductMove skips the species that derive membership", () => {
+  const plan = planProductMove(NODES, ["V-home", "D-user", "A-loads"], "app");
+  assert.deepEqual(plan.reassignments, [
+    { nodeId: "V-home", product: "app" },
+    { nodeId: "A-loads", product: "app" },
+  ]);
+  assert.equal(plan.products, null);
+});
+
+test("planProductMove skips nodes already in the target", () => {
+  const plan = planProductMove(NODES, ["V-home", "V-list", "F-signup"], "admin");
+  assert.deepEqual(plan.reassignments, [{ nodeId: "F-signup", product: "admin" }]);
+});
+
+test("planProductMove to null unassigns", () => {
+  const plan = planProductMove(NODES, ["V-home"], null);
+  assert.deepEqual(plan.reassignments, [{ nodeId: "V-home", product: null }]);
+});
+
+test("withProductMembership removes the key rather than blanking it", () => {
+  assert.deepEqual(withProductMembership({ product: "admin", note: "keep me" }, null), { note: "keep me" });
+  assert.deepEqual(withProductMembership(undefined, "app"), { product: "app" });
+});
+
+test("planToOps patches metadata and preserves the rest of it", () => {
+  const nodesById = new Map(NODES.map((n) => [n.id, n]));
+  const ops = planToOps(planProductMove(NODES, ["V-home"], null), nodesById);
+  assert.deepEqual(ops, [
+    { op: "update_node", node_id: "V-home", patch: { metadata: { note: "keep me" } } },
+  ]);
+});
+
+test("platformMenuFor: a product's own menu, canonically ordered", () => {
+  assert.deepEqual(platformMenuFor({ id: "a", title: "A", platforms: ["android", "web"] }), ["web", "android"]);
+});
+
+test("platformMenuFor: a platform-less product has an empty menu", () => {
+  // Arity 0 — availability is not a tracked dimension. The form shows no toggles.
+  assert.deepEqual(platformMenuFor(PRODUCTS[2]), []);
+});
+
+test("platformMenuFor: unassigned means every platform", () => {
+  assert.deepEqual(platformMenuFor(null), ["web", "ios", "android"]);
+  assert.deepEqual(platformMenuFor({ id: "junk", title: "Junk" }), ["web", "ios", "android"]);
+});
+
+test("constrainPlatforms prunes a selection the product forbids", () => {
+  assert.deepEqual(constrainPlatforms(["web", "ios"], ["web"]), ["web"]);
+  assert.deepEqual(constrainPlatforms(["ios", "web"], ["web", "ios", "android"]), ["web", "ios"]);
+  assert.deepEqual(constrainPlatforms(["web"], []), []);
+});
+
+test("degenerate case: with no products declared, no plan changes anything", () => {
+  const plan = planProductDeletion([], NODES, "nope", null);
+  assert.deepEqual(plan.products, []);
+  assert.deepEqual(plan.reassignments, []);
+  assert.deepEqual(planToOps(plan, new Map()), []);
+});
+
+// The transpiled CommonJS is a build artefact, not a fixture: leaving it behind
+// makes the next run's `require` cache and the working tree both dirtier than
+// they need to be. Matches tests/app/product-scope.test.js.
+fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+
+console.log(failures === 0 ? "\nAll product-editing tests passed" : `\n${failures} failing`);
+process.exit(failures === 0 ? 0 : 1);

--- a/tests/app/product-editing.test.js
+++ b/tests/app/product-editing.test.js
@@ -37,6 +37,7 @@ const {
   platformMenuFor,
   constrainPlatforms,
   withProductMembership,
+  platformLabel,
   applyProductPlan,
 } = loadProductEditing();
 
@@ -305,6 +306,18 @@ test("degenerate case: with no products declared, no plan changes anything", () 
 
   // And the node form is unchanged: every platform stays on offer.
   assert.deepEqual(platformMenuFor(null), ["web", "ios", "android"]);
+});
+
+test("platformLabel names a platform this build knows", () => {
+  assert.equal(platformLabel("ios"), "iOS");
+  assert.equal(platformLabel("web"), "Web");
+});
+
+test("platformLabel echoes an id it does not know rather than blanking it", () => {
+  // Showing the junk is what tells a bundle's author their file says something
+  // this build does not understand.
+  assert.equal(platformLabel("watchos"), "watchos");
+  assert.equal(platformLabel(undefined), "undefined");
 });
 
 console.log("\napply-product-plan");

--- a/tests/app/product-scope.test.js
+++ b/tests/app/product-scope.test.js
@@ -21,6 +21,7 @@ const {
   platformAvailabilityShape,
   resolveProductScope,
   productScopeOptions,
+  productDisplayTitle,
   platformCountLabel,
   nodeInScope,
   mapProductId,
@@ -211,6 +212,28 @@ assert(
   productScopeOptions({ project: { metadata: { products: [{ id: "p", title: "   ", platforms: ["ios"] }] } } })[0]
     .label === "p",
   "a whitespace-only title falls back too — a row of spaces is still a blank row",
+);
+
+// The singular fallback the settings manager, its delete dialog and the picker
+// all name a product with. It is asserted directly rather than only through
+// `productScopeOptions` because those callers hold a definition, not a bundle,
+// and a fourth inline copy of the rule is exactly what it exists to prevent.
+assert(
+  productDisplayTitle({ id: "admin", title: "Admin dashboard" }) === "Admin dashboard",
+  "productDisplayTitle uses the title when there is one",
+);
+assert(
+  productDisplayTitle({ id: "admin" }) === "admin",
+  "productDisplayTitle falls back to the id — resolveProducts requires an id and nothing else",
+);
+assert(
+  productDisplayTitle({ id: "admin", title: "   " }) === "admin" &&
+    productDisplayTitle({ id: "admin", title: 7 }) === "admin",
+  "productDisplayTitle falls back on a blank or non-string title too",
+);
+assert(
+  productDisplayTitle(null) === "" && productDisplayTitle(undefined) === "",
+  "productDisplayTitle survives a missing product — the delete dialog renders on its way out",
 );
 
 assert(platformCountLabel([]) === "No platforms", "arity 0 is a real state: 'No platforms'");

--- a/tests/app/product-scope.test.js
+++ b/tests/app/product-scope.test.js
@@ -29,6 +29,7 @@ const {
   computeMapSubgraph,
   productsOfNode,
   productLabelsOfNode,
+  productLabels,
   scopedPlatforms,
   scopedRollupPlatforms,
   flowGaugePlatforms,
@@ -362,6 +363,48 @@ assert(
 assert(
   eq(productLabelsOfNode(ghostView, allScope, libraryGraph), ["ghost"]),
   "a membership pointing at a product the project no longer declares renders the id — never silently dropped",
+);
+
+// --- productLabels — the ordering and the fallback, on their own -------------
+//
+// `productLabelsOfNode` is `productsOfNode` + this, and the acceptance editor
+// calls this half directly: it derives membership from `covers` anchors and has
+// no `usageIndex` to build. Pinned here so the one copy of the rule cannot drift
+// under either caller.
+
+assert(
+  eq(productLabels(new Set(["admin", "enduser"]), allScope), ["End-user app", "Admin dashboard"]),
+  "productLabels reads in DECLARATION order, not the argument's iteration order",
+);
+assert(
+  eq(productLabels(["admin", "enduser"], allScope), ["End-user app", "Admin dashboard"]),
+  "…and takes a plain array as readily as a Set — the caller need not build one",
+);
+assert(
+  eq(productLabels(new Set(["ghost", "enduser"]), allScope), ["End-user app", "ghost"]),
+  "an id the project no longer declares sorts LAST and renders as itself — never silently dropped",
+);
+assert(
+  eq(productLabels([], allScope), []),
+  "no ids, no labels — the emptiness the caller resolves, not a sentinel string",
+);
+
+const blankTitleScope = resolveProductScope(
+  {
+    project: {
+      metadata: {
+        products: [
+          { id: "no-title", platforms: [] },
+          { id: "blank-title", title: "   ", platforms: [] },
+        ],
+      },
+    },
+  },
+  null,
+);
+assert(
+  eq(productLabels(["blank-title", "no-title"], blankTitleScope), ["no-title", "blank-title"]),
+  "a missing title AND a whitespace-only one both fall back to the id — a row of spaces is still a blank row",
 );
 
 // --- The clamp: rollup widening, then the scope's menu -----------------------


### PR DESCRIPTION
Closes #314. Ships **P3** of [`docs/rfcs/products.md`](../blob/main/docs/rfcs/products.md) — the editing half that P0–P2 deliberately left out.

Products have been first-class in the schema and honoured by all eight read surfaces since #308, and completely unauthorable by a human: a definition lives in `project.metadata.products`, membership in `node.metadata.product`, so creating one meant hand-editing bundle JSON. **Products are now manageable without touching JSON** — the issue's acceptance criterion.

## What's in it

- **Products section in project settings** — create, rename, describe, set platforms, delete-with-reassign.
- **Product picker** in the node create form, the node detail panel, and the acceptance editor.
- **A real create dialog on the Acceptances page**, replacing a `window.prompt` that could only ask for a title.
- **Checkbox multi-select in the Library** with a bulk *Move to product* bar (every product, plus Unassigned).

## The bug this closes

Standing under a named product scope, creating a node produced one with no membership — and an unassigned flow or view shows under "All products" only. So the node you just created **vanished from the scope you were standing in**, with no explanation. The picker now prefills to the current scope, visibly and editably: a default you can see and change, not ambient state stamped silently onto stored data.

The Acceptances page had the same bug by a different route, found during implementation — it never used the node form at all.

## Design decisions

Recorded with their rejected alternatives in [the spec](../blob/main/docs/superpowers/specs/2026-08-02-product-management-ui-design.md):

- **The product id is auto-slugged on create and immutable after.** It is the key every member node stores; an editable id needs a multi-node rewrite that can half-fail.
- **Deleting names the member count and offers a destination.** One computed plan, memberships written before definitions, so a partial failure leaves a visible half-state rather than an invisible one.
- **An acceptance's picker shows always, and says when its anchors override it.** Membership is derived from what it covers; the stored key only applies when it covers nothing.
- **Narrowing a product's platforms is allowed, with a warning.** The containment rule is a validator warning, never an error — narrowing is a product decision and must not fail CI.
- **Library selection is a general mechanism.** Data models and endpoints derive their product and can't be moved, but their checkboxes aren't disabled — the bar names the subset instead of answering "why can't I tick this?" with silence.

## Architecture

Rules live in `lib/utils/product-editing.ts` as pure functions returning *plans*; `lib/utils/apply-product-plan.ts` is the one write spanning both stores; components compute nothing. That's what makes the destructive paths testable on a machine with no Postgres — 34 assertions in a new `test:product-editing` suite, wired into CI, plus new `product-scope` coverage.

**The degenerate-case guarantee holds throughout:** a project that declares no products gets no picker, no checkbox column, no new word, and no layout shift, on every surface touched.

## Known gaps, deliberately

A product's `root_node_id` is still not editable, so a product created here has no journey anchor until one is set by hand — its Journey page says so rather than borrowing the project's front door. The per-surface product override remains deferred. Both are recorded in the RFC status block.

## Verification

`tsc` clean, `npm run build` clean, and these suites pass: `product-editing`, `product-scope`, `products`, `delivery`, `acceptance-matrix`, `pyramid`, `coverage`, `journey-graph`, `effective-status`. Lint is untouched — it already fails on `main` for unrelated pre-existing reasons.

**Nothing was verified visually** — there's no browser driver in this environment. Worth an eye:

1. Library cards with products declared vs not — no width or baseline shift from the checkbox gutter, and clicking the gutter doesn't open the node.
2. Table "select all" tri-state: tick two of five rows, the header box should read indeterminate.
3. The selection bar inside `StickyToolbar` — opaque, with the list not showing through as it scrolls.
4. The acceptance picker on an anchored acceptance: the trigger reads the *derived* product while the open menu highlights the *stored* one. Deliberate, and the one place the control looks like it disagrees with itself.
5. A platform-less product: the node form should show zero platform toggles and exactly one status field.
6. Settings with zero products — the Products section sitting above Danger zone without disturbing the rhythm.

## Lab Note

```yaml
en:
  title: "Your project can hold several apps — and now you can say so"
  summary: "Name the apps your project covers — the main app, an admin dashboard, a public API — right from settings. Assign screens and flows to them as you create them, or move a whole shelf at once from the Library."
fr:
  title: "Ton projet peut contenir plusieurs apps — et tu peux enfin le dire"
  summary: "Nomme les apps que couvre ton projet — l'app principale, un back-office, une API publique — directement depuis les réglages. Range tes écrans et tes parcours au moment où tu les crées, ou déplace toute une étagère d'un coup depuis la Bibliothèque."
suggested:
  molecule: arkaik
  type: feature
  tags: [changelog]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
