### PR TITLE
Improve touch interaction and text selection behavior

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -112,19 +112,22 @@
     color: hsl(var(--foreground));
   }
 
-  /* Horizontal swipes never turn into browser back/forward navigation or a
-     page-wide shift — they stay inside whatever is being scrolled. */
+  /* Swipes never turn into browser back/forward navigation, a page-wide
+     bounce, or a pull-to-refresh — they stay inside whatever is being
+     scrolled. */
   html,
   body {
-    overscroll-behavior-x: none;
+    overscroll-behavior: none;
   }
 
   .overflow-auto,
   .overflow-x-auto,
+  .overflow-y-auto,
   .overflow-scroll,
   .overflow-x-scroll,
+  .overflow-y-scroll,
   [data-slot="table-container"] {
-    overscroll-behavior-x: contain;
+    overscroll-behavior: contain;
   }
 
   /* Controls are for clicking, not for selecting text. */

--- a/app/globals.css
+++ b/app/globals.css
@@ -111,6 +111,46 @@
     background-color: hsl(var(--background));
     color: hsl(var(--foreground));
   }
+
+  /* Horizontal swipes never turn into browser back/forward navigation or a
+     page-wide shift — they stay inside whatever is being scrolled. */
+  html,
+  body {
+    overscroll-behavior-x: none;
+  }
+
+  .overflow-auto,
+  .overflow-x-auto,
+  .overflow-scroll,
+  .overflow-x-scroll,
+  [data-slot="table-container"] {
+    overscroll-behavior-x: contain;
+  }
+
+  /* Controls are for clicking, not for selecting text. */
+  button,
+  summary,
+  label,
+  [role="button"],
+  [role="tab"],
+  [role="menuitem"],
+  [role="menuitemcheckbox"],
+  [role="menuitemradio"],
+  [role="option"],
+  [data-slot="button"],
+  [data-slot="dropdown-menu-item"],
+  [data-slot="sidebar-menu-button"] {
+    -webkit-user-select: none;
+    user-select: none;
+  }
+
+  /* …but text inputs and editable regions inside them still select. */
+  input,
+  textarea,
+  [contenteditable="true"] {
+    -webkit-user-select: text;
+    user-select: text;
+  }
 }
 
 @layer components {


### PR DESCRIPTION
## Summary

Added CSS rules to prevent unwanted overscroll effects (browser back/forward navigation, page bounce, pull-to-refresh), disable text selection on interactive controls, and preserve text selection in input fields and editable regions.

## Changes

- **Overscroll behavior**: Set `overscroll-behavior: none` on `html` and `body` — horizontal swipes no longer trigger browser back/forward navigation, and vertical overscroll no longer bounces the page or triggers pull-to-refresh. Applied `overscroll-behavior: contain` to scrollable containers (`.overflow-auto`, `.overflow-x-auto`, `.overflow-y-auto`, `.overflow-scroll`, `.overflow-x-scroll`, `.overflow-y-scroll`, and `[data-slot="table-container"]`) so scrolling past the end of a panel doesn't chain out to the page.

- **Control text selection**: Disabled text selection (`user-select: none`) on interactive elements including buttons, summaries, labels, and elements with ARIA roles (`button`, `tab`, `menuitem`, `option`, etc.) and data slots (`button`, `dropdown-menu-item`, `sidebar-menu-button`). This prevents accidental text selection when clicking controls.

- **Input field selection**: Explicitly enabled text selection (`user-select: text`) on `input`, `textarea`, and `[contenteditable="true"]` elements to ensure users can still select and edit text in these fields.

## Test Plan

No testing needed — these are CSS-only behavioral improvements that don't require code-level testing. Verify by:
- Attempting horizontal swipes on touch devices (should not navigate back/forward)
- Scrolling past the top/bottom of a panel (should not bounce the page or pull-to-refresh)
- Clicking buttons and interactive controls (should not select text)
- Interacting with text inputs and textareas (should allow normal text selection)

## Lab Note

```yaml
en:
  title: "Scrolling stays put"
  summary: "Swiping across breadcrumbs, tables and boards no longer bounces the page around or sends you back a screen, and scrolling past the end of a panel stops there instead of dragging the whole page with it. Buttons and menu items also stopped highlighting themselves like text when you click them."
fr:
  title: "Le défilement reste à sa place"
  summary: "Tu peux balayer les fils d'Ariane, les tableaux et les boards sans que la page saute ou te renvoie à l'écran précédent, et arriver au bout d'un panneau ne fait plus bouger toute la page. Et les boutons et menus ne se surlignent plus comme du texte quand tu cliques dessus."
suggested:
  molecule: arkaik
  type: improvement
  tags: [changelog]
```

https://claude.ai/code/session_01KDknpxChK4dTgJpHAF3Lj2