### PR TITLE
Show product scope in page headers across all surfaces

### DIFF
--- a/app/project/[id]/changelog/page.tsx
+++ b/app/project/[id]/changelog/page.tsx
@@ -6,11 +6,13 @@ import { LightbulbIcon, MessageSquareTextIcon, TagIcon } from "lucide-react";
 import { orderEvents } from "@arkaik/schema";
 import { PageShell } from "@/components/layout/PageShell";
 import { useNodes } from "@/lib/hooks/useNodes";
+import { useEffectiveProduct } from "@/lib/hooks/useProductScope";
 import { useProject } from "@/lib/hooks/useProject";
 import { useJournal } from "@/lib/hooks/useJournal";
 import { computeBacklog, computeChangelog, type Backlog, type Changelog } from "@/lib/utils/journal";
 import { describeJournalEvent, formatEventDate } from "@/components/journal/describe-event";
 import { PLATFORM_LABELS } from "@/components/graph/nodes/node-styles";
+import { productScopeMetaLabel } from "@/lib/utils/product-scope";
 import type { Node, ReleaseTaggedEvent } from "@/lib/data/types";
 
 interface ReleaseEntry {
@@ -93,6 +95,9 @@ export default function ChangelogPage() {
   const { project: projectBundle, loading: projectLoading } = useProject(id);
   const { nodes: dataNodes, loading: nodesLoading } = useNodes(id);
   const { journal, loading: journalLoading } = useJournal(id);
+  // Display only — the changelog itself stays unscoped; this just fills the
+  // header's meta line with the same scope name every other surface shows.
+  const scope = useEffectiveProduct(id, projectBundle);
 
   const nodesById = useMemo(() => new Map(dataNodes.map((node) => [node.id, node])), [dataNodes]);
 
@@ -129,6 +134,7 @@ export default function ChangelogPage() {
   return (
     <PageShell
       title="Changelog"
+      meta={productScopeMetaLabel(scope)}
       headerExtra={
         projectBundle?.project.version ? (
           <div className="flex items-center gap-2 text-xs text-muted-foreground">

--- a/app/project/[id]/delivery/page.tsx
+++ b/app/project/[id]/delivery/page.tsx
@@ -24,7 +24,7 @@ import { useEffectiveProduct, useProductList } from "@/lib/hooks/useProductScope
 import { useProject } from "@/lib/hooks/useProject";
 import { computeDeliveryItems, groupItemsByStatus, type DeliveryItem } from "@/lib/utils/delivery";
 import { generateNodeId } from "@/lib/utils/id";
-import type { ProductGraph } from "@/lib/utils/product-scope";
+import { productScopeMetaLabel, type ProductGraph } from "@/lib/utils/product-scope";
 import { matchesSearch } from "@/lib/utils/search";
 import { buildProductUsageIndex } from "@arkaik/schema";
 
@@ -154,6 +154,7 @@ export default function ProjectDeliveryPage() {
     <>
       <PageShell
         title="Delivery"
+        meta={productScopeMetaLabel(scope)}
         action={{
           label: "New node",
           icon: PlusIcon,

--- a/app/project/[id]/overview/page.tsx
+++ b/app/project/[id]/overview/page.tsx
@@ -29,7 +29,7 @@ import {
 import { computeBacklog } from "@/lib/utils/journal";
 import { computeMapCounts } from "@/lib/utils/journey-graph";
 import { getRollupPlatforms } from "@/lib/utils/platform-status";
-import { type ProductGraph } from "@/lib/utils/product-scope";
+import { productScopeMetaLabel, type ProductGraph } from "@/lib/utils/product-scope";
 import { computeScopedPyramidTiers } from "@/lib/utils/pyramid";
 
 /**
@@ -156,6 +156,7 @@ export default function OverviewPage() {
   return (
     <PageShell
       title="Overview"
+      meta={productScopeMetaLabel(scope)}
       headerExtra={
         projectBundle?.project.version ? (
           <div className="flex items-center gap-2 text-xs text-muted-foreground">

--- a/app/project/[id]/pyramid/page.tsx
+++ b/app/project/[id]/pyramid/page.tsx
@@ -15,6 +15,7 @@ import {
 import { VALUES, VALUE_TIERS_CONFIG } from "@/lib/config/values";
 import type { PyramidElement } from "@/lib/utils/pyramid";
 import { computeScopedPyramidTiers } from "@/lib/utils/pyramid";
+import { productScopeMetaLabel } from "@/lib/utils/product-scope";
 import { useEdges } from "@/lib/hooks/useEdges";
 import { useNodes } from "@/lib/hooks/useNodes";
 import { useEffectiveProduct } from "@/lib/hooks/useProductScope";
@@ -96,7 +97,7 @@ export default function PyramidPage() {
   }
 
   return (
-    <PageShell title="Value pyramid">
+    <PageShell title="Value pyramid" meta={productScopeMetaLabel(scope)}>
       <div className="h-full overflow-auto">
         <div className="mx-auto w-full max-w-6xl">
           <StickyToolbar>

--- a/lib/utils/product-scope.ts
+++ b/lib/utils/product-scope.ts
@@ -178,6 +178,25 @@ export function productScopeOptions(
   }));
 }
 
+/**
+ * The scope's name for the header's meta line — the second row `PageHeader`
+ * shows in place of the breadcrumb trail when no panel is open (Overview,
+ * Delivery, Pyramid and Changelog otherwise pass no `meta` at all and sat
+ * permanently blank).
+ *
+ * **`undefined` when the project declares no products**, matching
+ * `ProductScopeSelector`'s own guard (`productScopeOptions(project).length
+ * === 0`): a project that has never heard of products must keep looking
+ * exactly as it did before the feature existed, so the header grows no new
+ * word either. `scope.productsById` is built from the same
+ * `resolveProducts(project)` call the selector's options are, so the two
+ * checks can never disagree.
+ */
+export function productScopeMetaLabel(scope: ProductScope): string | undefined {
+  if (scope.productsById.size === 0) return undefined;
+  return scope.productId === null ? "All products" : productDisplayTitle(scope.product);
+}
+
 /** Anchor ids an acceptance covers (outgoing `covers` edges). */
 export function coveredAnchorIds(acceptanceId: string, edges: readonly Edge[]): string[] {
   return edges


### PR DESCRIPTION
## Summary

Adds a new `productScopeMetaLabel()` utility function that generates a display label for the current product scope ("All products" or a specific product name), and wires it into the `meta` prop of `PageShell` across Overview, Delivery, Pyramid, and Changelog pages. This ensures the header's meta line consistently reflects the active product scope, matching the behavior of the `ProductScopeSelector`.

The label is `undefined` when no products are declared, preserving the original appearance for projects that don't use the product feature.

## Changes

- **`lib/utils/product-scope.ts`**: Added `productScopeMetaLabel()` function with comprehensive documentation explaining its behavior and alignment with `ProductScopeSelector`
- **`app/project/[id]/overview/page.tsx`**: Import and pass `productScopeMetaLabel(scope)` to `PageShell`'s `meta` prop
- **`app/project/[id]/delivery/page.tsx`**: Import and pass `productScopeMetaLabel(scope)` to `PageShell`'s `meta` prop
- **`app/project/[id]/pyramid/page.tsx`**: Import and pass `productScopeMetaLabel(scope)` to `PageShell`'s `meta` prop
- **`app/project/[id]/changelog/page.tsx`**: Import `useEffectiveProduct` hook and `productScopeMetaLabel()` function; use scope to populate header meta line (changelog data itself remains unscoped)

## Lab Note

```yaml
en:
  title: "Product scope now shows in every page header"
  summary: "When you switch between products, the header's meta line updates to show which product you're viewing — 'All products' or the specific product name — keeping you oriented as you navigate."
fr:
  title: "Le scope produit s'affiche maintenant dans chaque en-tête de page"
  summary: "Quand tu changes de produit, la ligne meta de l'en-tête se met à jour pour montrer quel produit tu consultes — 'Tous les produits' ou le nom spécifique — pour que tu restes orienté en naviguant."
suggested:
  molecule: arkaik
  type: improvement
  tags: [ui, product-scope]
```

https://claude.ai/code/session_01AinpKhFLDkxmdGrk8khQGB