### PR TITLE
Read the query at call time so two writers can't clobber each other

### DIFF
--- a/components/acceptances/acceptance-filters.ts
+++ b/components/acceptances/acceptance-filters.ts
@@ -1,8 +1,9 @@
 "use client";
 
 import { useCallback, useMemo } from "react";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import { PLATFORM_IDS, STATUS_IDS, VALUE_IDS } from "@arkaik/schema";
+import { useQueryWriter } from "@/lib/hooks/useQueryWriter";
 import type { AcceptanceFilters } from "@/lib/utils/acceptance-matrix";
 import { EMPTY_FILTERS } from "@/lib/utils/acceptance-matrix";
 
@@ -44,25 +45,27 @@ export function useAcceptanceFilters(): {
   setFilters: (next: AcceptanceFilters) => void;
   reset: () => void;
 } {
-  const router = useRouter();
-  const pathname = usePathname();
+  const writeQuery = useQueryWriter();
   const searchParams = useSearchParams();
   const filters = useMemo(() => readFilters(new URLSearchParams(searchParams.toString())), [searchParams]);
 
+  // Writes through `useQueryWriter`, which reads the live query at call time.
+  // Rebuilding from the closed-over `searchParams` would drop a `?product=`
+  // written by `useProductOverride` since this render — same bar, second writer.
+  // Only `KEYS` are touched, so anything else on the URL survives untouched.
   const setFilters = useCallback(
     (next: AcceptanceFilters) => {
-      const params = new URLSearchParams(searchParams.toString());
-      for (const key of KEYS) params.delete(key);
-      if (next.search) params.set("search", next.search);
-      if (next.platform !== "all") params.set("platform", next.platform);
-      if (next.status !== "all") params.set("status", next.status);
-      if (next.value !== "all") params.set("value", next.value);
-      if (next.anchor !== "all") params.set("anchor", next.anchor);
-      if (next.parityGap) params.set("parity_gap", "1");
-      const qs = params.toString();
-      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+      writeQuery((params) => {
+        for (const key of KEYS) params.delete(key);
+        if (next.search) params.set("search", next.search);
+        if (next.platform !== "all") params.set("platform", next.platform);
+        if (next.status !== "all") params.set("status", next.status);
+        if (next.value !== "all") params.set("value", next.value);
+        if (next.anchor !== "all") params.set("anchor", next.anchor);
+        if (next.parityGap) params.set("parity_gap", "1");
+      });
     },
-    [router, pathname, searchParams],
+    [writeQuery],
   );
 
   const reset = useCallback(() => setFilters(EMPTY_FILTERS), [setFilters]);

--- a/lib/hooks/useProductScope.ts
+++ b/lib/hooks/useProductScope.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useMemo, useSyncExternalStore } from "react";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import type { ProductDefinition } from "@arkaik/schema";
 import type { ProjectBundle } from "@/lib/data/types";
 import {
@@ -16,6 +16,7 @@ import {
   resolveProductScope,
   type ProductScope,
 } from "@/lib/utils/product-scope";
+import { useQueryWriter } from "@/lib/hooks/useQueryWriter";
 
 /**
  * The global product scope, persisted per project in localStorage.
@@ -99,12 +100,15 @@ export function useEffectiveProduct(
  * `useEffectiveProduct` (which is why it cannot diverge), and only the four
  * controls in `ProductOverrideSelector` may move it.
  *
- * `setOverride` rebuilds the query from the live params rather than replacing
- * it, so `species`, `panel` and the acceptance filters survive a scope change;
- * and All products **deletes** the key rather than writing a sentinel, so the
- * absence of an override is the absence of a param. `replace` (not `push`) with
- * `scroll: false`, matching `useAcceptanceFilters` — narrowing a surface is not
- * a navigation and must not eat the back button.
+ * `setOverride` touches only its own key, so `species`, `panel` and the
+ * acceptance filters survive a scope change; and All products **deletes** the
+ * key rather than writing a sentinel, so the absence of an override is the
+ * absence of a param. It writes through `useQueryWriter`, which reads the live
+ * query at call time — the acceptance bar's debounced search is a second,
+ * independent writer on the same surface, and a base captured at render time
+ * would drop whichever of the two wrote last. `replace` (not `push`) with
+ * `scroll: false` is that hook's too — narrowing a surface is not a navigation
+ * and must not eat the back button.
  *
  * `overrideId` is what the control should display. It is `null` — All products —
  * whenever the surface may not override at all, or the param is absent, blank,
@@ -116,8 +120,7 @@ export function useProductOverride(
   projectId: string,
   project: ProjectBundle | undefined,
 ): { canOverride: boolean; overrideId: string | null; setOverride: (next: string | null) => void } {
-  const router = useRouter();
-  const pathname = usePathname();
+  const writeQuery = useQueryWriter();
   const searchParams = useSearchParams();
   const { productId: globalId } = useProductScope(projectId);
 
@@ -133,13 +136,12 @@ export function useProductOverride(
 
   const setOverride = useCallback(
     (next: string | null) => {
-      const params = new URLSearchParams(searchParams.toString());
-      if (next === null) params.delete(PRODUCT_OVERRIDE_PARAM);
-      else params.set(PRODUCT_OVERRIDE_PARAM, next);
-      const qs = params.toString();
-      router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+      writeQuery((params) => {
+        if (next === null) params.delete(PRODUCT_OVERRIDE_PARAM);
+        else params.set(PRODUCT_OVERRIDE_PARAM, next);
+      });
     },
-    [router, pathname, searchParams],
+    [writeQuery],
   );
 
   return { canOverride, overrideId, setOverride };

--- a/lib/hooks/useQueryWriter.ts
+++ b/lib/hooks/useQueryWriter.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { useCallback } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { buildQueryHref, currentSearch, type QueryMutation } from "@/lib/utils/query-url";
+
+/**
+ * The single way this app mutates a surface's query string.
+ *
+ * Hand it a mutation over `URLSearchParams` and it applies it to the *live*
+ * query — read from `window.location.search` at call time, not from a
+ * `useSearchParams()` value closed over at render time. That is the whole point:
+ * two writers on one surface (`useAcceptanceFilters` and `useProductOverride` on
+ * Acceptances) each used to rebuild the string from their own stale closure, so
+ * a write landing before the App Router transition committed dropped the other's
+ * change. See `lib/utils/query-url.ts` for the failure in full.
+ *
+ * Mutations are keyed writes — set what you own, delete what you clear, leave
+ * everything else alone. A mutation that assigns the whole string would
+ * reintroduce the clobber from the other side.
+ *
+ * `replace` (not `push`) with `scroll: false`: filtering or narrowing a surface
+ * is not a navigation and must not eat the back button.
+ *
+ * The returned callback is stable across renders — it closes over nothing that
+ * changes except `router` and `pathname` — so it is safe in the dependency list
+ * of a debounce effect without restarting the timer on every keystroke.
+ */
+export function useQueryWriter(): (mutate: QueryMutation) => void {
+  const router = useRouter();
+  const pathname = usePathname();
+
+  return useCallback(
+    (mutate: QueryMutation) => {
+      router.replace(buildQueryHref(pathname, currentSearch(), mutate), { scroll: false });
+    },
+    [router, pathname],
+  );
+}

--- a/lib/utils/query-url.ts
+++ b/lib/utils/query-url.ts
@@ -1,0 +1,48 @@
+/**
+ * The pure half of "write the query string without clobbering the other writer".
+ *
+ * A surface can have more than one independent query writer — Acceptances has
+ * two, `useAcceptanceFilters` and `useProductOverride` — and each used to
+ * rebuild the string from the `searchParams` captured in its own `useCallback`
+ * closure. Neither sees the other's write until the App Router transition
+ * commits, so a write landing inside that window is built from a stale base and
+ * silently drops the other's change: pick a product mid-debounce and the typed
+ * search text vanishes from the box.
+ *
+ * The fix is to read the query at *call* time rather than from a closure, which
+ * makes each writer independently correct with no coordination between them.
+ * `window.location.search` is the only base that is always current: the browser
+ * updates it synchronously on `router.replace`, before and regardless of when
+ * React commits the transition.
+ *
+ * This module is the part of that with no React in it — given a base string and
+ * a mutation, produce the href. `useQueryWriter` supplies the base.
+ */
+
+/** Mutates the params in place; the return value is ignored. */
+export type QueryMutation = (params: URLSearchParams) => void;
+
+/**
+ * `pathname` when the mutation leaves no params, `pathname?qs` otherwise — never
+ * a bare trailing `?`, which would make two equivalent URLs compare unequal and
+ * push a pointless entry through `replace`.
+ *
+ * `search` may carry its leading `?` or not; `URLSearchParams` accepts both.
+ */
+export function buildQueryHref(pathname: string, search: string, mutate: QueryMutation): string {
+  const params = new URLSearchParams(search);
+  mutate(params);
+  const qs = params.toString();
+  return qs ? `${pathname}?${qs}` : pathname;
+}
+
+/**
+ * The live query string, or `""` where there is no `window` (SSR, tests).
+ *
+ * The fallback is safe because every caller runs inside an event handler or a
+ * debounce timer — client-only by construction — and a writer that somehow ran
+ * during SSR has no router to write to either.
+ */
+export function currentSearch(): string {
+  return typeof window === "undefined" ? "" : window.location.search;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10561,25 +10561,25 @@
     },
     "packages/cli": {
       "name": "arkaik",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
-      "dependencies": {
-        "@arkaik/schema": "*"
-      },
       "bin": {
         "arkaik": "dist/index.js"
+      },
+      "devDependencies": {
+        "@arkaik/schema": "*"
       }
     },
     "packages/mcp": {
       "name": "arkaik-mcp",
-      "version": "0.1.0",
+      "version": "0.2.2",
       "license": "MIT",
-      "dependencies": {
-        "@arkaik/schema": "*",
-        "arkaik": "*"
-      },
       "bin": {
         "arkaik-mcp": "dist/index.js"
+      },
+      "devDependencies": {
+        "@arkaik/schema": "*",
+        "arkaik": "*"
       }
     },
     "packages/schema": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test:acceptance-matrix": "node tests/app/acceptance-matrix.test.js",
     "test:product-scope": "node tests/app/product-scope.test.js",
     "test:product-editing": "node tests/app/product-editing.test.js",
+    "test:query-url": "node tests/app/query-url.test.js",
     "test:mcp": "npm run build -w arkaik && npm run build -w arkaik-mcp && node tests/mcp/run-mcp-tests.js && node tests/mcp/remote-store.test.js && node tests/mcp/version.test.js",
     "test:journal-projections": "node tests/data/journal-projections.test.js",
     "test:emit": "node tests/schema/emit.test.js",

--- a/tests/app/query-url.test.js
+++ b/tests/app/query-url.test.js
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+
+/**
+ * Query-string writes (lib/utils/query-url.ts) — the pure half of the fix for
+ * two independent writers on one surface clobbering each other.
+ *
+ * The interesting assertions are the interleaving ones at the bottom: a
+ * keyed mutation applied to a base read *after* the other writer has landed
+ * keeps both changes, which is exactly what rebuilding from a render-time
+ * `searchParams` closure could not do. The two mutations here are the real
+ * ones — the acceptance filters' delete-then-set over `KEYS`, and the product
+ * override's single set/delete — restated only as far as this module's shape
+ * requires, since the hooks themselves need React to load.
+ */
+
+const fs = require("fs");
+const { loadUtil, BUILD_DIR } = require("./load-panel-utils");
+
+const { buildQueryHref, currentSearch } = loadUtil("query-url");
+
+let failures = 0;
+function assert(cond, message) {
+  if (cond) console.log(`PASS: ${message}`);
+  else {
+    failures++;
+    console.log(`FAIL: ${message}`);
+  }
+}
+
+const PATH = "/project/p1/acceptances";
+
+// The two real writers, as mutations.
+const FILTER_KEYS = ["search", "platform", "status", "value", "anchor", "parity_gap"];
+const setSearch = (search) => (params) => {
+  for (const key of FILTER_KEYS) params.delete(key);
+  if (search) params.set("search", search);
+};
+const setProduct = (next) => (params) => {
+  if (next === null) params.delete("product");
+  else params.set("product", next);
+};
+
+// --- href shape ---
+assert(
+  buildQueryHref(PATH, "", setSearch("checkout")) === `${PATH}?search=checkout`,
+  "a write onto an empty query produces pathname?qs",
+);
+assert(
+  buildQueryHref(PATH, "?search=checkout", setSearch("")) === PATH,
+  "clearing the last param yields a bare pathname, not a trailing '?'",
+);
+assert(
+  buildQueryHref(PATH, "?product=admin", setProduct(null)) === PATH,
+  "All products deletes the key rather than writing a sentinel",
+);
+assert(
+  buildQueryHref(PATH, "search=checkout", setProduct("admin")) === `${PATH}?search=checkout&product=admin`,
+  "a base without its leading '?' is accepted",
+);
+
+// --- each writer leaves foreign keys alone ---
+assert(
+  buildQueryHref(PATH, "?panel=n1&search=old", setSearch("new")) === `${PATH}?panel=n1&search=new`,
+  "the filter writer preserves params it does not own",
+);
+assert(
+  buildQueryHref(PATH, "?species=view&product=admin", setProduct("web")) ===
+    `${PATH}?species=view&product=web`,
+  "the override writer preserves params it does not own",
+);
+
+// --- the race from issue #328, both directions ---
+// Step 1: the debounced search lands. Step 2: the product control fires before
+// the router transition commits — so it reads a base that already has `search`,
+// which is the whole point of reading at call time.
+const afterSearch = buildQueryHref(PATH, "", setSearch("checkout"));
+const afterBoth = buildQueryHref(PATH, afterSearch.slice(afterSearch.indexOf("?")), setProduct("admin"));
+assert(
+  afterBoth === `${PATH}?search=checkout&product=admin`,
+  "product picked mid-debounce keeps the typed search",
+);
+
+const afterProduct = buildQueryHref(PATH, "", setProduct("admin"));
+const afterBothMirror = buildQueryHref(
+  PATH,
+  afterProduct.slice(afterProduct.indexOf("?")),
+  setSearch("checkout"),
+);
+assert(
+  afterBothMirror === `${PATH}?product=admin&search=checkout`,
+  "a search debounce landing after a product pick keeps the override",
+);
+
+// The stale-closure behaviour this replaces, stated once so the regression is
+// visible: same two writes, second one built from the pre-search base.
+assert(
+  buildQueryHref(PATH, "", setProduct("admin")) === `${PATH}?product=admin`,
+  "building from a stale base drops the other writer's change (the old bug)",
+);
+
+// --- currentSearch under SSR ---
+assert(typeof window === "undefined" && currentSearch() === "", "currentSearch falls back to '' with no window");
+
+fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+
+if (failures > 0) {
+  console.error(`\n${failures} assertion(s) failed`);
+  process.exit(1);
+}
+console.log("\nAll query-url tests passed");


### PR DESCRIPTION
Acceptances has two independent query writers — the filter bar's debounced
search (useAcceptanceFilters) and the product override (useProductOverride).
Each rebuilt the string from a `searchParams` captured in its own useCallback
closure, so a write landing before the App Router transition committed was
built from a stale base and silently dropped the other's change: pick a
product mid-debounce and the typed search text vanished from the box.

Both now write through a shared `useQueryWriter`, which applies a keyed
mutation to `window.location.search` read at call time. That makes each writer
independently correct without coordinating them, and closes the pre-existing
case between the debounce and the status/value/anchor selects too.

Closes #328

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NBqCWS1rji5yxV93y1L7CX