### PR TITLE
Acceptance-first intake: attach, detach, create, and split

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,9 @@ jobs:
       - name: Acceptance matrix util tests
         run: npm run test:acceptance-matrix
 
+      - name: Acceptance-first intake rule tests
+        run: npm run test:acceptance-intake
+
       - name: Effective platform-status seam tests
         run: npm run test:effective-status
 

--- a/app/project/[id]/acceptances/page.tsx
+++ b/app/project/[id]/acceptances/page.tsx
@@ -10,6 +10,7 @@ import { useEdges } from "@/lib/hooks/useEdges";
 import { useProjectPanels } from "@/lib/hooks/useProjectPanels";
 import { useProject } from "@/lib/hooks/useProject";
 import { useJournal } from "@/lib/hooks/useJournal";
+import { useAcceptanceIntake } from "@/lib/hooks/useAcceptanceIntake";
 import { useEffectiveProduct, useProductList } from "@/lib/hooks/useProductScope";
 import { useAcceptanceFilters } from "@/components/acceptances/acceptance-filters";
 import { filterAcceptances } from "@/lib/utils/acceptance-matrix";
@@ -29,6 +30,13 @@ export default function ProjectAcceptancesPage() {
   const { edges: dataEdges, loading: edgesLoading, syncEdges } = useEdges(id);
   const { project: projectBundle } = useProject(id);
   const { journal } = useJournal(id);
+  const intake = useAcceptanceIntake({
+    projectId: id,
+    nodes: dataNodes,
+    edges: dataEdges,
+    applyMutations,
+    syncEdges,
+  });
   const { filters, setFilters } = useAcceptanceFilters();
   const [newAcceptanceOpen, setNewAcceptanceOpen] = useState(false);
 
@@ -169,6 +177,7 @@ export default function ProjectAcceptancesPage() {
         journal={journal}
         onUpdate={handleNodeUpdate}
         onCreateAcceptanceForAnchor={handleCreateAcceptanceForAnchor}
+        intake={intake}
       >
         <div className="h-full overflow-auto p-4 md:p-6">
           <div className="flex w-full flex-col gap-4">

--- a/app/project/[id]/delivery/page.tsx
+++ b/app/project/[id]/delivery/page.tsx
@@ -18,6 +18,7 @@ import {
 import type { Node as DataNode } from "@/lib/data/types";
 import { useEdges } from "@/lib/hooks/useEdges";
 import { useJournal } from "@/lib/hooks/useJournal";
+import { useAcceptanceIntake } from "@/lib/hooks/useAcceptanceIntake";
 import { useProjectPanels } from "@/lib/hooks/useProjectPanels";
 import { useNodes } from "@/lib/hooks/useNodes";
 import { useEffectiveProduct, useProductList } from "@/lib/hooks/useProductScope";
@@ -57,8 +58,15 @@ export default function ProjectDeliveryPage() {
 
   const { openNode } = useProjectPanels();
 
-  const { nodes: dataNodes, loading: nodesLoading, updateNode, addNode } = useNodes(id);
-  const { edges: dataEdges, loading: edgesLoading } = useEdges(id);
+  const { nodes: dataNodes, loading: nodesLoading, updateNode, addNode, applyMutations } = useNodes(id);
+  const { edges: dataEdges, loading: edgesLoading, syncEdges } = useEdges(id);
+  const intake = useAcceptanceIntake({
+    projectId: id,
+    nodes: dataNodes,
+    edges: dataEdges,
+    applyMutations,
+    syncEdges,
+  });
   const { project: projectBundle } = useProject(id);
   const { journal } = useJournal(id);
   // The shell's scope, narrowed by this surface's own `?product=` when it has
@@ -167,6 +175,7 @@ export default function ProjectDeliveryPage() {
         journal={journal}
         onUpdate={handleNodeUpdate}
         onCreateNode={handleCreateNodeFromPanel}
+        intake={intake}
       >
         <div className="flex h-full flex-col gap-4 overflow-auto p-4 md:p-6">
           <DeliveryFilterBar

--- a/app/project/[id]/library/page.tsx
+++ b/app/project/[id]/library/page.tsx
@@ -22,6 +22,7 @@ import { useNodes } from "@/lib/hooks/useNodes";
 import { useEffectiveProduct, useProductList } from "@/lib/hooks/useProductScope";
 import { useProject } from "@/lib/hooks/useProject";
 import { useJournal } from "@/lib/hooks/useJournal";
+import { useAcceptanceIntake } from "@/lib/hooks/useAcceptanceIntake";
 import { findWhereUsed } from "@/lib/utils/where-used";
 import { generateNodeId } from "@/lib/utils/id";
 import {
@@ -167,7 +168,14 @@ export default function ProjectLibraryPage() {
   const speciesFilter = parseSpeciesFilter(searchParams.get("species"));
 
   const { nodes: dataNodes, loading: nodesLoading, updateNode, addNode, applyMutations } = useNodes(id);
-  const { edges: dataEdges, loading: edgesLoading } = useEdges(id);
+  const { edges: dataEdges, loading: edgesLoading, syncEdges } = useEdges(id);
+  const intake = useAcceptanceIntake({
+    projectId: id,
+    nodes: dataNodes,
+    edges: dataEdges,
+    applyMutations,
+    syncEdges,
+  });
   const { project: projectBundle, updateProject } = useProject(id);
   const { journal } = useJournal(id);
   // The shell's scope, narrowed by this surface's own `?product=` when it has
@@ -444,6 +452,7 @@ export default function ProjectLibraryPage() {
         journal={journal}
         onUpdate={handleNodeUpdate}
         onCreateNode={handleCreateNodeFromPanel}
+        intake={intake}
       >
         <div className="h-full overflow-auto">
           <div className="w-full">

--- a/components/acceptances/AcceptanceFilterBar.tsx
+++ b/components/acceptances/AcceptanceFilterBar.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { SearchIcon, TriangleAlertIcon, XIcon } from "lucide-react";
 import type { ProjectBundle } from "@/lib/data/types";
 import type { AcceptanceFilters } from "@/lib/utils/acceptance-matrix";
-import { EMPTY_FILTERS } from "@/lib/utils/acceptance-matrix";
+import { EMPTY_FILTERS, UNANCHORED_FILTER } from "@/lib/utils/acceptance-matrix";
 import { PLATFORMS } from "@/lib/config/platforms";
 import { STATUSES } from "@/lib/config/statuses";
 import { VALUES } from "@/lib/config/values";
@@ -146,6 +146,10 @@ export function AcceptanceFilterBar({ filters, onChange, anchorOptions, projectI
         <SelectTrigger className="w-[11rem]" aria-label="Anchor"><SelectValue placeholder="Anchor" /></SelectTrigger>
         <SelectContent>
           <SelectItem value={ALL}>All anchors</SelectItem>
+          {/* The intake inbox: ideas filed before their flows and views exist.
+              First, not sorted in among the anchors, because it is the one entry
+              here that names an absence rather than a node. */}
+          <SelectItem value={UNANCHORED_FILTER}>Unanchored (intake)</SelectItem>
           {anchorOptions.map((a) => <SelectItem key={a.id} value={a.id}>{a.title}</SelectItem>)}
         </SelectContent>
       </Select>

--- a/components/layout/PageShell.tsx
+++ b/components/layout/PageShell.tsx
@@ -6,6 +6,7 @@ import { ProjectPanels } from "@/components/panels/ProjectPanels";
 import type { PlatformId } from "@/lib/config/platforms";
 import type { Edge, JournalEvent, Node } from "@/lib/data/types";
 import type { ProductScope } from "@/lib/utils/product-scope";
+import type { AcceptanceIntake } from "@/lib/hooks/useAcceptanceIntake";
 
 interface PageShellProps {
   title: string;
@@ -37,6 +38,8 @@ interface PageShellProps {
   onDelete?: (nodeId: string) => void;
   onCreateNode?: (species: "flow" | "view", title: string) => Promise<Node>;
   onCreateAcceptanceForAnchor?: (anchor: Node, title: string) => Promise<Node>;
+  /** The acceptance decompose gestures — see `useAcceptanceIntake`. */
+  intake?: AcceptanceIntake;
   onZoomShot?: (node: Node, platform: PlatformId) => void;
 }
 

--- a/components/maps/JourneyMap.tsx
+++ b/components/maps/JourneyMap.tsx
@@ -25,6 +25,7 @@ import { useEdges } from "@/lib/hooks/useEdges";
 import { useProject } from "@/lib/hooks/useProject";
 import { useEffectiveProduct, useProductList } from "@/lib/hooks/useProductScope";
 import { useJournal } from "@/lib/hooks/useJournal";
+import { useAcceptanceIntake } from "@/lib/hooks/useAcceptanceIntake";
 import { useProjectPanels } from "@/lib/hooks/useProjectPanels";
 import { useElkLayout } from "@/lib/hooks/useElkLayout";
 import { useKeyboardShortcuts } from "@/lib/hooks/useKeyboardShortcuts";
@@ -87,8 +88,15 @@ export function JourneyMap({ projectId, definition }: JourneyMapProps) {
   } | null>(null);
   const [playlistError, setPlaylistError] = useState<string | null>(null);
 
-  const { nodes: dataNodes, loading: nodesLoading, updateNode, addNode, removeNode, removeNodes } = useNodes(id);
-  const { edges: dataEdges, loading: edgesLoading, addEdge, removeEdge } = useEdges(id);
+  const { nodes: dataNodes, loading: nodesLoading, updateNode, addNode, removeNode, removeNodes, applyMutations } = useNodes(id);
+  const { edges: dataEdges, loading: edgesLoading, addEdge, removeEdge, syncEdges } = useEdges(id);
+  const intake = useAcceptanceIntake({
+    projectId: id,
+    nodes: dataNodes,
+    edges: dataEdges,
+    applyMutations,
+    syncEdges,
+  });
   const { project: projectBundle, loading: projectLoading, updateProject } = useProject(id);
   // The shell's scope (§ Decision 2), passed down to the canvas cards and to
   // every panel this map opens — never read from a global by the cards
@@ -768,6 +776,7 @@ export function JourneyMap({ projectId, definition }: JourneyMapProps) {
         onUpdate={handleNodeUpdate}
         onDelete={handleDeleteNodeRequest}
         onCreateNode={handleCreateNodeFromPanel}
+        intake={intake}
         onZoomShot={(node, platform) => {
           setZoomNode(node);
           setZoomPlatform(platform);

--- a/components/maps/SystemMap.tsx
+++ b/components/maps/SystemMap.tsx
@@ -22,6 +22,7 @@ import type { Node as DataNode, Edge as DataEdge } from "@/lib/data/types";
 import { useEdges } from "@/lib/hooks/useEdges";
 import { useElkLayout } from "@/lib/hooks/useElkLayout";
 import { useJournal } from "@/lib/hooks/useJournal";
+import { useAcceptanceIntake } from "@/lib/hooks/useAcceptanceIntake";
 import { useProjectPanels } from "@/lib/hooks/useProjectPanels";
 import { useNodes } from "@/lib/hooks/useNodes";
 import { useProject } from "@/lib/hooks/useProject";
@@ -77,8 +78,15 @@ export function SystemMap({ projectId, definition }: SystemMapProps) {
   const [deleteEdgeTarget, setDeleteEdgeTarget] = useState<DataEdge | null>(null);
   const [deleteEdgeDialogOpen, setDeleteEdgeDialogOpen] = useState(false);
 
-  const { nodes: dataNodes, loading: nodesLoading, updateNode, addNode } = useNodes(projectId);
-  const { edges: dataEdges, loading: edgesLoading, addEdge, removeEdge } = useEdges(projectId);
+  const { nodes: dataNodes, loading: nodesLoading, updateNode, addNode, applyMutations } = useNodes(projectId);
+  const { edges: dataEdges, loading: edgesLoading, addEdge, removeEdge, syncEdges } = useEdges(projectId);
+  const intake = useAcceptanceIntake({
+    projectId: projectId,
+    nodes: dataNodes,
+    edges: dataEdges,
+    applyMutations,
+    syncEdges,
+  });
   const { project: projectBundle, updateProject } = useProject(projectId);
   // The shell's scope (§ Decision 2), passed down to the canvas cards and to
   // every panel this map opens — never read from a global by the cards
@@ -320,6 +328,7 @@ export function SystemMap({ projectId, definition }: SystemMapProps) {
         journal={journal}
         onUpdate={handleNodeUpdate}
         onCreateNode={handleCreateNodeFromPanel}
+        intake={intake}
       >
         <Canvas
           nodes={nodes}

--- a/components/panels/AcceptanceEditor.tsx
+++ b/components/panels/AcceptanceEditor.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { SplitIcon, XIcon } from "lucide-react";
+import { toast } from "sonner";
 import type { Node, Edge, PlatformStatusMap } from "@/lib/data/types";
 import type { PlatformId } from "@/lib/config/platforms";
 import type { StatusId } from "@/lib/config/statuses";
@@ -10,8 +12,13 @@ import { getEditablePlatformStatuses } from "@/lib/utils/platform-status";
 import type { ProductScope } from "@/lib/utils/product-scope";
 import { productLabels, productsOfAcceptance } from "@/lib/utils/product-scope";
 import { withProductMembership } from "@/lib/utils/product-editing";
+import { attachEmptiesMembership } from "@/lib/utils/acceptance-intake";
+import type { AcceptanceIntake } from "@/lib/hooks/useAcceptanceIntake";
 import { productOf } from "@arkaik/schema";
 import { ProductPicker } from "@/components/panels/ProductPicker";
+import { NodeSearchCombobox } from "@/components/panels/NodeSearchCombobox";
+import { SplitAcceptanceDialog } from "@/components/panels/SplitAcceptanceDialog";
+import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { STATUS_ICONS, STATUS_STYLES, SPECIES_ICONS } from "@/components/graph/nodes/node-styles";
 import { PlatformVariants } from "@/components/panels/PlatformVariants";
@@ -25,10 +32,19 @@ interface AcceptanceEditorProps {
   scope: ProductScope;
   onUpdate: (id: string, patch: Partial<Omit<Node, "id" | "project_id">>) => Promise<void> | void;
   onNavigate?: (node: Node) => void;
+  /**
+   * The decompose gestures — attach, detach, create-and-attach, split.
+   *
+   * Absent on a surface whose panels are read-only, and then the Covers list is
+   * exactly the list it has always been. Present, and this editor becomes the
+   * place an idea filed with no anchor gets turned into one that has them.
+   */
+  intake?: AcceptanceIntake;
 }
 
-export function AcceptanceEditor({ node, allNodes, allEdges, scope, onUpdate, onNavigate }: AcceptanceEditorProps) {
+export function AcceptanceEditor({ node, allNodes, allEdges, scope, onUpdate, onNavigate, intake }: AcceptanceEditorProps) {
   const [gherkin, setGherkin] = useState(node.metadata?.gherkin ?? "");
+  const [splitOpen, setSplitOpen] = useState(false);
   const nodeRef = useRef(node);
   useEffect(() => { nodeRef.current = node; }, [node]);
   // Debounce-save gherkin. The effect reschedules on every keystroke and clears
@@ -52,6 +68,22 @@ export function AcceptanceEditor({ node, allNodes, allEdges, scope, onUpdate, on
 
   function patchMetadata(next: Record<string, unknown>) {
     onUpdate(node.id, { metadata: { ...node.metadata, ...next } });
+  }
+
+  /**
+   * Run one intake gesture, reporting a failure instead of swallowing it.
+   *
+   * Every one of them is a write to a store the panel does not own, and a
+   * rejected batch otherwise leaves the list looking unchanged with nothing
+   * saying why — the same treatment `AcceptancesSection` gives its create.
+   */
+  async function run(action: () => Promise<void>, failure: string) {
+    try {
+      await action();
+    } catch (err) {
+      toast.error(failure);
+      console.error(err);
+    }
   }
 
   /* --- Product (§ D5) ------------------------------------------------------
@@ -197,22 +229,166 @@ export function AcceptanceEditor({ node, allNodes, allEdges, scope, onUpdate, on
       <section className="flex flex-col gap-1.5">
         <span className="text-xs text-muted-foreground">Covers</span>
         {coveredAnchors.length === 0 ? (
-          <p className="text-xs text-muted-foreground">Unanchored (covers nothing).</p>
+          <p className="text-xs text-muted-foreground">
+            {intake
+              ? "Unanchored — an idea in intake. Attach it to a view or a flow below."
+              : "Unanchored (covers nothing)."}
+          </p>
         ) : (
           <ul className="flex flex-col gap-1">
             {coveredAnchors.map((anchor) => {
               const Icon = SPECIES_ICONS[anchor.species];
               return (
-                <li key={anchor.id}>
-                  <button type="button" className="inline-flex items-center gap-2 text-sm hover:underline" onClick={() => onNavigate?.(anchor)}>
+                <li key={anchor.id} className="flex items-center gap-1">
+                  <button type="button" className="inline-flex flex-1 items-center gap-2 text-left text-sm hover:underline" onClick={() => onNavigate?.(anchor)}>
                     <Icon className="size-3.5 text-muted-foreground" /> {anchor.title}
                   </button>
+                  {intake && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="size-7 shrink-0"
+                      aria-label={`Stop covering ${anchor.title}`}
+                      onClick={() => void run(() => intake.detach(node, anchor.id), "Couldn't detach that node.")}
+                    >
+                      <XIcon className="size-3.5" />
+                    </Button>
+                  )}
                 </li>
               );
             })}
           </ul>
         )}
+        {intake && (
+          <AttachAnchorRow
+            node={node}
+            allNodes={allNodes}
+            allEdges={allEdges}
+            nodesById={nodesById}
+            hasProducts={scope.productsById.size > 0}
+            intake={intake}
+            run={run}
+          />
+        )}
       </section>
+
+      {intake && (
+        <section className="flex flex-col gap-1.5">
+          <span className="text-xs text-muted-foreground">Decompose</span>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="self-start"
+            onClick={() => setSplitOpen(true)}
+          >
+            <SplitIcon className="size-4" /> Split into several…
+          </Button>
+          <p className="text-xs text-muted-foreground">
+            One acceptance states one thing. Split when the idea has grown into several.
+          </p>
+          <SplitAcceptanceDialog
+            open={splitOpen}
+            onOpenChange={setSplitOpen}
+            title={node.title}
+            anchorCount={anchorCount}
+            // Not `run`: the dialog has to know whether the write landed, so
+            // that a failure leaves the rows on screen instead of discarding
+            // them. Reported here all the same, then rethrown.
+            onSubmit={async (titles) => {
+              try {
+                await intake.split(node, titles);
+              } catch (err) {
+                toast.error("Couldn't split the acceptance.");
+                console.error(err);
+                throw err;
+              }
+            }}
+          />
+        </section>
+      )}
+    </div>
+  );
+}
+
+interface AttachAnchorRowProps {
+  node: Node;
+  allNodes: Node[];
+  allEdges: Edge[];
+  nodesById: Map<string, Node>;
+  /**
+   * Whether the project declares any product at all. The triage warning below
+   * is gated on it rather than on the membership computation alone: a project
+   * that has never heard of products can still carry a stray `metadata.product`
+   * from an import, and a toast naming "All products" there would introduce a
+   * word the whole feature promises such a project never sees.
+   */
+  hasProducts: boolean;
+  intake: AcceptanceIntake;
+  run: (action: () => Promise<void>, failure: string) => Promise<void>;
+}
+
+/**
+ * Attach this acceptance to a view or a flow — one that exists, or one created
+ * in the same gesture.
+ *
+ * The species select plus `NodeSearchCombobox` is the shape the playlist editor
+ * and the insert dialog already use for "an existing node, or a new one by that
+ * name", and reusing it means the create affordance appears under exactly the
+ * same rule everywhere: only once something is typed that no node of that
+ * species already answers to.
+ *
+ * **Attaching an unassigned anchor is allowed and announced.** An acceptance
+ * anchored only to unassigned views derives an empty membership, so this gesture
+ * can move an idea filed under one app back into the "All products" inbox
+ * (§ Decision 5, the interaction the spec left open). Blocking it would be
+ * wrong — the anchor is the truth and triage is the honest place for an
+ * acceptance whose anchors are themselves in triage — but letting it happen in
+ * silence means watching the acceptance vanish from the scope you were standing
+ * in. So it is written, and then said. A node created here inherits the
+ * acceptance's product precisely so the common path never trips this.
+ */
+function AttachAnchorRow({ node, allNodes, allEdges, nodesById, hasProducts, intake, run }: AttachAnchorRowProps) {
+  const [species, setSpecies] = useState<"view" | "flow">("view");
+
+  function announceTriage(anchor: Pick<Node, "id" | "species" | "title" | "metadata">) {
+    if (!hasProducts) return;
+    // Evaluated against the edges as they were BEFORE the write — the predicate
+    // asks what this attach did, and the answer needs the graph it acted on.
+    if (!attachEmptiesMembership(node, anchor, allEdges, nodesById)) return;
+    toast.warning(`"${anchor.title}" has no product, so this acceptance now appears under All products only.`);
+  }
+
+  return (
+    <div className="mt-1 grid gap-2 sm:grid-cols-[7rem_1fr] sm:items-center">
+      <Select value={species} onValueChange={(value) => setSpecies(value as "view" | "flow")}>
+        <SelectTrigger aria-label="Anchor species">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="view">View</SelectItem>
+          <SelectItem value="flow">Flow</SelectItem>
+        </SelectContent>
+      </Select>
+      <NodeSearchCombobox
+        species={species}
+        allNodes={allNodes}
+        onSelect={(anchorId) => {
+          const anchor = nodesById.get(anchorId);
+          if (!anchor) return;
+          void run(async () => {
+            await intake.attach(node, anchor);
+            announceTriage(anchor);
+          }, "Couldn't attach that node.");
+        }}
+        onCreate={(title) =>
+          run(async () => {
+            const created = await intake.createAnchor(node, species, title);
+            if (created) toast.success(`Created "${created.title}" and attached it.`);
+          }, `Couldn't create the ${species}.`)
+        }
+      />
     </div>
   );
 }

--- a/components/panels/NodeDetailPanel.tsx
+++ b/components/panels/NodeDetailPanel.tsx
@@ -24,6 +24,7 @@ import { PlatformGaugeList } from "@/components/graph/nodes/PlatformGaugeList";
 import { PlaylistEditor } from "@/components/panels/PlaylistEditor";
 import { AcceptanceEditor } from "@/components/panels/AcceptanceEditor";
 import { AcceptancesSection } from "@/components/panels/AcceptancesSection";
+import type { AcceptanceIntake } from "@/lib/hooks/useAcceptanceIntake";
 import {
   computeFlowPlatformRollup,
   getEditablePlatformStatuses,
@@ -56,6 +57,8 @@ interface NodeDetailPanelProps {
   onNavigate?: (node: Node) => void;
   onCreateNode?: (species: "flow" | "view", title: string) => Promise<Node>;
   onCreateAcceptanceForAnchor?: (anchor: Node, title: string) => Promise<Node>;
+  /** The acceptance decompose gestures, on surfaces whose panels can write. */
+  intake?: AcceptanceIntake;
   onZoomShot?: (node: Node, platform: PlatformId) => void;
 }
 
@@ -551,6 +554,7 @@ export function NodeDetailPanel({
   onNavigate,
   onCreateNode,
   onCreateAcceptanceForAnchor,
+  intake,
   onZoomShot,
 }: NodeDetailPanelProps) {
   void onDelete;
@@ -580,6 +584,7 @@ export function NodeDetailPanel({
           allEdges={allEdges}
           onUpdate={onUpdate}
           onNavigate={onNavigate}
+          intake={intake}
         />
       )}
       {node.species === "view" && (

--- a/components/panels/ProjectPanels.tsx
+++ b/components/panels/ProjectPanels.tsx
@@ -13,6 +13,7 @@ import { useProjectPanels } from "@/lib/hooks/useProjectPanels";
 import type { PanelEntry } from "@/lib/utils/panel-stack";
 import type { PanelDescriptor } from "@/lib/utils/project-panels";
 import { resolveProductScope, type ProductScope } from "@/lib/utils/product-scope";
+import type { AcceptanceIntake } from "@/lib/hooks/useAcceptanceIntake";
 
 interface ProjectPanelsProps {
   /** The surface — canvas, board, or list. The grid's first cell. */
@@ -41,6 +42,12 @@ interface ProjectPanelsProps {
   onDelete?: (nodeId: string) => void;
   onCreateNode?: (species: "flow" | "view", title: string) => Promise<Node>;
   onCreateAcceptanceForAnchor?: (anchor: Node, title: string) => Promise<Node>;
+  /**
+   * The acceptance decompose gestures (`useAcceptanceIntake`), forwarded to
+   * every acceptance panel this grid opens. Omitted by pages whose panels are
+   * read-only, and then the Covers list is the read-only list it always was.
+   */
+  intake?: AcceptanceIntake;
   onZoomShot?: (node: Node, platform: PlatformId) => void;
 }
 
@@ -77,6 +84,7 @@ export function ProjectPanels({
   onDelete,
   onCreateNode,
   onCreateAcceptanceForAnchor,
+  intake,
   onZoomShot,
 }: ProjectPanelsProps) {
   const { entries, openNode, closeAt, unwindTo, pruneMissingNodes, panelStates } =
@@ -176,6 +184,7 @@ export function ProjectPanels({
             onNavigate={(target) => openNode({ nodeId: target.id }, index + 1)}
             onCreateNode={onCreateNode}
             onCreateAcceptanceForAnchor={onCreateAcceptanceForAnchor}
+            intake={intake}
             onZoomShot={onZoomShot}
           />
         );

--- a/components/panels/SplitAcceptanceDialog.tsx
+++ b/components/panels/SplitAcceptanceDialog.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useState } from "react";
+import { PlusIcon, XIcon } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useSeedOnOpen } from "@/lib/hooks/useSeedOnOpen";
+import { splitPieces } from "@/lib/utils/acceptance-intake";
+
+/**
+ * Break one acceptance into several.
+ *
+ * **The first row is the acceptance you are standing in.** It arrives filled
+ * with the current title and renames it in place; every row below creates a new
+ * acceptance. Saying so on screen is what makes the gesture legible — a "split"
+ * that silently left a parent behind, or silently deleted one, would be two
+ * quite different operations wearing the same word.
+ *
+ * The dialog collects titles and nothing else. What each piece inherits — the
+ * product, the anchors, the platforms — is `planAcceptanceSplit`'s to decide and
+ * is stated once, in the footnote, rather than offered as choices nobody filing
+ * an idea has an opinion about yet.
+ */
+
+interface SplitAcceptanceDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** The title the first row is seeded with — the acceptance being split. */
+  title: string;
+  /** How many nodes the original covers, for the sentence about what carries over. */
+  anchorCount: number;
+  onSubmit: (titles: string[]) => Promise<void> | void;
+}
+
+export function SplitAcceptanceDialog({
+  open,
+  onOpenChange,
+  title,
+  anchorCount,
+  onSubmit,
+}: SplitAcceptanceDialogProps) {
+  const [rows, setRows] = useState<string[]>([title, ""]);
+  const [busy, setBusy] = useState(false);
+
+  // Seeded on the closed → open transition, like `NewAcceptanceForm`: the panel
+  // keeps this mounted, and the title can change under it (the editor renames on
+  // a debounce), so an initial `useState` would show a stale first row forever.
+  useSeedOnOpen(open, title, (next) => setRows([next, ""]));
+
+  const pieces = splitPieces(rows);
+  const canSplit = pieces.length >= 2 && !busy;
+
+  function setRow(index: number, value: string) {
+    setRows((prev) => prev.map((row, i) => (i === index ? value : row)));
+  }
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    if (!canSplit) return;
+    setBusy(true);
+    try {
+      await onSubmit(pieces);
+      onOpenChange(false);
+    } catch {
+      // Closing here would throw away rows the user typed for a write that did
+      // not happen. The caller has already reported the failure; leave the
+      // dialog exactly as it was so the same submit can be tried again.
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => (busy ? undefined : onOpenChange(next))}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Split acceptance</DialogTitle>
+          <DialogDescription>
+            One idea, several statements. The first piece renames this acceptance; the rest are
+            created as new ideas.
+          </DialogDescription>
+        </DialogHeader>
+        <form id="split-acceptance-form" onSubmit={handleSubmit} className="flex flex-col gap-2">
+          {rows.map((row, index) => (
+            <div key={index} className="flex items-center gap-2">
+              <Input
+                value={row}
+                onChange={(event) => setRow(index, event.target.value)}
+                placeholder={index === 0 ? "The What — what must be true" : "Another piece"}
+                aria-label={index === 0 ? "First piece (renames this acceptance)" : `Piece ${index + 1}`}
+                disabled={busy}
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                // The first two rows are the split itself — removing one would
+                // leave a dialog that cannot do the thing it is for.
+                disabled={rows.length <= 2 || busy}
+                onClick={() => setRows((prev) => prev.filter((_, i) => i !== index))}
+                aria-label={`Remove piece ${index + 1}`}
+              >
+                <XIcon className="size-4" />
+              </Button>
+            </div>
+          ))}
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="self-start"
+            onClick={() => setRows((prev) => [...prev, ""])}
+            disabled={busy}
+          >
+            <PlusIcon className="size-4" /> Add a piece
+          </Button>
+        </form>
+        <p className="text-xs text-muted-foreground">
+          Each new piece keeps this acceptance&apos;s product
+          {anchorCount > 0
+            ? `, covers the same ${anchorCount} node${anchorCount === 1 ? "" : "s"},`
+            : ""}{" "}
+          and starts as an idea. Blank and duplicate rows are ignored.
+        </p>
+        <DialogFooter>
+          <Button variant="outline" type="button" onClick={() => onOpenChange(false)} disabled={busy}>
+            Cancel
+          </Button>
+          <Button type="submit" form="split-acceptance-form" disabled={!canSplit}>
+            {pieces.length >= 2 ? `Split into ${pieces.length}` : "Split"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/docs/arkaik-skill/skill.md
+++ b/docs/arkaik-skill/skill.md
@@ -274,8 +274,10 @@ Creating a new acceptance + covers edge is itself a dual-write: append
 - `Given` encodes render variants ("Given the pebble has a picture attached…").
 - `platforms` lists only the platforms where the behavior is *expected* — a
   mobile-only behavior is `["ios", "android"]`, not backlog-on-web.
-- `covers` edges: acceptance → view or acceptance → flow. Zero edges = a
-  product-level acceptance (legal). Several = the behavior spans surfaces.
+- `covers` edges: acceptance → view or acceptance → flow. Zero edges = an
+  anchorless acceptance in **intake** (legal): an idea filed before its flows and
+  views exist, carrying `metadata.product` until it has anchors to derive
+  membership from. Several = the behavior spans surfaces.
 - Statuses reuse the standard lifecycle; "shipped" = `live`.
 
 **Example** — iOS ships the draw-in animation:

--- a/docs/spec/bundle-format.md
+++ b/docs/spec/bundle-format.md
@@ -168,7 +168,10 @@ uses the same `metadata.platformStatuses` mechanic as views; `platforms` lists
 the platforms where the behavior is expected ("availability").
 
 `covers` edges (acceptance → view | flow) anchor the promise to surfaces. Zero
-covers edges is legal (a product-level acceptance). Stored per-platform status
+covers edges is legal, and it is **intake**, not "applies everywhere": an idea
+filed before the flows and views exist, carrying `metadata.product` from day one
+and waiting to be decomposed (§ Products). It is anchorless, and the app calls
+it that. Stored per-platform status
 lives on acceptances; covered views compute theirs (validator: missing
 `gherkin`/`values` on an acceptance are warnings; unknown value ids are errors;
 `gherkin`/`values` on other species are warnings).

--- a/lib/hooks/useAcceptanceIntake.ts
+++ b/lib/hooks/useAcceptanceIntake.ts
@@ -1,0 +1,93 @@
+"use client";
+
+import { useMemo } from "react";
+import type { MutationOp } from "@arkaik/schema";
+import type { Edge, Node } from "@/lib/data/types";
+import {
+  planAcceptanceAttach,
+  planAcceptanceDetach,
+  planAcceptanceSplit,
+  planAnchorForAcceptance,
+} from "@/lib/utils/acceptance-intake";
+
+/**
+ * The four gestures acceptance-first intake needs, bound to one surface's data.
+ *
+ * A single object rather than four props because it is one capability: a panel
+ * either can decompose an idea or it cannot, and threading four callbacks
+ * through the shell, the panel grid and the detail panel would be four chances
+ * for a surface to end up half-wired — a Covers list that can attach but not
+ * detach is worse than one that does neither.
+ */
+export interface AcceptanceIntake {
+  /** Cover an existing view or flow. A no-op if it is already covered. */
+  attach(acceptance: Node, anchor: Node): Promise<void>;
+  /** Stop covering one anchor. The anchor itself is untouched. */
+  detach(acceptance: Node, anchorId: string): Promise<void>;
+  /**
+   * Create the view or flow *and* cover it, as one write. Resolves to the new
+   * node so the caller can open it, or to `null` when the title was blank.
+   */
+  createAnchor(acceptance: Node, species: "view" | "flow", title: string): Promise<Node | null>;
+  /** Split into the given pieces — the first renames, the rest are created. */
+  split(acceptance: Node, titles: readonly string[]): Promise<void>;
+}
+
+interface AcceptanceIntakeParams {
+  projectId: string;
+  nodes: readonly Node[];
+  edges: readonly Edge[];
+  /** `useNodes`'s atomic batch — every gesture here is more than one write. */
+  applyMutations: (ops: MutationOp[]) => Promise<{ nodes: Node[]; edges: Edge[] }>;
+  /** `useEdges`'s adopt-the-batch-result, since `applyMutations` owns only nodes. */
+  syncEdges: (edges: Edge[]) => void;
+}
+
+/**
+ * Bind the intake rules to a surface's node/edge state.
+ *
+ * The rules themselves live in `lib/utils/acceptance-intake.ts` and are asserted
+ * there; this hook only turns a plan into a write and keeps both halves of the
+ * surface's local state in step afterwards. A plan with no ops is not written at
+ * all — every one of these gestures has a legitimate no-op case (an anchor
+ * already covered, a blank title, a split into one piece), and an empty batch
+ * would still be a round-trip and a journal read.
+ *
+ * Every page that lets a panel *edit* passes one of these; pages whose panels
+ * are read-only pass none, and the Covers list renders exactly as it did before.
+ */
+export function useAcceptanceIntake({
+  projectId,
+  nodes,
+  edges,
+  applyMutations,
+  syncEdges,
+}: AcceptanceIntakeParams): AcceptanceIntake {
+  const nodesById = useMemo(() => new Map(nodes.map((node) => [node.id, node])), [nodes]);
+
+  return useMemo(() => {
+    async function commit(ops: MutationOp[]): Promise<void> {
+      if (ops.length === 0) return;
+      const result = await applyMutations(ops);
+      syncEdges(result.edges);
+    }
+
+    return {
+      async attach(acceptance, anchor) {
+        await commit(planAcceptanceAttach(acceptance, anchor, projectId, edges));
+      },
+      async detach(acceptance, anchorId) {
+        await commit(planAcceptanceDetach(acceptance.id, anchorId, edges));
+      },
+      async createAnchor(acceptance, species, title) {
+        const plan = planAnchorForAcceptance(acceptance, species, title, projectId, edges, nodesById);
+        if (!plan) return null;
+        await commit(plan.ops);
+        return plan.node;
+      },
+      async split(acceptance, titles) {
+        await commit(planAcceptanceSplit(acceptance, titles, projectId, edges, nodesById));
+      },
+    };
+  }, [projectId, edges, nodesById, applyMutations, syncEdges]);
+}

--- a/lib/utils/acceptance-intake.ts
+++ b/lib/utils/acceptance-intake.ts
@@ -1,0 +1,321 @@
+/**
+ * The rules for **acceptance-first intake**, as pure functions over plain data.
+ *
+ * An acceptance with zero `covers` edges is not a cross-cutting NFR floating
+ * above every app — it is an *idea in intake*, filed by a PM before the flows
+ * and views exist, waiting to be decomposed (§ Decision 5). The model has
+ * supported that since products landed: an acceptance can carry
+ * `metadata.product` before it carries a single edge, and the stored key is read
+ * only when it covers nothing. What was missing is the workflow — attaching an
+ * idea to views and flows once they exist, and splitting one idea into several.
+ *
+ * Every operation returns **mutation ops** rather than performing itself, for
+ * the same reason `product-editing.ts` returns plans: attaching an idea to a
+ * view it created in the same gesture is two writes that must commit as one,
+ * and a rule living inside a dialog is a rule this repo has no runner to assert.
+ *
+ * Deliberately React-free and provider-free.
+ */
+
+import type { Edge, Node } from "@/lib/data/types";
+import {
+  deriveNodeId,
+  edgeId,
+  productOf,
+  VALID_EDGE_SEMANTICS,
+  type MutationOp,
+  type SpeciesId,
+} from "@arkaik/schema";
+import { coveredAnchorIds, productsOfAcceptance } from "@/lib/utils/product-scope";
+import { withProductMembership } from "@/lib/utils/product-editing";
+
+/** The species a `covers` edge may point at, read from the grammar rather than restated. */
+const ANCHOR_SPECIES: readonly SpeciesId[] = VALID_EDGE_SEMANTICS.covers.map(([, target]) => target);
+
+/** Whether this node can be the target of a `covers` edge — a view or a flow. */
+export function isAnchorSpecies(species: SpeciesId): species is "view" | "flow" {
+  return ANCHOR_SPECIES.includes(species);
+}
+
+/** The minimum shape these rules need of a node — never the whole thing. */
+type NodeLike = Pick<Node, "id" | "species" | "metadata">;
+
+/**
+ * Attach an acceptance to an anchor it does not cover yet.
+ *
+ * **Empty is a real answer, and the caller must be able to tell.** Three
+ * distinct situations produce no ops: the edge already exists (a second click on
+ * the same candidate, or a combobox selection racing a sync), the anchor is not
+ * a view or a flow (the `covers` grammar admits nothing else, and a bundle can
+ * hold ids of any species), and an acceptance pointed at itself. None of them is
+ * an error worth surfacing, and all three are a write that must not happen.
+ */
+export function planAcceptanceAttach(
+  acceptance: Pick<Node, "id">,
+  anchor: NodeLike,
+  projectId: string,
+  edges: readonly Edge[],
+): MutationOp[] {
+  if (anchor.id === acceptance.id) return [];
+  if (!isAnchorSpecies(anchor.species)) return [];
+  if (coveredAnchorIds(acceptance.id, edges).includes(anchor.id)) return [];
+
+  return [
+    {
+      op: "create_edge",
+      edge: {
+        id: edgeId(acceptance.id, anchor.id),
+        project_id: projectId,
+        source_id: acceptance.id,
+        target_id: anchor.id,
+        edge_type: "covers",
+      },
+    },
+  ];
+}
+
+/**
+ * Detach an acceptance from one anchor.
+ *
+ * **Every** matching edge is deleted, not the first: `e-{source}-{target}` makes
+ * a duplicate pair impossible to mint through the app, but a hand-edited or
+ * half-synced bundle can carry two edges with different ids and the same
+ * endpoints. Deleting one would leave the anchor on screen after the user
+ * detached it, with no way to tell why.
+ */
+export function planAcceptanceDetach(
+  acceptanceId: string,
+  anchorId: string,
+  edges: readonly Edge[],
+): MutationOp[] {
+  return edges
+    .filter(
+      (edge) =>
+        edge.edge_type === "covers" && edge.source_id === acceptanceId && edge.target_id === anchorId,
+    )
+    .map((edge) => ({ op: "delete_edge", edge_id: edge.id }));
+}
+
+/**
+ * The product a node created *for* this acceptance should be born into.
+ *
+ * The one answer that keeps an idea where its author filed it. Anchors govern
+ * membership, so a view created with no product would derive an empty membership
+ * for the acceptance covering it and drop the whole thing back into triage — the
+ * user watches the idea they just decomposed leave the scope they were standing
+ * in, which is the exact failure `NewAcceptanceForm` was built to stop.
+ *
+ * `null` when the acceptance resolves to no product (it is in triage already, so
+ * there is nothing to inherit) **or to several** (an acceptance spanning two apps
+ * is a warning state, not a mandate to pick one of them for a node the user has
+ * not been asked about).
+ */
+export function inheritedProductFor(
+  acceptance: NodeLike,
+  edges: readonly Edge[],
+  nodesById: ReadonlyMap<string, Node>,
+): string | null {
+  const products = productsOfAcceptance(acceptance, edges, nodesById);
+  if (products.size !== 1) return null;
+  return [...products][0];
+}
+
+/** A new anchor and the edge attaching it — the node is returned so a caller can navigate to it. */
+export interface AnchorCreationPlan {
+  node: Node;
+  ops: MutationOp[];
+}
+
+/**
+ * Create a view or flow and attach this acceptance to it, as one write.
+ *
+ * `platforms: []` matches the other create-from-a-panel path (`onCreateNode`):
+ * a node minted mid-gesture states no platform availability it has not been
+ * asked about, and the panel that opens next is where that gets said.
+ *
+ * Returns `null` for a blank title rather than minting a hash-suffixed id for an
+ * untitled node — the combobox only offers the action when something is typed,
+ * and a whitespace-only title reaching here is a mis-click, not an intent.
+ */
+export function planAnchorForAcceptance(
+  acceptance: Node,
+  species: "view" | "flow",
+  title: string,
+  projectId: string,
+  edges: readonly Edge[],
+  nodesById: ReadonlyMap<string, Node>,
+): AnchorCreationPlan | null {
+  const trimmed = title.trim();
+  if (!trimmed) return null;
+
+  const product = inheritedProductFor(acceptance, edges, nodesById);
+  const metadata = withProductMembership(undefined, product);
+
+  const node: Node = {
+    id: deriveNodeId(species, trimmed, nodesById.keys()),
+    project_id: projectId,
+    species,
+    title: trimmed,
+    status: "idea",
+    platforms: [],
+    ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+  };
+
+  return {
+    node,
+    ops: [
+      { op: "create_node", node },
+      ...planAcceptanceAttach(acceptance, node, projectId, edges),
+    ],
+  };
+}
+
+/**
+ * Whether attaching this anchor would move the acceptance *into* triage.
+ *
+ * The interaction the spec flagged as worth designing around: an acceptance
+ * anchored only to unassigned views or flows derives an empty membership and
+ * lands under "All products" whatever its own stored key says. That falls
+ * straight out of anchors-first and is deliberate — but it means "attach to a
+ * view" can quietly undo the product the idea was filed under, so the surface
+ * says so rather than letting the user discover it in a list that no longer
+ * holds their acceptance.
+ *
+ * It is true in exactly one situation, which is why it is three tests and not a
+ * simulated re-derivation: the acceptance has no resolvable anchor yet (so its
+ * membership is the stored key), that key names a product, and the anchor
+ * arriving names none. Once an acceptance *does* have an anchor carrying a
+ * product, adding an unassigned one cannot empty the union — and if its current
+ * membership is already empty there is nothing left to lose. A project
+ * declaring no products answers `false` throughout, since nothing there names a
+ * product at all.
+ */
+export function attachEmptiesMembership(
+  acceptance: NodeLike,
+  anchor: NodeLike,
+  edges: readonly Edge[],
+  nodesById: ReadonlyMap<string, Node>,
+): boolean {
+  if (productOf(anchor) !== null) return false;
+  if (coveredAnchorIds(acceptance.id, edges).some((id) => nodesById.has(id))) return false;
+  return productsOfAcceptance(acceptance, edges, nodesById).size > 0;
+}
+
+/**
+ * The pieces a split will actually produce: trimmed, blank-free, duplicate-free.
+ *
+ * Duplicates are dropped case-insensitively because two pieces with the same
+ * title are two acceptances the reader cannot tell apart, and `deriveNodeId`
+ * would hand the second one a `-2` suffix that reads as an accident. The first
+ * spelling wins, so the row the user typed first is the one that survives.
+ */
+export function splitPieces(titles: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const pieces: string[] = [];
+  for (const title of titles) {
+    const trimmed = title.trim();
+    if (!trimmed) continue;
+    const key = trimmed.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    pieces.push(trimmed);
+  }
+  return pieces;
+}
+
+/**
+ * Split one acceptance into several, preserving the product across the split.
+ *
+ * **The first piece renames the original in place.** The alternative — creating
+ * n new acceptances and leaving or deleting the original — either strands a
+ * parent that now says the same thing as its children, or throws away the node's
+ * id, its journal, and every edge pointing at it. Renaming keeps the split
+ * *inside* the thing being split: one of the pieces is the acceptance the user
+ * started from, and the rest are new.
+ *
+ * **Both halves of membership are carried, because only carrying both preserves
+ * it.** The stored `metadata.product` goes onto every new piece — that is the
+ * answer for an idea still in intake — *and* so do the original's `covers`
+ * edges, because anchors govern the moment they exist. Copying the key alone
+ * would split an anchored acceptance into pieces that all land in triage;
+ * copying the anchors alone would split an intake idea into pieces that lose the
+ * product it was filed under. The issue asks for the product to survive the
+ * split, and in this model that is two things, not one.
+ *
+ * **What is deliberately not copied.** Gherkin — the How is the one field that
+ * is *about* the specific piece, and duplicating it would assert the same
+ * scenario n times. Per-platform statuses, notes and screenshots — evidence a
+ * new piece has not earned. And status: every acceptance in this app is born an
+ * idea, whatever it was split out of, so a split of a live acceptance yields
+ * pieces that still have to be verified.
+ *
+ * Fewer than two pieces returns no ops. A "split" into one is a rename, and the
+ * title field already does that.
+ */
+export function planAcceptanceSplit(
+  original: Node,
+  titles: readonly string[],
+  projectId: string,
+  edges: readonly Edge[],
+  nodesById: ReadonlyMap<string, Node>,
+): MutationOp[] {
+  const pieces = splitPieces(titles);
+  if (pieces.length < 2) return [];
+
+  const [first, ...rest] = pieces;
+  const ops: MutationOp[] = [];
+
+  if (first !== original.title) {
+    ops.push({ op: "update_node", node_id: original.id, patch: { title: first } });
+  }
+
+  // Ids minted in this batch are added as they are taken. `deriveNodeId` can
+  // only disambiguate against what it is given, and two pieces whose titles
+  // kebab-case identically — "Export as PDF" and "Export as pdf" survive
+  // `splitPieces` only if they differ, but "Export/PDF" and "Export PDF" do not —
+  // would otherwise both claim the same id and the batch would fail as a
+  // duplicate_node.
+  const taken = new Set(nodesById.keys());
+  // Resolvable anchors only, the same filter `productsOfAcceptance` and
+  // `groupAcceptancesByAnchor` apply. Copying a dangling `covers` edge onto each
+  // new piece would multiply one broken reference by the number of pieces —
+  // `applyOps` does not check that an edge's endpoints exist, so nothing
+  // downstream would refuse it.
+  const anchorIds = coveredAnchorIds(original.id, edges).filter(
+    (id) => id !== original.id && nodesById.has(id),
+  );
+  const storedProduct = productOf(original);
+  const values = original.metadata?.values;
+
+  for (const title of rest) {
+    const id = deriveNodeId("acceptance", title, taken);
+    taken.add(id);
+
+    const metadata = withProductMembership(values && values.length > 0 ? { values } : undefined, storedProduct);
+    const node: Node = {
+      id,
+      project_id: projectId,
+      species: "acceptance",
+      title,
+      status: "idea",
+      platforms: [...original.platforms],
+      ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
+    };
+
+    ops.push({ op: "create_node", node });
+    for (const anchorId of anchorIds) {
+      ops.push({
+        op: "create_edge",
+        edge: {
+          id: edgeId(id, anchorId),
+          project_id: projectId,
+          source_id: id,
+          target_id: anchorId,
+          edge_type: "covers",
+        },
+      });
+    }
+  }
+
+  return ops;
+}

--- a/lib/utils/acceptance-matrix.ts
+++ b/lib/utils/acceptance-matrix.ts
@@ -53,6 +53,22 @@ export const EMPTY_FILTERS: AcceptanceFilters = {
  */
 export const UNANCHORED_GROUP_LABEL = "Unanchored";
 
+/**
+ * The `anchor` filter value that means "the intake inbox" — acceptances covering
+ * nothing, rather than acceptances covering one named node.
+ *
+ * A sentinel in the same field rather than a second control, because it answers
+ * the same question the field already asks ("anchored to what?") and one of its
+ * answers is "nothing yet". It cannot collide with a node id: every node id
+ * carries a species prefix (`V-`, `F-`, …), and this has none.
+ *
+ * It exists because filing an idea before its flows and views (§ Decision 5) is
+ * only half a workflow if you cannot find the ideas again — the unanchored
+ * *group* is always last in the matrix, which is the least reachable place on a
+ * long page.
+ */
+export const UNANCHORED_FILTER = "unanchored";
+
 /** True if any applicable platform of the acceptance resolves to `status`. */
 function hasResolvedStatusOnAny(acceptance: Node, status: StatusId): boolean {
   return acceptance.platforms.some((p) => resolvePlatformStatus(acceptance, p) === status);
@@ -94,7 +110,14 @@ export function filterAcceptances(
       }
     }
     if (filters.value !== "all" && !(acc.metadata?.values ?? []).includes(filters.value)) return false;
-    if (filters.anchor !== "all" && !coveredAnchorIds(acc.id, edges).includes(filters.anchor)) return false;
+    if (filters.anchor === UNANCHORED_FILTER) {
+      // Resolvable anchors, the same test `groupAcceptancesByAnchor` applies, so
+      // the filter and the "Unanchored" group it exists to reach never disagree
+      // about an acceptance whose only `covers` edge dangles.
+      if (coveredAnchorIds(acc.id, edges).some((id) => nodesById.has(id))) return false;
+    } else if (filters.anchor !== "all" && !coveredAnchorIds(acc.id, edges).includes(filters.anchor)) {
+      return false;
+    }
     if (filters.parityGap && !hasParityGap(acc)) return false;
     return true;
   });

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test:root-redirect": "node tests/app/root-redirect.test.js",
     "test:value-icons": "node tests/app/value-icons.test.js",
     "test:acceptance-matrix": "node tests/app/acceptance-matrix.test.js",
+    "test:acceptance-intake": "node tests/app/acceptance-intake.test.js",
     "test:product-scope": "node tests/app/product-scope.test.js",
     "test:product-editing": "node tests/app/product-editing.test.js",
     "test:query-url": "node tests/app/query-url.test.js",

--- a/plugin/skills/arkaik/SKILL.md
+++ b/plugin/skills/arkaik/SKILL.md
@@ -274,8 +274,10 @@ Creating a new acceptance + covers edge is itself a dual-write: append
 - `Given` encodes render variants ("Given the pebble has a picture attached…").
 - `platforms` lists only the platforms where the behavior is *expected* — a
   mobile-only behavior is `["ios", "android"]`, not backlog-on-web.
-- `covers` edges: acceptance → view or acceptance → flow. Zero edges = a
-  product-level acceptance (legal). Several = the behavior spans surfaces.
+- `covers` edges: acceptance → view or acceptance → flow. Zero edges = an
+  anchorless acceptance in **intake** (legal): an idea filed before its flows and
+  views exist, carrying `metadata.product` until it has anchors to derive
+  membership from. Several = the behavior spans surfaces.
 - Statuses reuse the standard lifecycle; "shipped" = `live`.
 
 **Example** — iOS ships the draw-in animation:

--- a/tests/app/acceptance-intake.test.js
+++ b/tests/app/acceptance-intake.test.js
@@ -1,0 +1,363 @@
+#!/usr/bin/env node
+
+/**
+ * Acceptance-first intake rules (lib/utils/acceptance-intake.ts) — issue #316.
+ *
+ * The claim these tests exist to defend is the one the issue is actually about:
+ * **the product survives the workflow**. Membership is anchors-first, so
+ * "preserve the product across a split" is two separate carries — the stored key
+ * for a piece still in intake, and the `covers` anchors for a piece that has
+ * them — and a plan that carried only one of them would look right in a diff and
+ * be wrong on screen. So the split assertions do not inspect the ops and stop:
+ * they run the plan through the real `applyOps` and then ask
+ * `productsOfAcceptance`, the same function every read surface asks, whether
+ * each piece landed where the original was.
+ *
+ * The second load-bearing group is the interaction § Decision 5 flagged and left
+ * open: attaching an *unassigned* anchor empties an intake idea's membership and
+ * drops it into triage. `attachEmptiesMembership` is what lets the panel say so,
+ * and `inheritedProductFor` is what keeps the common path — decompose an idea
+ * into a view created in the same gesture — from tripping it at all.
+ *
+ * Everything else here is data-loss shaped: ids that must not collide inside one
+ * batch, dangling anchors that must not be multiplied across pieces, evidence
+ * (gherkin, per-platform statuses) that must not be copied onto a piece that has
+ * not earned it.
+ */
+
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const { loadAcceptanceIntake, BUILD_DIR } = require("./load-acceptance-intake");
+
+const {
+  isAnchorSpecies,
+  planAcceptanceAttach,
+  planAcceptanceDetach,
+  planAnchorForAcceptance,
+  inheritedProductFor,
+  attachEmptiesMembership,
+  splitPieces,
+  planAcceptanceSplit,
+  productsOfAcceptance,
+  applyOps,
+} = loadAcceptanceIntake();
+
+const PROJECT = "p1";
+
+function node(id, species, extra = {}) {
+  return { id, project_id: PROJECT, species, title: id, status: "idea", platforms: [], ...extra };
+}
+
+function covers(acceptanceId, anchorId) {
+  return {
+    id: `e-${acceptanceId}-${anchorId}`,
+    project_id: PROJECT,
+    source_id: acceptanceId,
+    target_id: anchorId,
+    edge_type: "covers",
+  };
+}
+
+function byId(nodes) {
+  return new Map(nodes.map((n) => [n.id, n]));
+}
+
+let failures = 0;
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ok - ${name}`);
+  } catch (err) {
+    failures += 1;
+    console.error(`  FAIL - ${name}`);
+    console.error(`    ${err.message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Attach / detach
+// ---------------------------------------------------------------------------
+
+console.log("\nattach");
+
+test("attaching an intake idea to a view creates one covers edge", () => {
+  const acceptance = node("A-export", "acceptance", { metadata: { product: "admin" } });
+  const view = node("V-notes", "view", { metadata: { product: "admin" } });
+  assert.deepEqual(planAcceptanceAttach(acceptance, view, PROJECT, []), [
+    { op: "create_edge", edge: covers("A-export", "V-notes") },
+  ]);
+});
+
+test("attaching a node it already covers is a no-op", () => {
+  const acceptance = node("A-export", "acceptance");
+  const view = node("V-notes", "view");
+  assert.deepEqual(planAcceptanceAttach(acceptance, view, PROJECT, [covers("A-export", "V-notes")]), []);
+});
+
+test("only views and flows can be covered", () => {
+  // The `covers` grammar admits nothing else, and the row is read from
+  // VALID_EDGE_SEMANTICS rather than restated, so this also guards the day a
+  // sixth species arrives.
+  assert.equal(isAnchorSpecies("view"), true);
+  assert.equal(isAnchorSpecies("flow"), true);
+  assert.equal(isAnchorSpecies("data-model"), false);
+  const acceptance = node("A-export", "acceptance");
+  assert.deepEqual(planAcceptanceAttach(acceptance, node("DM-note", "data-model"), PROJECT, []), []);
+  assert.deepEqual(planAcceptanceAttach(acceptance, node("A-other", "acceptance"), PROJECT, []), []);
+});
+
+test("an acceptance cannot cover itself", () => {
+  const acceptance = node("A-export", "acceptance");
+  assert.deepEqual(planAcceptanceAttach(acceptance, acceptance, PROJECT, []), []);
+});
+
+console.log("\ndetach");
+
+test("detach removes every covers edge to that anchor, and only those", () => {
+  // `e-{source}-{target}` makes a duplicate unreachable through the app, but a
+  // hand-edited bundle can carry one, and leaving it behind would put the anchor
+  // straight back on screen after the user detached it.
+  const edges = [
+    covers("A-export", "V-notes"),
+    { ...covers("A-export", "V-notes"), id: "legacy-uuid" },
+    covers("A-export", "V-other"),
+    covers("A-second", "V-notes"),
+    { id: "e-V-notes-DM-note", project_id: PROJECT, source_id: "V-notes", target_id: "DM-note", edge_type: "displays" },
+  ];
+  assert.deepEqual(planAcceptanceDetach("A-export", "V-notes", edges), [
+    { op: "delete_edge", edge_id: "e-A-export-V-notes" },
+    { op: "delete_edge", edge_id: "legacy-uuid" },
+  ]);
+});
+
+test("detaching a node it does not cover writes nothing", () => {
+  assert.deepEqual(planAcceptanceDetach("A-export", "V-ghost", [covers("A-export", "V-notes")]), []);
+});
+
+// ---------------------------------------------------------------------------
+// Creating an anchor for an idea
+// ---------------------------------------------------------------------------
+
+console.log("\ncreate-and-attach");
+
+test("a view created for an intake idea is born into that idea's product", () => {
+  // The whole point: anchors govern membership, so a view created with no
+  // product would derive an empty membership for the acceptance covering it and
+  // drop the idea back into triage the moment it was decomposed.
+  const acceptance = node("A-export", "acceptance", { metadata: { product: "admin" } });
+  const nodes = [acceptance];
+  const plan = planAnchorForAcceptance(acceptance, "view", "  Session notes  ", PROJECT, [], byId(nodes));
+
+  assert.equal(plan.node.id, "V-session-notes");
+  assert.equal(plan.node.title, "Session notes");
+  assert.equal(plan.node.species, "view");
+  assert.equal(plan.node.status, "idea");
+  assert.deepEqual(plan.node.platforms, []);
+  assert.equal(plan.node.metadata.product, "admin");
+
+  const next = applyOps({ projectId: PROJECT, nodes, edges: [] }, plan.ops);
+  assert.deepEqual(
+    [...productsOfAcceptance(acceptance, next.edges, byId(next.nodes))],
+    ["admin"],
+    "the idea must still be in Admin once it has an anchor",
+  );
+});
+
+test("an acceptance spanning two products picks neither for the new node", () => {
+  const acceptance = node("A-export", "acceptance", { metadata: { product: "admin" } });
+  const nodes = [acceptance, node("V-a", "view", { metadata: { product: "admin" } }), node("V-b", "view", { metadata: { product: "care" } })];
+  const edges = [covers("A-export", "V-a"), covers("A-export", "V-b")];
+  assert.equal(inheritedProductFor(acceptance, edges, byId(nodes)), null);
+  const plan = planAnchorForAcceptance(acceptance, "flow", "Export", PROJECT, edges, byId(nodes));
+  assert.equal(plan.node.metadata, undefined, "no metadata key at all, not product: \"\"");
+});
+
+test("with no products declared the new node carries no metadata", () => {
+  // The degenerate-case guarantee: a project that has never heard of products
+  // must come out of this path byte-identical to the plain create path.
+  const acceptance = node("A-export", "acceptance");
+  const plan = planAnchorForAcceptance(acceptance, "view", "Notes", PROJECT, [], byId([acceptance]));
+  assert.equal(plan.node.metadata, undefined);
+});
+
+test("a blank title creates nothing rather than a hash-suffixed id", () => {
+  const acceptance = node("A-export", "acceptance");
+  assert.equal(planAnchorForAcceptance(acceptance, "view", "   ", PROJECT, [], byId([acceptance])), null);
+});
+
+test("a title colliding with an existing node gets a suffixed id", () => {
+  const acceptance = node("A-export", "acceptance");
+  const nodes = [acceptance, node("V-notes", "view")];
+  const plan = planAnchorForAcceptance(acceptance, "view", "Notes", PROJECT, [], byId(nodes));
+  assert.equal(plan.node.id, "V-notes-2");
+});
+
+// ---------------------------------------------------------------------------
+// The interaction § Decision 5 left open
+// ---------------------------------------------------------------------------
+
+console.log("\nattach into triage");
+
+test("attaching an unassigned view empties an intake idea's membership", () => {
+  const acceptance = node("A-export", "acceptance", { metadata: { product: "admin" } });
+  const view = node("V-notes", "view");
+  assert.equal(attachEmptiesMembership(acceptance, view, [], byId([acceptance, view])), true);
+});
+
+test("an assigned anchor never empties anything", () => {
+  const acceptance = node("A-export", "acceptance", { metadata: { product: "admin" } });
+  const view = node("V-notes", "view", { metadata: { product: "care" } });
+  assert.equal(attachEmptiesMembership(acceptance, view, [], byId([acceptance, view])), false);
+});
+
+test("an already-anchored acceptance cannot be emptied by one more anchor", () => {
+  // Its membership is the union of its anchors' — adding an unassigned one
+  // contributes nothing and takes nothing away.
+  const acceptance = node("A-export", "acceptance", { metadata: { product: "admin" } });
+  const anchored = node("V-a", "view", { metadata: { product: "admin" } });
+  const fresh = node("V-b", "view");
+  const nodes = [acceptance, anchored, fresh];
+  assert.equal(attachEmptiesMembership(acceptance, fresh, [covers("A-export", "V-a")], byId(nodes)), false);
+});
+
+test("an idea already in triage has nothing left to lose", () => {
+  const acceptance = node("A-export", "acceptance");
+  const view = node("V-notes", "view");
+  assert.equal(attachEmptiesMembership(acceptance, view, [], byId([acceptance, view])), false);
+});
+
+test("a dangling covers edge does not count as being anchored", () => {
+  // `productsOfAcceptance` skips unresolvable anchors, so an acceptance whose
+  // only edge points at a missing node still reads its membership from the
+  // stored key — and can still be dropped into triage by a real one.
+  const acceptance = node("A-export", "acceptance", { metadata: { product: "admin" } });
+  const view = node("V-notes", "view");
+  const nodes = byId([acceptance, view]);
+  assert.equal(attachEmptiesMembership(acceptance, view, [covers("A-export", "V-gone")], nodes), true);
+});
+
+// ---------------------------------------------------------------------------
+// Split
+// ---------------------------------------------------------------------------
+
+console.log("\nsplit pieces");
+
+test("pieces are trimmed, blank-free and duplicate-free, first spelling wins", () => {
+  assert.deepEqual(splitPieces(["  Export as PDF ", "", "   ", "export as pdf", "Export as CSV"]), [
+    "Export as PDF",
+    "Export as CSV",
+  ]);
+});
+
+console.log("\nsplit");
+
+test("a split into fewer than two pieces writes nothing", () => {
+  const original = node("A-export", "acceptance", { title: "Export notes" });
+  assert.deepEqual(planAcceptanceSplit(original, ["Export notes"], PROJECT, [], byId([original])), []);
+  assert.deepEqual(planAcceptanceSplit(original, ["", "  "], PROJECT, [], byId([original])), []);
+});
+
+test("the first piece renames the original, and only when it changed", () => {
+  const original = { ...node("A-export", "acceptance"), title: "Export notes" };
+  const nodes = byId([original]);
+
+  const renamed = planAcceptanceSplit(original, ["Export as PDF", "Export as CSV"], PROJECT, [], nodes);
+  assert.deepEqual(renamed[0], { op: "update_node", node_id: "A-export", patch: { title: "Export as PDF" } });
+
+  const kept = planAcceptanceSplit(original, ["Export notes", "Export as CSV"], PROJECT, [], nodes);
+  assert.equal(kept.some((op) => op.op === "update_node"), false, "an unchanged title is not a write");
+});
+
+test("an anchored acceptance splits into pieces that stay in the same product", () => {
+  // Both carries at once. The stored key alone would leave every piece in
+  // triage (anchors govern); the anchors alone would be enough here but not for
+  // the intake case below — and the issue asks for the product to survive both.
+  const original = {
+    ...node("A-export", "acceptance", { metadata: { product: "care", values: ["time"], gherkin: "When … Then …" } }),
+    title: "Export notes",
+    platforms: ["web"],
+    status: "live",
+  };
+  const view = node("V-notes", "view", { metadata: { product: "admin" } });
+  const nodes = [original, view];
+  const edges = [covers("A-export", "V-notes")];
+
+  const ops = planAcceptanceSplit(original, ["Export as PDF", "Export as CSV"], PROJECT, edges, byId(nodes));
+  const next = applyOps({ projectId: PROJECT, nodes, edges }, ops);
+  const nextById = byId(next.nodes);
+  const piece = nextById.get("AC-export-as-csv");
+
+  assert.ok(piece, "the second piece exists");
+  assert.deepEqual([...productsOfAcceptance(piece, next.edges, nextById)], ["admin"]);
+  assert.deepEqual(
+    [...productsOfAcceptance(nextById.get("A-export"), next.edges, nextById)],
+    ["admin"],
+    "and so does the piece that renamed the original",
+  );
+  assert.deepEqual(piece.platforms, ["web"], "platform availability carries");
+  assert.deepEqual(piece.metadata.values, ["time"], "the Why carries");
+  assert.equal(piece.metadata.product, "care", "the stored key carries, for the day it stops covering anything");
+  assert.equal(piece.status, "idea", "a new piece has not been verified, whatever it was split out of");
+  assert.equal(piece.metadata.gherkin, undefined, "the How is about the specific piece, and is not duplicated");
+});
+
+test("an intake idea splits into pieces that keep the product it was filed under", () => {
+  const original = { ...node("A-export", "acceptance", { metadata: { product: "admin" } }), title: "Export notes" };
+  const nodes = [original];
+
+  const ops = planAcceptanceSplit(original, ["Export as PDF", "Export as CSV"], PROJECT, [], byId(nodes));
+  const next = applyOps({ projectId: PROJECT, nodes, edges: [] }, ops);
+  const nextById = byId(next.nodes);
+
+  for (const id of ["A-export", "AC-export-as-csv"]) {
+    assert.deepEqual([...productsOfAcceptance(nextById.get(id), next.edges, nextById)], ["admin"], id);
+  }
+});
+
+test("per-platform evidence is not copied onto a new piece", () => {
+  const original = {
+    ...node("A-export", "acceptance", {
+      metadata: {
+        platformStatuses: { web: "live" },
+        platformNotes: { web: "shipped in 4.2" },
+        platformScreenshots: { web: "shot.png" },
+      },
+    }),
+    title: "Export notes",
+    platforms: ["web"],
+  };
+  const ops = planAcceptanceSplit(original, ["A", "B"], PROJECT, [], byId([original]));
+  const created = ops.find((op) => op.op === "create_node").node;
+  assert.equal(created.metadata, undefined);
+});
+
+test("pieces whose titles kebab-case identically get distinct ids", () => {
+  // `deriveNodeId` can only disambiguate against what it is handed, so ids
+  // minted earlier in the same batch have to be fed back in — otherwise both
+  // pieces claim `AC-export-pdf` and `applyOps` refuses the batch.
+  const original = { ...node("A-x", "acceptance"), title: "Original" };
+  const nodes = [original];
+  const ops = planAcceptanceSplit(original, ["Keep", "Export/PDF", "Export PDF"], PROJECT, [], byId(nodes));
+  const ids = ops.filter((op) => op.op === "create_node").map((op) => op.node.id);
+  assert.deepEqual(ids, ["AC-export-pdf", "AC-export-pdf-2"]);
+  assert.doesNotThrow(() => applyOps({ projectId: PROJECT, nodes, edges: [] }, ops));
+});
+
+test("a dangling anchor is not multiplied across the pieces", () => {
+  // `applyOps` does not check that an edge's endpoints exist, so nothing
+  // downstream would refuse three copies of one broken reference.
+  const original = { ...node("A-export", "acceptance"), title: "Export notes" };
+  const view = node("V-notes", "view");
+  const nodes = [original, view];
+  const edges = [covers("A-export", "V-notes"), covers("A-export", "V-gone")];
+
+  const ops = planAcceptanceSplit(original, ["A", "B", "C"], PROJECT, edges, byId(nodes));
+  const targets = ops.filter((op) => op.op === "create_edge").map((op) => op.edge.target_id);
+  assert.deepEqual(targets, ["V-notes", "V-notes"]);
+});
+
+// The transpiled CommonJS is a build artefact, not a fixture.
+fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+
+console.log(failures === 0 ? "\nAll acceptance-intake tests passed" : `\n${failures} failing`);
+process.exit(failures === 0 ? 0 : 1);

--- a/tests/app/acceptance-matrix.test.js
+++ b/tests/app/acceptance-matrix.test.js
@@ -13,6 +13,7 @@ const {
   productsOfAcceptance,
   EMPTY_FILTERS,
   UNANCHORED_GROUP_LABEL,
+  UNANCHORED_FILTER,
 } = loadAcceptanceMatrix();
 
 const view = { id: "V-detail", project_id: "p", species: "view", title: "Detail", status: "live", platforms: ["web", "ios", "android"] };
@@ -44,6 +45,16 @@ check("platform+status filter matches that platform's resolved status",
 check("value filter", filterAcceptances(acceptances, edges, nodesById, { ...EMPTY_FILTERS, value: "reduces-anxiety" }).map((a) => a.id).join() === "AC-palette");
 check("anchor filter keeps acceptances covering that anchor", filterAcceptances(acceptances, edges, nodesById, { ...EMPTY_FILTERS, anchor: "F-swap" }).map((a) => a.id).join() === "AC-anim");
 check("parity_gap filter keeps only gapped acceptances", filterAcceptances(acceptances, edges, nodesById, { ...EMPTY_FILTERS, parityGap: true }).map((a) => a.id).join() === "AC-anim");
+check("the unanchored filter is the intake inbox — acceptances covering nothing",
+  filterAcceptances(acceptances, edges, nodesById, { ...EMPTY_FILTERS, anchor: UNANCHORED_FILTER }).map((a) => a.id).join() === "AC-offline");
+// The filter and the group it exists to reach must agree about a dangling edge,
+// or "Unanchored (intake)" would hide an acceptance the matrix files under
+// "Unanchored" a screen further down.
+check("the unanchored filter counts a dangling covers edge as unanchored, like the group does",
+  filterAcceptances(acceptances, [...edges, { id: "e-AC-offline-V-missing", project_id: "p", source_id: "AC-offline", target_id: "V-missing", edge_type: "covers" }],
+    nodesById, { ...EMPTY_FILTERS, anchor: UNANCHORED_FILTER }).map((a) => a.id).join() === "AC-offline");
+check("the sentinel did not swallow the named-anchor branch",
+  filterAcceptances(acceptances, edges, nodesById, { ...EMPTY_FILTERS, anchor: "V-detail" }).map((a) => a.id).sort().join() === "AC-anim,AC-palette");
 
 const accWithDesc = { ...acc2, id: "AC-desc", description: "supports quiet reflection", metadata: { values: ["reduces-anxiety"] } };
 check("search matches description text",

--- a/tests/app/load-acceptance-intake.js
+++ b/tests/app/load-acceptance-intake.js
@@ -1,0 +1,77 @@
+/**
+ * Loads lib/utils/acceptance-intake.ts into a plain Node process, following the
+ * tests/app/load-*.js idiom: transpile to CommonJS, rewrite the `@/` alias, and
+ * point `@arkaik/schema` at the schema package's own test build.
+ *
+ * The module's whole dependency graph comes along because it is *used*, not
+ * stubbed: intake reads membership through `product-scope.ts` and writes it
+ * through `product-editing.ts`, and a suite that reimplemented either would be
+ * asserting its own copy of the anchors-first rule rather than the app's.
+ *
+ * lib/hooks/useAcceptanceIntake.ts is deliberately absent — it is a React hook,
+ * this repo has no component runner, and everything it decides beyond "turn a
+ * plan into a write" lives in the module built here.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const ts = require("typescript");
+const { loadSchema, BUILD_DIR: SCHEMA_BUILD_DIR } = require("../schema/load-schema");
+
+const ROOT = path.join(__dirname, "..", "..");
+const BUILD_DIR = path.join(__dirname, ".test-build-acceptance-intake");
+
+const MODULES = [
+  ["lib/config/platforms.ts", "platforms"],
+  ["lib/utils/product-scope.ts", "product-scope"],
+  ["lib/utils/product-editing.ts", "product-editing"],
+  ["lib/utils/acceptance-intake.ts", "acceptance-intake"],
+];
+
+function loadAcceptanceIntake() {
+  loadSchema();
+
+  fs.rmSync(BUILD_DIR, { recursive: true, force: true });
+  fs.mkdirSync(BUILD_DIR, { recursive: true });
+  fs.writeFileSync(path.join(BUILD_DIR, "package.json"), JSON.stringify({ type: "commonjs" }));
+
+  const schemaIndex = path.join(SCHEMA_BUILD_DIR, "index.js");
+
+  for (const [srcRel, outName] of MODULES) {
+    const source = fs.readFileSync(path.join(ROOT, srcRel), "utf8");
+    const { outputText } = ts.transpileModule(source, {
+      fileName: path.basename(srcRel),
+      compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2020, esModuleInterop: true },
+    });
+
+    // `@/lib/data/types` is imported type-only and is elided by the transpiler;
+    // everything else is a real require and is pointed at the schema test build
+    // or at a sibling output in this flat build directory.
+    const rewritten = outputText
+      .replace(/require\((['"])@arkaik\/schema\1\)/g, `require(${JSON.stringify(schemaIndex)})`)
+      .replace(/require\((['"])@\/lib\/config\/platforms\1\)/g, `require("./platforms.js")`)
+      .replace(/require\((['"])@\/lib\/utils\/product-scope\1\)/g, `require("./product-scope.js")`)
+      .replace(/require\((['"])@\/lib\/utils\/product-editing\1\)/g, `require("./product-editing.js")`);
+    fs.writeFileSync(path.join(BUILD_DIR, `${outName}.js`), rewritten);
+  }
+
+  for (const [, outName] of MODULES) {
+    delete require.cache[path.join(BUILD_DIR, `${outName}.js`)];
+  }
+
+  return {
+    ...require(path.join(BUILD_DIR, "acceptance-intake.js")),
+    // The read authority the intake rules are judged against. Picked, not
+    // spread: this suite asserts what membership *is* after a plan, and it must
+    // ask the same function every read surface asks.
+    productsOfAcceptance: require(path.join(BUILD_DIR, "product-scope.js")).productsOfAcceptance,
+    // The real op interpreter. A plan is only correct if the graph it produces
+    // is, and reimplementing "apply these ops" in the suite would hide exactly
+    // the mistakes worth catching — a duplicate id inside one batch, an edge id
+    // that does not match the `e-{source}-{target}` convention `applyOps`
+    // rewrites to.
+    applyOps: require(schemaIndex).applyOps,
+  };
+}
+
+module.exports = { loadAcceptanceIntake, BUILD_DIR };


### PR DESCRIPTION
## Summary

Implements the acceptance-first intake workflow (issue #316): PMs can now file ideas as acceptances before flows and views exist, then decompose them by attaching to existing anchors, creating new ones, and splitting into multiple ideas. The product membership is preserved across all operations through both the stored `metadata.product` key and the `covers` edges that govern it.

Adds four core operations:
- **Attach**: Link an unanchored acceptance to a view or flow
- **Detach**: Remove a covers edge
- **Create and attach**: Mint a new anchor (view/flow) with the acceptance's product and immediately cover it
- **Split**: Break one acceptance into several, preserving product and anchors on each piece

The implementation is pure functions over plain data (`lib/utils/acceptance-intake.ts`), tested exhaustively in `tests/app/acceptance-intake.test.js`, and wired into the UI through a new `useAcceptanceIntake` hook. The `AcceptanceEditor` panel gains attach/detach buttons, a combobox to create anchors, and a split dialog.

Also adds `UNANCHORED_FILTER` to the acceptance matrix, enabling the intake inbox as a filterable view.

## Lab Note

```yaml
en:
  title: "File ideas before you build them"
  summary: "PMs can now write acceptances as intake ideas, then attach them to views and flows as they're built, or split one idea into several. The product stays with the idea through every step."
fr:
  title: "Rédiger les idées avant de les construire"
  summary: "Les PM peuvent maintenant écrire les acceptances comme des idées en attente, puis les rattacher aux vues et flux au fur et à mesure de leur construction, ou diviser une idée en plusieurs. Le produit reste avec l'idée à chaque étape."
suggested:
  molecule: arkaik
  type: feature
  tags: [changelog]
```

https://claude.ai/code/session_019EKtsS8M3J9GrHb48LktwF