### PR TITLE
CI: fix the vocabulary-migration apply flag (falsy empty string)

### DIFF
--- a/.github/workflows/migrate-status-vocabulary.yml
+++ b/.github/workflows/migrate-status-vocabulary.yml
@@ -45,6 +45,8 @@ jobs:
         run: npm ci
 
       - name: Run status vocabulary migration
-        run: node scripts/migrate/status-vocabulary.js ${{ inputs.apply == true && '' || '--dry-run' }}
+        # NOT `apply && '' || '--dry-run'`: in Actions expressions the empty
+        # string is falsy, so that form dry-runs even when apply=true.
+        run: node scripts/migrate/status-vocabulary.js ${{ !inputs.apply && '--dry-run' || '' }}
         env:
           DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}


### PR DESCRIPTION
`inputs.apply == true && '' || '--dry-run'` always evaluates to `--dry-run` because '' is falsy in Actions expressions — the apply run silently dry-ran. Inverted to `!inputs.apply && '--dry-run' || ''`. Chore, no Lab Note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)