### PR TITLE
Self-map content: the whole product, mapped (cycle 5, PR A)

### DIFF
--- a/docs/superpowers/plans/2026-08-04-content-population.md
+++ b/docs/superpowers/plans/2026-08-04-content-population.md
@@ -1,0 +1,557 @@
+# Content Population (Self-Map Cycle 5) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. **This plan's tasks are agent fan-outs, not code edits** — the orchestrating session dispatches the wave agents itself (parallel `Agent` calls) and runs the merge/validate machinery between waves.
+
+**Goal:** Populate `seed/arkaik-self-map.json` with the whole Arkaik product (~160–210 nodes, 60–90 valued acceptances) and a curated history (~60–120 deliverables, 8–12 thematic releases, ~12–18 decisions), landing as two stacked PRs.
+
+**Architecture:** Corpus-first layered fan-out (spec: `docs/superpowers/specs/2026-08-04-content-population-design.md`). Agents emit JSON *fragments* into a scratch directory; a deterministic merge script owns ID uniqueness, edge derivation, `node.created` coverage, and journal ordering; `validate-bundle.js` (warning-clean) gates every wave. Agents never edit the seed.
+
+**Tech Stack:** Node scripts in the session scratchpad (never committed), `gh` CLI for the PR corpus, `npm run validate:seeds` as the gate, parallel general-purpose subagents for content authoring.
+
+**Conventions used below:**
+- `$REPO` = the repo root (`/Users/alexis/code/arkaik`).
+- `$SCRATCH` = `<session scratchpad>/cycle5` (created in Task 0). Layout: `corpus/`, `fragments/`, `base-seed.json`, `dates.json`, `project-patch.json`, `merge.mjs`, `arcs.mjs`.
+- Branches: PR A on `cycle5-content-population-spec` (carries the spec + this plan); PR B on `cycle5-self-map-story` branched from A.
+- All work references the schema contract in `docs/arkaik-skill/references/schema.md` and values in `docs/arkaik-skill/references/values.md`.
+
+---
+
+### Task 0: Scratch layout + commit this plan
+
+**Files:**
+- Create: `$SCRATCH/{corpus,fragments}` (directories)
+- Commit: `docs/superpowers/plans/2026-08-04-content-population.md`
+
+- [ ] **Step 1: Create scratch dirs and snapshot the pristine seed**
+
+```bash
+mkdir -p "$SCRATCH/corpus" "$SCRATCH/fragments"
+cp "$REPO/seed/arkaik-self-map.json" "$SCRATCH/base-seed.json"
+```
+
+`base-seed.json` is the merge base for all of PR A. The merge always starts from it, so revising or renaming a fragment node can never leave stale nodes/events behind.
+
+- [ ] **Step 2: Commit the plan on the spec branch**
+
+```bash
+cd "$REPO" && git add docs/superpowers/plans/2026-08-04-content-population.md
+git commit -m "docs: cycle 5 plan — content population"
+```
+
+### Task 1: PR corpus
+
+**Files:**
+- Create: `$SCRATCH/corpus/prs.json`, `$SCRATCH/corpus/pr-files.json`, `$SCRATCH/corpus/docs-manifest.txt`
+
+- [ ] **Step 1: Snapshot merged PRs**
+
+```bash
+cd "$REPO" && gh pr list --state merged --limit 500 \
+  --json number,title,body,mergedAt,labels,author > "$SCRATCH/corpus/prs.json"
+python3 -c "import json;d=json.load(open('$SCRATCH/corpus/prs.json'));print(len(d), min(p['number'] for p in d), max(p['number'] for p in d))"
+```
+
+Expected: ~330+ PRs, numbers spanning the repo's history.
+
+- [ ] **Step 2: Map PR number → changed files from git history**
+
+```bash
+cd "$REPO" && python3 - "$SCRATCH" <<'EOF'
+import json, re, subprocess, sys
+scratch = sys.argv[1]
+log = subprocess.run(["git","log","origin/main","--name-only","--format=@@%s"],
+                     capture_output=True, text=True).stdout
+out, cur = {}, None
+for line in log.splitlines():
+    if line.startswith("@@"):
+        m = re.search(r"\(#(\d+)\)", line)
+        cur = m.group(1) if m else None
+    elif line.strip() and cur:
+        out.setdefault(cur, []).append(line.strip())
+json.dump(out, open(f"{scratch}/corpus/pr-files.json","w"), indent=0)
+print("PRs with files:", len(out))
+EOF
+```
+
+Expected: a few hundred PRs mapped (PRs merged without the `(#N)` squash suffix are simply absent — acceptable).
+
+- [ ] **Step 3: Docs manifest**
+
+```bash
+ls "$REPO"/docs/*.md "$REPO"/docs/spec/*.md "$REPO"/docs/rfcs/*.md \
+   "$REPO"/docs/superpowers/specs/*.md > "$SCRATCH/corpus/docs-manifest.txt"
+wc -l "$SCRATCH/corpus/docs-manifest.txt"
+```
+
+### Task 2: Merge machinery
+
+**Files:**
+- Create: `$SCRATCH/merge.mjs`
+
+**Fragment contract** (what every content agent emits, one JSON file in `$SCRATCH/fragments/`):
+
+```json
+{
+  "area": "canvas-maps",
+  "nodes": [ { "id": "V-canvas", "species": "view", "title": "Project Canvas",
+               "status": "live", "platforms": ["web"],
+               "metadata": { "product": "studio" } } ],
+  "edges": [ { "source_id": "V-canvas", "target_id": "DM-node", "edge_type": "displays" } ],
+  "events": [ { "ts": "2026-05-10T12:00:00.000Z", "type": "deliverable.shipped",
+                "deliverable_id": "pr-123", "title": "…", "summary": "…",
+                "url": "…", "node_ids": ["V-canvas"] } ]
+}
+```
+
+Agents omit `project_id` and edge `id`s (derived). `events` is only used in PR B (plus `node.created` coverage, which the script owns).
+
+- [ ] **Step 1: Write `$SCRATCH/merge.mjs`**
+
+```js
+#!/usr/bin/env node
+// Usage: node merge.mjs <repoRoot> <scratchDir>
+// Assembles <scratch>/fragments/*.json onto <scratch>/base-seed.json and
+// writes <repoRoot>/seed/arkaik-self-map.json. Deterministic; rerun freely.
+import { readFileSync, writeFileSync, readdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+const [repo = ".", scratch = "."] = process.argv.slice(2);
+const seedPath = join(repo, "seed/arkaik-self-map.json");
+const fragDir = join(scratch, "fragments");
+const PROJECT_ID = "arkaik-self-map";
+const PRODUCTS = [
+  { id: "studio", title: "Studio", platforms: ["web"] },
+  { id: "platform", title: "Platform", platforms: ["web"] },
+  { id: "toolchain", title: "Toolchain", platforms: ["web"] },
+];
+
+const seed = JSON.parse(readFileSync(join(scratch, "base-seed.json"), "utf8"));
+const nodes = new Map(seed.nodes.map((n) => [n.id, n]));
+const edges = new Map(seed.edges.map((e) => [e.id, e]));
+const journal = [...(seed.journal ?? [])];
+const owner = new Map(); // node id -> area, collision guard
+
+let seq = 0;
+const eid = (ts) =>
+  "01" + ts.replace(/\D/g, "").slice(2, 14) + String(seq++).padStart(10, "0");
+
+for (const f of readdirSync(fragDir).filter((x) => x.endsWith(".json")).sort()) {
+  const frag = JSON.parse(readFileSync(join(fragDir, f), "utf8"));
+  for (const n of frag.nodes ?? []) {
+    if (owner.has(n.id) && owner.get(n.id) !== frag.area)
+      throw new Error(`${f}: ${n.id} already claimed by area "${owner.get(n.id)}"`);
+    owner.set(n.id, frag.area);
+    nodes.set(n.id, { ...n, project_id: PROJECT_ID });
+  }
+  for (const e of frag.edges ?? []) {
+    const id = `e-${e.source_id}-${e.target_id}`;
+    edges.set(id, { id, project_id: PROJECT_ID, source_id: e.source_id,
+                    target_id: e.target_id, edge_type: e.edge_type });
+  }
+  for (const ev of frag.events ?? [])
+    journal.push({ id: ev.id ?? eid(ev.ts), actor: "claude-code", ...ev });
+}
+
+const ids = new Set(nodes.keys());
+const dangling = [...edges.values()].filter(
+  (e) => !ids.has(e.source_id) || !ids.has(e.target_id));
+if (dangling.length) {
+  console.error("DANGLING EDGES:\n" +
+    dangling.map((e) => `  ${e.source_id} -> ${e.target_id}`).join("\n"));
+  process.exit(1);
+}
+
+// node.created coverage — ts from dates.json, else project.created_at
+const dates = existsSync(join(scratch, "dates.json"))
+  ? JSON.parse(readFileSync(join(scratch, "dates.json"), "utf8")) : {};
+const created = new Set(
+  journal.filter((e) => e.type === "node.created").map((e) => e.node_id));
+for (const n of nodes.values()) {
+  if (created.has(n.id)) continue;
+  const ts = dates[n.id] ?? seed.project.created_at;
+  journal.push({ id: eid(ts), ts, actor: "claude-code", type: "node.created",
+                 node_id: n.id, species: n.species, title: n.title });
+}
+
+journal.sort((a, b) =>
+  a.ts < b.ts ? -1 : a.ts > b.ts ? 1 : a.id < b.id ? -1 : a.id > b.id ? 1 : 0);
+
+if (existsSync(join(scratch, "project-patch.json"))) {
+  const { metadata, ...rest } =
+    JSON.parse(readFileSync(join(scratch, "project-patch.json"), "utf8"));
+  Object.assign(seed.project, rest);
+  seed.project.metadata = { ...(seed.project.metadata ?? {}), ...(metadata ?? {}) };
+}
+seed.project.metadata = { ...(seed.project.metadata ?? {}), products: PRODUCTS };
+seed.nodes = [...nodes.values()];
+seed.edges = [...edges.values()];
+seed.journal = journal;
+seed.project.updated_at = "2026-08-04T12:00:00.000Z";
+const out = JSON.stringify(seed, null, 2) + "\n";
+writeFileSync(seedPath, out);
+console.log(`nodes=${seed.nodes.length} edges=${seed.edges.length} ` +
+  `journal=${journal.length} size=${Math.round(out.length / 1024)}KB`);
+```
+
+- [ ] **Step 2: No-op smoke test**
+
+```bash
+node "$SCRATCH/merge.mjs" "$REPO" "$SCRATCH"
+node "$REPO/docs/arkaik-skill/scripts/validate-bundle.js" "$REPO/seed/arkaik-self-map.json"
+cd "$REPO" && git diff --stat seed/arkaik-self-map.json
+```
+
+Expected: `nodes=15 edges=19 journal=20`, validator exit 0, diff limited to `products` injection + `updated_at` + formatting. Then `git checkout seed/arkaik-self-map.json` to reset until the real merge.
+
+**The wave gate** (used at the end of every wave; "warning-clean" means zero errors AND zero warnings):
+
+```bash
+node "$SCRATCH/merge.mjs" "$REPO" "$SCRATCH" && \
+node "$REPO/docs/arkaik-skill/scripts/validate-bundle.js" "$REPO/seed/arkaik-self-map.json"
+```
+
+### Task 3: Wave 1a — data-layer inventory (runs first, alone)
+
+One agent owns **all** `DM-` and `API-` nodes so parallel area agents can reference them without collisions.
+
+- [ ] **Step 1: Dispatch the data-layer agent**
+
+Prompt (fill `$SCRATCH` literally):
+
+> Read `docs/arkaik-skill/references/schema.md` (ID conventions, edge semantics) in /Users/alexis/code/arkaik, then inventory Arkaik's data models and API endpoints by reading: `lib/data/` (types, db, providers), `db/`, `app/api/**` (auth, synk, publik, graph, tokens, github), `packages/schema/src/`, `docs/data-layer.md`, `docs/architecture.md`, `docs/spec/bundle-format.md`, `docs/spec/journal.md`.
+> Produce fragment `$SCRATCH/fragments/10-data-layer.json` (shape: `{"area":"data-layer","nodes":[…],"edges":[…]}`) containing:
+> - `DM-` nodes for **concepts** (Project, Node, Edge, ProjectBundle, JournalEvent, MapDefinition, Product, Deliverable…) and **physical stores** (each IndexedDB store, each Postgres table) as distinct nodes per the concept-vs-table rule. ~20–25 total.
+> - `API-` nodes for every real route under `app/api` (title like "POST /api/synk/projects"). ~15–20 total.
+> - `queries` edges (api-endpoint → data-model) where the route genuinely reads/writes the model, and `calls` edges between endpoints where one fans out to another.
+> - Every node: `status` (almost all `live`), `platforms: ["web"]`, a one-sentence `description`. **No** `metadata.product` (membership is derived for these species). No playlists, no gherkin.
+> - IDs deterministic from titles with correct prefixes. Return the fragment path and a one-paragraph inventory summary.
+
+- [ ] **Step 2: Sanity-check the fragment**
+
+```bash
+python3 -c "
+import json;f=json.load(open('$SCRATCH/fragments/10-data-layer.json'))
+from collections import Counter
+print(Counter(n['species'] for n in f['nodes']), len(f['edges']),'edges')
+print(sorted(n['id'] for n in f['nodes']))"
+```
+
+Expected: only `data-model`/`api-endpoint` species; DM/API counts inside spec ranges; no obviously duplicate concepts.
+
+### Task 4: Wave 1b — seven area agents in parallel (flows, views, edges)
+
+- [ ] **Step 1: Dispatch all seven agents in one message**
+
+Shared prompt template (per-area values from the table below; attach the **id list** from `10-data-layer.json` — ids and titles only — to every prompt):
+
+> Read `docs/arkaik-skill/references/schema.md` in /Users/alexis/code/arkaik — especially ID conventions, edge semantics, and playlists. You are mapping the **AREA** area of Arkaik itself. Read: FILES. The existing seed (`seed/arkaik-self-map.json`) already contains 15 nodes about the /projects area — reuse those exact ids where your area overlaps them rather than minting near-duplicates.
+> Produce fragment `$SCRATCH/fragments/NN-AREA.json` (`{"area":"AREA","nodes":[…],"edges":[…]}`):
+> - `V-` nodes for each distinct screen/page/panel a user perceives; `F-` nodes for each user journey. Every flow has `metadata.playlist` with real entries, and a matching `composes` edge for every view/flow the playlist references.
+> - `metadata.product: "PRODUCT"` on every flow and view. `platforms: ["web"]`, `status` honest (`live` for shipped surfaces, `development`/`backlog` only if genuinely unfinished). `metadata.stage` only for `beta`/`monitoring`/`deprecated` realities.
+> - `calls` edges to the attached `API-` ids and `displays` edges to `DM-` ids where the surface genuinely does so. Only reference `DM-`/`API-` ids from the attached list — never invent new ones; if something is missing, note it in your summary instead.
+> - No acceptances, no decisions, no gherkin/values. IDs deterministic from titles. Budget: BUDGET nodes — every *distinct* surface, no filler.
+> Return the fragment path, a summary, and any DM/API gaps you noticed.
+
+| NN | AREA | PRODUCT | BUDGET | FILES |
+|---|---|---|---|---|
+| 20 | projects-home | studio | 5–9 | `app/projects/page.tsx`, `lib/data/project-sections.ts`, `lib/data/create-target.ts`, `components/projects/`, `lib/data/arkaik-seed.ts` |
+| 21 | canvas-maps | studio | 8–12 | `app/project/[id]/{page.tsx,canvas,maps}`, `components/graph/`, `components/maps/`, `lib/utils/{graph-build,elk-layout,journey-graph,graph-spotlight,keyboard-shortcuts,command-palette}.ts`, `docs/spec/maps.md` |
+| 22 | detail-editing | studio | 8–12 | `app/project/[id]/{library,overview,pyramid,acceptances}`, `components/{panels,library,acceptances,values,pyramid,overview}/`, `lib/utils/{acceptance-matrix,coverage,product-editing}.ts` |
+| 23 | pm-surfaces | studio | 6–10 | `app/project/[id]/{changelog,delivery,history,decisions}`, `components/{journal,delivery,decisions}/`, `lib/utils/{journal,delivery,decision}.ts`, `docs/spec/journal.md` |
+| 24 | sharing-platform | platform | 8–12 | `app/p/`, `app/generate/`, `app/settings/`, `auth.ts`, `components/{publik,sync,auth,generate,settings}/`, `lib/{sync,services,prompts}/`, `docs/hosted-projects.md` |
+| 25 | sandbox-io | studio | 5–8 | `lib/utils/export.ts`, `lib/data/{seed-provider,routing-provider,migrate,seed-project-id}.ts`, `app/docs/`, `components/docs/`, cycle-4 spec `docs/superpowers/specs/2026-08-04-public-self-map-design.md` |
+| 26 | toolchain | toolchain | 6–10 | `packages/cli/`, `packages/mcp/`, `plugin/`, `docs/arkaik-skill/`, `docs/spec/{toolchain,mcp}.md` (CLI commands and MCP tools map naturally to flows; the skill/plugin surfaces to views sparingly) |
+
+- [ ] **Step 2: Merge + validate (errors only at this stage)**
+
+```bash
+node "$SCRATCH/merge.mjs" "$REPO" "$SCRATCH" && \
+node "$REPO/docs/arkaik-skill/scripts/validate-bundle.js" "$REPO/seed/arkaik-self-map.json"
+```
+
+Expected: node count in the 90–120 range (pre-acceptances), zero **errors**. Warnings about missing acceptances/values are expected until Task 6. If the merge aborts on dangling edges or an id collision, fix the named fragment (edit the JSON, or redispatch that one agent with the error attached) and rerun.
+
+### Task 5: Wave 1 adversarial review + node dating
+
+- [ ] **Step 1: Dispatch the anatomy reviewer**
+
+> You are reviewing the product map of Arkaik against the real product — adversarially. Repo: /Users/alexis/code/arkaik. Read `seed/arkaik-self-map.json`, then spot-check it against the codebase (`app/`, `components/`, `packages/`, `plugin/`). Hunt for: (1) real user-facing surfaces with no node — check every route under `app/` and every `packages/cli` command; (2) nodes describing surfaces that do not exist or misdescribing ones that do; (3) playlists that misrepresent the actual journey; (4) `calls`/`displays`/`queries` edges that are false, and important ones that are missing; (5) duplicate concepts under different ids. Do NOT edit anything. Return a numbered findings list — each with the node/edge id, what is wrong, and the file evidence — ordered by severity.
+
+- [ ] **Step 2: Apply findings to the fragments, re-merge, re-validate**
+
+Edit the named fragment files (never the seed), rerun the wave gate. Repeat until the reviewer's material findings are addressed.
+
+- [ ] **Step 3: Dispatch the dating agent**
+
+Attach: the current seed's `{id,title,species}` node list, and `corpus/prs.json` reduced to `{number,title,mergedAt}` (plus `corpus/pr-files.json`).
+
+> For each node of Arkaik's self-map (attached), find the merged PR that first shipped that surface, using PR titles and the PR→files map (e.g. nodes about `components/graph` date to early canvas PRs). Output **JSON only** — `{"<node_id>": "<ISO 8601 merge timestamp>", …}` — covering every attached node id. When no PR clearly matches, use the merge date of the era when the area appeared (infer from neighboring surfaces); never omit a node, never use a date outside the repo's PR history.
+
+Save output to `$SCRATCH/dates.json`, spot-check five known nodes (e.g. Decision Log dates ≈ 2026-08-03, `V-projects` early), then re-run the wave gate — `node.created` timestamps now become historical.
+
+### Task 6: Wave 2 — acceptances + values
+
+- [ ] **Step 1: Dispatch seven acceptance agents in parallel**
+
+One per area from the Task 4 table (fragment `3N-AREA-acceptances.json`, area `AREA-acceptances`). Attach the merged seed's node list (`{id,title,species,product}`) for the agent's area. Template:
+
+> Read `docs/arkaik-skill/references/values.md` and the acceptance conventions in `docs/arkaik-skill/references/schema.md` (repo /Users/alexis/code/arkaik). For the **AREA** area of Arkaik's self-map, write acceptance nodes — the testable promises the product makes on those surfaces. For each: `id` `AC-<kebab-promise>`, `species: "acceptance"`, honest `status` (`live` if the promise holds today), `platforms: ["web"]`, `metadata.product: "PRODUCT"`, `metadata.gherkin` with ONE Given/When/Then scenario grounded in real behavior (read the code/docs when unsure), `metadata.values` with 1–3 elements from the values doc — most specific element; higher tier only when genuinely earned. Add a `covers` edge to each view/flow anchor (attached list; anchors must be in your area — never span products). Budget: BUDGET acceptances covering the area's real promises — quality over count. Fragment shape: `{"area":"AREA-acceptances","nodes":[…],"edges":[…]}`.
+
+Budgets: projects-home 6–9, canvas-maps 10–14, detail-editing 10–14, pm-surfaces 8–12, sharing-platform 10–14, sandbox-io 6–9, toolchain 8–12 (total lands in the spec's 60–90).
+
+- [ ] **Step 2: Merge + validate**
+
+Run the wave gate. Expected: acceptance warnings gone for covered nodes; zero errors; total nodes 150–210.
+
+- [ ] **Step 3: Values-balance review**
+
+```bash
+python3 -c "
+import json;from collections import Counter
+b=json.load(open('$REPO/seed/arkaik-self-map.json'))
+vs=Counter(v for n in b['nodes'] if n['species']=='acceptance' for v in n.get('metadata',{}).get('values',[]))
+print(vs.most_common())"
+```
+
+Dispatch one reviewer with this distribution + the acceptance list: instruct it to flag over-assigned elements (anything > ~25% of all assignments), acceptances whose values ring hollow, and pyramid-tier inflation; return per-acceptance reassignments. Apply to fragments, re-merge, re-validate: gate is **warning-clean** from here on.
+
+### Task 7: Curated maps + project finalize (inline, no agent)
+
+- [ ] **Step 1: Write `$SCRATCH/project-patch.json`**
+
+Using the merged seed's real ids (adjust `root_node_id`/roots to actual ids after Task 6; the shape below is the contract, the four maps are the deliverable):
+
+```json
+{
+  "description": "Arkaik mapped in Arkaik — the whole product as a living graph: every surface, the promises it makes, and the history of how it got here.",
+  "root_node_id": "V-projects",
+  "metadata": {
+    "maps": [
+      { "id": "studio-journey", "title": "Studio journey", "kind": "journey",
+        "product": "studio", "root_node_id": "V-projects" },
+      { "id": "platform-journey", "title": "Platform journey", "kind": "journey",
+        "product": "platform", "root_node_id": "<platform home view id>" },
+      { "id": "toolchain-journey", "title": "Toolchain journey", "kind": "journey",
+        "product": "toolchain", "root_node_id": "<toolchain root id>" },
+      { "id": "data-spine", "title": "Data spine", "kind": "system",
+        "species": ["api-endpoint", "data-model"],
+        "edge_types": ["queries", "calls"] }
+    ]
+  }
+}
+```
+
+- [ ] **Step 2: Re-run the wave gate**
+
+Expected: warning-clean (map root warnings would surface a bad id), size printed and ≤ ~600KB.
+
+### Task 8: PR A — the map
+
+- [ ] **Step 1: Final gate + commit**
+
+```bash
+node "$SCRATCH/merge.mjs" "$REPO" "$SCRATCH" && \
+node "$REPO/docs/arkaik-skill/scripts/validate-bundle.js" "$REPO/seed/arkaik-self-map.json" && \
+cd "$REPO" && git add seed/arkaik-self-map.json && \
+git commit -m "Self-map: whole-product anatomy, acceptances, values, curated maps (cycle 5, PR A)"
+```
+
+- [ ] **Step 2: Push and open the PR**
+
+PR body: what the map now contains (counts per species, the three products, the four maps), the validator/warning-clean statement, a visual-pass checklist for Alexis (canvas legibility at this scale; product filter; each curated map opens; pyramid/coverage pages; Explore sandbox unchanged mechanically), and this Lab Note section:
+
+```markdown
+## Lab Note
+```yaml
+en:
+  title: "Arkaik's own map just got real"
+  summary: "The sandbox project on the projects page now holds the whole product — every screen, journey, and promise Arkaik makes, wired to the value it serves. Open it and wander."
+fr:
+  title: "La carte d'Arkaik devient réelle"
+  summary: "Le projet bac à sable de la page projets contient maintenant tout le produit — chaque écran, chaque parcours, chaque promesse, reliés à la valeur servie. Ouvre-la et balade-toi."
+suggested:
+  molecule: arkaik
+  type: feature
+  tags: [changelog]
+```
+```
+
+```bash
+git push -u origin cycle5-content-population-spec
+gh pr create --title "Self-map content: the whole product, mapped (cycle 5, PR A)" --body-file <body>
+```
+
+- [ ] **Step 3: Read the PR comments**
+
+```bash
+gh pr view --comments
+```
+
+Expected: no Lab Note reminder comment (or fix the body until it clears). CI must go green — remember main carries pre-existing lint errors; the bar is no new ones (no code files touched here, so build + validate:seeds are the live risks).
+
+### Task 9: Story setup (PR B branch, era definition)
+
+- [ ] **Step 1: Branch and re-snapshot the base**
+
+```bash
+cd "$REPO" && git checkout -b cycle5-self-map-story
+cp seed/arkaik-self-map.json "$SCRATCH/base-seed.json"
+mv "$SCRATCH/fragments" "$SCRATCH/fragments-pr-a" && mkdir "$SCRATCH/fragments"
+```
+
+(The PR A seed becomes the new merge base; PR A fragments are retired.)
+
+- [ ] **Step 2: Define the eras (inline, from the corpus)**
+
+Read `corpus/prs.json` mergedAt distribution + titles and write `$SCRATCH/eras.json`: 8–12 entries `{ "version": "<kebab-slug>", "title": "…", "boundary_pr": <last PR number>, "ts": "<just after that PR's merge>", "notes": "<one narrative paragraph>" }`, using the spec's working list (`first-graph`, `journal-and-changelog`, `going-multi-product`, `acceptance-and-value`, `hosted-and-public`, `decisions-and-history`, `the-self-map`) as the starting shape, adjusted to what the corpus actually shows. Convert to a fragment `$SCRATCH/fragments/50-releases.json` with one `release.tagged` event per era (`{ts, type, version, notes, actor: "alexis"}`).
+
+### Task 10: Wave 3 — era deliverables + decisions + ideas (parallel)
+
+- [ ] **Step 1: Dispatch one agent per era (8–12, parallel) + one decisions agent**
+
+Era-agent template — attach: the era's corpus slice (PRs between the previous boundary and this one, full bodies), `pr-files.json` entries for those PRs, and the seed's node id/title list:
+
+> You are writing the deliverable history for the "**ERA**" chapter of Arkaik's self-map. From the attached merged PRs, select every **user-visible** change (a PR whose body contains a `## Lab Note` section is user-visible by definition; for others, judge: would a user notice?). Skip chores, CI, refactors, docs-only. For each selected PR emit one event: `{ "ts": "<mergedAt>", "type": "deliverable.shipped", "deliverable_id": "pr-<number>", "title": "…", "summary": "…", "url": "https://github.com/alexisbohns/arkaik/pull/<number>", "node_ids": [ids from the attached list that the PR touched], "actor": "claude-code" }`. Where a Lab Note exists, adapt its `en` title/summary (benefit-first, no jargon); otherwise write in that same voice. `node_ids` must only use attached ids (use the PR's changed files to infer which surfaces it touched); leave `[]` when nothing maps. Fragment: `$SCRATCH/fragments/6N-ERA.json`, `{"area":"ERA","events":[…]}`.
+
+Decisions-agent prompt — attach the seed node list and `docs-manifest.txt`:
+
+> Mine Arkaik's decision record. Read the spec docs in `docs/superpowers/specs/` (especially `2026-08-03-self-map-program.md`'s standing decisions), `docs/rfcs/`, and `docs/spec/journal.md` (repo /Users/alexis/code/arkaik). The seed already has 3 `DEC-` nodes — keep their ids untouched. Add ~9–15 more: for each, a `DEC-` node (`species: "decision"`, no `platforms`, `metadata`: `context` (the Why, markdown), `consequences` (the How), `decided_at` (real date from the doc/PR), `decision_status` (mostly `enacted`), and `status` set to the lifecycle mapping — enacted→`live`, proposed→`discovery`, approved→`backlog`, rejected/deprecated/superseded→`archived`). Add `generates` edges (decision→acceptance), `impacts` edges (decision→flow|view|data-model|api-endpoint) to attached ids, and `supersedes` where one decision replaced another. For every NEW decision also emit `decision.status_changed` events tracing its real path (e.g. proposed at brainstorm date → enacted at ship date), final `to` matching its `decision_status`, `actor: "alexis"`. Fragment: `$SCRATCH/fragments/70-decisions.json`, `{"area":"decisions","nodes":[…],"edges":[…],"events":[…]}`.
+
+- [ ] **Step 2: Ideas fragment (inline)**
+
+Write `$SCRATCH/fragments/75-ideas.json` with 3–6 `idea.proposed` events for genuinely open items with real dates, e.g. blocked indicator on StatusRing rollups (deferred in cycle 1, 2026-08-03), milestones (parked in cycle 2), pebbles retro-population — `{ "ts": "…", "type": "idea.proposed", "title": "…", "description": "…", "actor": "alexis" }`.
+
+### Task 11: Status arcs + story merge
+
+- [ ] **Step 1: Merge wave 3 first** (deliverables must exist before arcs can use ship dates)
+
+Run the wave gate. Expected: zero errors; journal now has releases + deliverables + decision events in historical order.
+
+- [ ] **Step 2: Write `$SCRATCH/arcs.mjs`**
+
+```js
+#!/usr/bin/env node
+// Usage: node arcs.mjs <repoRoot> <scratchDir>
+// Emits fragments/80-status-arcs.json: honest node.status_changed arcs.
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+const [repo = ".", scratch = "."] = process.argv.slice(2);
+const seed = JSON.parse(readFileSync(join(repo, "seed/arkaik-self-map.json"), "utf8"));
+const created = new Map(seed.journal.filter((e) => e.type === "node.created")
+  .map((e) => [e.node_id, e.ts]));
+const ship = new Map(); // node id -> earliest deliverable ts
+for (const ev of seed.journal) {
+  if (ev.type !== "deliverable.shipped") continue;
+  for (const id of ev.node_ids ?? [])
+    if (!ship.has(id) || ev.ts < ship.get(id)) ship.set(id, ev.ts);
+}
+const overrides = existsSync(join(scratch, "arc-overrides.json"))
+  ? JSON.parse(readFileSync(join(scratch, "arc-overrides.json"), "utf8")) : {};
+const bump = (ts, h) => { const d = new Date(ts); d.setHours(d.getHours() + h);
+  return d.toISOString(); };
+const events = [];
+for (const n of seed.nodes) {
+  if (n.species === "decision") continue; // decisions have their own events
+  const o = overrides[n.id];
+  if (o === "skip") continue;
+  if (o) { for (const s of o) events.push({ ts: s.ts, type: "node.status_changed",
+      node_id: n.id, from: s.from, to: s.to }); continue; }
+  const t0 = created.get(n.id) ?? seed.project.created_at;
+  if (n.status === "live") {
+    const dev = bump(t0, 1);
+    const live = ship.has(n.id) && ship.get(n.id) > dev ? ship.get(n.id) : bump(t0, 48);
+    events.push({ ts: dev, type: "node.status_changed", node_id: n.id,
+      from: "idea", to: "development" });
+    events.push({ ts: live, type: "node.status_changed", node_id: n.id,
+      from: "development", to: "live" });
+  } else if (n.status !== "idea") {
+    events.push({ ts: bump(t0, 1), type: "node.status_changed", node_id: n.id,
+      from: "idea", to: n.status });
+  }
+}
+writeFileSync(join(scratch, "fragments/80-status-arcs.json"),
+  JSON.stringify({ area: "status-arcs", events }, null, 2) + "\n");
+console.log(`status events: ${events.length}`);
+```
+
+- [ ] **Step 3: Generate arcs, re-merge, era-consistency check**
+
+```bash
+node "$SCRATCH/arcs.mjs" "$REPO" "$SCRATCH"
+node "$SCRATCH/merge.mjs" "$REPO" "$SCRATCH" && \
+node "$REPO/docs/arkaik-skill/scripts/validate-bundle.js" "$REPO/seed/arkaik-self-map.json"
+python3 - "$REPO/seed/arkaik-self-map.json" <<'EOF'
+import json, sys
+b = json.load(open(sys.argv[1])); j = b["journal"]
+rel = [(e["ts"], e["version"]) for e in j if e["type"] == "release.tagged"]
+first = {}
+for e in j:
+    if e["type"] == "deliverable.shipped" and e["deliverable_id"] not in first:
+        first[e["deliverable_id"]] = e["ts"]
+after_last = [d for d, ts in first.items() if rel and ts > max(r[0] for r in rel)]
+print(len(rel), "releases;", len(first), "deliverables;", len(after_last), "unreleased:", after_last)
+EOF
+```
+
+Expected: warning-clean validate; every deliverable inside an era slice (unreleased list empty, or only deliberately-post-era items). If arcs put a node's `live` before its era looks right, add an `arc-overrides.json` entry for it and regenerate.
+
+### Task 12: Story adversarial review
+
+- [ ] **Step 1: Dispatch the story reviewer**
+
+> Review the historical narrative in `seed/arkaik-self-map.json` (repo /Users/alexis/code/arkaik) as a skeptical editor. Check: (1) era release notes — do they tell a true, benefit-first story matching their deliverables? (2) deliverable summaries — corporate jargon, ticket-speak, or mechanism-first phrasing? (3) `node_ids` — spot-check ten deliverables against their real PRs (`gh pr view <n>`); are the touched nodes plausible? (4) decisions — do context/consequences match the actual spec docs; are `decided_at` dates real? (5) any journal event whose `ts` is obviously wrong (before the repo existed, after today, out of era). Return numbered findings with severity; do not edit.
+
+- [ ] **Step 2: Apply findings to fragments, re-merge, re-validate (warning-clean)**
+
+### Task 13: PR B — the story
+
+- [ ] **Step 1: Update the program doc**
+
+Edit `docs/superpowers/specs/2026-08-03-self-map-program.md`: cycle 4 line → `✅ SHIPPED 2026-08-04 (PR #338)`; cycle 5 line → `✅ SHIPPED <date> (PR A #…, PR B #…)` with a one-line summary and a pointer to the cycle-5 spec; header status line updated.
+
+- [ ] **Step 2: Final gate + commit + PR**
+
+```bash
+node "$SCRATCH/merge.mjs" "$REPO" "$SCRATCH" && \
+node "$REPO/docs/arkaik-skill/scripts/validate-bundle.js" "$REPO/seed/arkaik-self-map.json" && \
+cd "$REPO" && git add seed/arkaik-self-map.json docs/superpowers/specs/2026-08-03-self-map-program.md && \
+git commit -m "Self-map: the story — deliverables, thematic releases, decisions, status arcs (cycle 5, PR B)"
+git push -u origin cycle5-self-map-story
+gh pr create --base cycle5-content-population-spec --title "Self-map content: the story (cycle 5, PR B)" --body-file <body>
+```
+
+PR body: counts (releases, deliverables, decisions, journal size, file size), the era list, visual-pass checklist (Changelog Design | Delivery panels, release grouping, History page density, Decision Log, a node's timeline), and this Lab Note:
+
+```markdown
+## Lab Note
+```yaml
+en:
+  title: "Arkaik's map now remembers its own story"
+  summary: "Open the sandbox project's changelog: every chapter of how Arkaik was built is there — what shipped, what was decided, and why. A product that keeps its own diary."
+fr:
+  title: "La carte d'Arkaik raconte maintenant son histoire"
+  summary: "Ouvre le changelog du projet bac à sable : chaque chapitre de la construction d'Arkaik y est — ce qui a été livré, ce qui a été décidé, et pourquoi. Un produit qui tient son propre journal."
+suggested:
+  molecule: arkaik
+  type: feature
+  tags: [changelog]
+```
+```
+
+- [ ] **Step 3: Read PR comments, confirm CI green on both PRs, hand the visual pass to Alexis**
+
+```bash
+gh pr view --comments
+gh pr checks
+```
+
+Both PRs then wait on Alexis's visual pass; PR B retargets to `main` automatically when PR A merges (or re-point it manually).
+
+---
+
+## Execution notes
+
+- **Fragments are the source of truth during the cycle** — every content fix goes into a fragment (or `dates.json`/`project-patch.json`/overrides), then re-merge. Editing the seed by hand guarantees the change is lost on the next merge.
+- **Dangling-edge aborts** name the exact ids: fix the owning fragment, not the referencing one, when the id was misspelled at mint time.
+- **Agent failures** (a fragment that won't parse or violates the contract): redispatch that one agent with the validator/merge error attached — don't hand-patch large fragments.
+- The `eid()` pseudo-ULIDs are sortable strings, not real ULIDs; the validator only requires string ids, and consumers order by `ts` first.

--- a/docs/superpowers/specs/2026-08-04-content-population-design.md
+++ b/docs/superpowers/specs/2026-08-04-content-population-design.md
@@ -1,0 +1,226 @@
+# Content population: filling the self-map — design
+
+**Date:** 2026-08-04 · **Cycle:** 5 of the
+[self-map program](2026-08-03-self-map-program.md) · **Status:** approved
+
+## Goal
+
+Turn `seed/arkaik-self-map.json` from a 15-node beachhead into the flagship
+demo the sandbox (cycle 4) deserves: a comprehensive map of the whole Arkaik
+product, an acceptance layer wired to Value elements, and a curated
+historical narrative — deliverables, thematic releases, decisions, and
+per-node status arcs — mined from the repo's 338 merged PRs and its docs by
+a subagent fan-out. Content-only: no app code changes.
+
+Decisions made in this cycle's brainstorm (2026-08-04):
+
+- **History depth: curated arc.** Every user-visible PR becomes a
+  deliverable (~60–120); chores/CI skipped. Not full-338, not
+  highlights-only.
+- **Map breadth: whole product**, including developer-facing surfaces (CLI,
+  MCP server, plugin, arkaik-dev skill).
+- **Releases: thematic eras** — 8–12 editorial chapters, not monthly rollups
+  or invented semver.
+- **Delivery: two staged PRs.** PR A = the map (anatomy + acceptances +
+  values). PR B (branched on A) = the story (journal history, deliverables,
+  releases, decisions).
+- **Execution: corpus-first layered fan-out** with deterministic merge —
+  agents emit fragments; a script owns ID uniqueness and referential
+  integrity; agents never edit the seed directly.
+
+## PR A — the map (present state)
+
+### Scale
+
+~160–210 nodes: 25–35 flows, 35–45 views, 20–25 data models, 15–20 API
+endpoints, 60–90 acceptances. Calibration: `seed/pebbles.json` renders 152
+nodes / 283 edges comfortably at 183KB, so this is known-good canvas
+territory.
+
+### Products
+
+Whole-product breadth is expressed through the multi-product feature (which
+the map thereby demos). `project.metadata.products` declares three products,
+all with platform menu `[web]` (the schema's platform enum is
+`web|ios|android`; products, not platforms, are the axis for the developer
+split):
+
+| id | Covers |
+|---|---|
+| `studio` | Projects home, canvas + maps, detail panels/editors, changelog + History, Decision Log, import/export, the Explore sandbox |
+| `platform` | Synk hosted projects, auth, Publik publishing, /generate intake — the account-and-sharing layer |
+| `toolchain` | CLI (`arkaik init/log/release/pack/doctor`), `@arkaik/schema`, MCP server, plugin, arkaik-dev skill |
+
+Flows, views, and acceptances carry `metadata.product`; data models and API
+endpoints derive membership from consumers (validator rule
+`product-membership-wrong-species`).
+
+### Anatomy discipline
+
+- IDs per the skill reference: deterministic from title, species prefixes,
+  the concept-vs-physical-table `DM-` rule (`DM-project` vs `DM-projects`).
+- Every flow ships a real `metadata.playlist`; the validator enforces
+  playlist↔`composes` coherence and cycle-freedom.
+- Edges only from the legal semantics table (`composes`, `calls`,
+  `displays`, `queries`, `covers`, plus decision edges in PR B).
+- Data models cover concepts (Project, Node, Edge, JournalEvent,
+  MapDefinition, Product…) and physical stores (IndexedDB stores, Postgres
+  tables) as distinct nodes.
+
+### Acceptances + values
+
+Each acceptance: one Given/When/Then in `metadata.gherkin`; 1–3 Bain value
+elements in `metadata.values` (most specific element wins; higher tier only
+when genuinely earned — per `docs/arkaik-skill/references/values.md`);
+`covers` edges to its view/flow anchors; single-product anchoring (the
+validator warns on cross-product spans). Platform scoping stays trivial —
+everything is `@web`.
+
+### Curated maps
+
+3–5 `MapDefinition`s in `project.metadata.maps` so the project opens well:
+a journey map per product and a system map of the bundle/journal data
+layer. `project.root_node_id` moves to the studio's real home view.
+
+### Journal coupling
+
+The validator requires a `node.created` event for every snapshot node
+(`journal-missing-node-created`), so PR A ships a minimal journal: one
+`node.created` per node, timestamped from the PR corpus — the merge date of
+the PR that actually first shipped that surface, not today — preserving the
+existing 20 events. Status-transition history waits for PR B; the validator
+only cross-checks transitions that exist.
+
+## PR B — the story (history)
+
+### Thematic eras as releases
+
+8–12 `release.tagged` events, each an editorial chapter: kebab `version`
+slug + `notes` narrative paragraph. Working list (exact cut lines come from
+the corpus): `first-graph`, `journal-and-changelog`,
+`going-multi-product`, `acceptance-and-value`, `hosted-and-public`,
+`decisions-and-history`, `the-self-map`. An era's marker is dated just
+after the merge of its last deliverable. `project.version` ends at the
+latest era slug.
+
+### Curated deliverables
+
+~60–120 `deliverable.shipped` events — every user-visible PR. The filter is
+mostly mechanical: a PR with a Lab Note is user-visible by definition;
+pre-pipeline PRs get agent judgment. Per deliverable:
+
+- `deliverable_id`: `pr-<number>`
+- `title` / `summary`: adapted from the Lab Note where one exists
+  (benefit-first voice for free); written fresh otherwise
+- `url`: the PR; `node_ids`: the map nodes it touched
+- `ts`: real merge timestamp
+
+A deliverable belongs to an era by journal-slice position (the spec's
+grouping rule), so ordering is the grouping — the merge script sorts by
+`ts` and verifies each deliverable lands inside its intended era.
+
+### Decisions
+
+Grow from 3 to ~12–18 `DEC-` nodes mined from spec docs and program
+history — the standing decisions (two axes stay; migration philosophy;
+JSONL union-merge journal; in-memory seed provider; acceptance-first
+intake; `idea` stays a status; …). Each gets real `metadata.context` /
+`consequences` / `decided_at`, a truthful `decision_status` (mostly
+`enacted`), `generates`/`impacts`/`supersedes` edges, and matching `node.created` +
+`decision.status_changed` events (the journal coupling applies to PR B's
+new nodes too). Lifecycle status follows
+`lifecycleStatusForDecision`.
+
+### Status history
+
+Per anatomy node, 1–3 `node.status_changed` events telling an honest arc
+(e.g. created at its first PR, `live` when it shipped), with the final `to`
+equal to the snapshot status — enforced by `journal-status-mismatch`. This
+is what makes the Design panel's commitments and per-node timelines render.
+Default to the current status vocabulary; pre-v3 aliases only where
+authenticity demands (the validator accepts them).
+
+### Backlog texture and actors
+
+A handful of `idea.proposed` events for real deferred items (blocked
+indicator on StatusRing, milestones, pebbles retro-population…) so the
+backlog projection isn't empty. Events carry honest `actor` values
+(`alexis`, `claude-code`).
+
+## Execution machinery
+
+### Corpus (one-time, scratchpad-only)
+
+A script snapshots all merged PRs via `gh` into JSONL: number, title, body
+(Lab Note included), merge date, labels, changed-file paths — plus a docs
+manifest (specs, RFCs, program doc). Working material only; never
+committed.
+
+### Fragments
+
+Agents never touch the seed. Each emits a JSON fragment file into a scratch
+directory — `{nodes, edges}` shapes for waves 1–2,
+`{deliverables, releases, decisions, events}` for wave 3. Slugs are
+namespaced by area to preempt collisions; the merge script still verifies
+globally.
+
+### Merge scripts
+
+Deterministic scripts, kept in the session scratchpad — not committed, like
+the corpus (this is a content-only cycle; the repo's contract is the seed
+plus `validate:seeds`): assemble fragments → dedupe/verify IDs → resolve
+cross-area edge references → sort journal by `ts` → set `updated_at` →
+write the seed → print the file size. Every wave ends with
+`npm run validate:seeds` as a hard gate, and the flagship seed must be
+**warning-clean** (most acceptance/product rules are warnings; they get
+fixed, not ignored).
+
+### Waves
+
+1. **Anatomy** — ~8 area agents: projects home; canvas + maps; detail
+   panels; changelog/History/Decision Log; import/export + sandbox;
+   Publik + Synk + auth + /generate; toolchain + MCP + plugin + skill;
+   data layer. Each reads the real code and docs for its area.
+2. **Acceptances + values** — fan out per surface against the merged
+   anatomy (so every `covers` edge targets a real node), plus a
+   cross-cutting values-balance reviewer (the pyramid must not collapse
+   into 90% `simplifies`).
+3. **Story** — era agents over corpus slices, a decisions agent, then
+   chronological merge.
+
+Each wave gets an adversarial reviewer pass — checked against the product,
+not just the schema — before its content is accepted.
+
+### Size budget
+
+Seed target ≤ ~600KB raw (gzips well; pebbles is 183KB at 152 nodes). The
+merge script prints the size; exceeding the budget is a review flag, not a
+silent fact. No screenshots or data-URIs in cycle 5.
+
+## Delivery & review
+
+- **PR A**: waves 1–2 (map + minimal journal). **PR B**: wave 3 (story),
+  branched on A.
+- Both are user-visible (the Explore sandbox fills with real content) →
+  both carry Lab Notes.
+- Visual pass checklist for Alexis per PR: canvas legibility at ~200 nodes,
+  curated maps, product filter, changelog Design | Delivery panels, History
+  page density, Decision Log.
+- No prod migration; the seed is build-time imported, so content ships with
+  the deploy.
+
+## Testing
+
+`npm run validate:seeds` is the primary gate (it enforces the full contract:
+ID uniqueness, edge semantics, playlist coherence, journal cross-checks,
+value enum). No new app tests — content-only. If a validator or renderer
+bug is discovered, it becomes its own small PR, not a rider on A or B.
+
+## Out of scope
+
+- App code changes (content-only cycle).
+- Pebbles retro-population (pending separately).
+- French localization of seed content (the bundle schema has no locale
+  axis today).
+- New journal event types or schema changes — everything above fits the
+  shipped vocabulary.

--- a/seed/arkaik-self-map.json
+++ b/seed/arkaik-self-map.json
@@ -3,169 +3,343 @@
   "project": {
     "id": "arkaik-self-map",
     "title": "Arkaik (Self Map)",
-    "description": "Map of the /projects experience and local storage interactions.",
+    "description": "Arkaik mapped in Arkaik — the whole product as a living graph: every surface, the promises it makes, and the history of how it got here.",
     "root_node_id": "V-projects",
     "created_at": "2026-03-21T00:00:00.000Z",
-    "updated_at": "2026-03-21T00:00:00.000Z"
+    "updated_at": "2026-08-04T12:00:00.000Z",
+    "metadata": {
+      "maps": [
+        {
+          "id": "studio-journey",
+          "title": "Studio journey",
+          "description": "The core app, walked from the projects home: sections, canvas and maps, editing, and the PM surfaces.",
+          "kind": "journey",
+          "product": "studio",
+          "root_node_id": "V-projects"
+        },
+        {
+          "id": "platform-wiring",
+          "title": "Platform wiring",
+          "description": "The account-and-sharing layer — Publik, Synk, auth, tokens — wired to the routes and tables that serve it.",
+          "kind": "system",
+          "product": "platform"
+        },
+        {
+          "id": "data-spine",
+          "title": "Data spine",
+          "description": "Every API route and the models it reads and writes — the product's data backbone, products aside.",
+          "kind": "system",
+          "species": [
+            "api-endpoint",
+            "data-model"
+          ],
+          "edge_types": [
+            "queries",
+            "calls"
+          ]
+        },
+        {
+          "id": "promise-coverage",
+          "title": "Promise coverage",
+          "description": "The acceptance layer over the surfaces it covers — where Arkaik makes promises, and what they anchor to.",
+          "kind": "system",
+          "species": [
+            "acceptance",
+            "view",
+            "flow"
+          ],
+          "edge_types": [
+            "covers"
+          ],
+          "layout": {
+            "algorithm": "organic"
+          }
+        }
+      ],
+      "products": [
+        {
+          "id": "studio",
+          "title": "Studio",
+          "platforms": [
+            "web"
+          ]
+        },
+        {
+          "id": "platform",
+          "title": "Platform",
+          "platforms": [
+            "web"
+          ]
+        },
+        {
+          "id": "toolchain",
+          "title": "Toolchain",
+          "platforms": [
+            "web"
+          ]
+        }
+      ]
+    }
   },
   "nodes": [
     {
       "id": "V-projects",
-      "project_id": "arkaik-self-map",
       "species": "view",
       "title": "/projects",
-      "description": "Projects listing page and primary actions.",
+      "description": "The projects home: Hosted / Synked / Lokal sections with per-section create menus, project cards, the Explore public self-map, empty states, and the generated-JSON import prompt.",
       "status": "live",
-      "platforms": ["web"]
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio"
+      },
+      "project_id": "arkaik-self-map"
     },
     {
       "id": "F-projects-routing",
-      "project_id": "arkaik-self-map",
       "species": "flow",
       "title": "Projects Actions Routing",
-      "description": "Branch behavior depending on whether projects already exist.",
-      "status": "development",
-      "platforms": ["web"],
+      "description": "Routes every way into a project from the /projects home — create, import JSON, load an example, or move a browser project into the account — with the signed-in state deciding which sections and targets are on offer.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
       "metadata": {
+        "product": "studio",
         "playlist": {
           "entries": [
             {
               "type": "condition",
-              "label": "There are existing projects?",
+              "label": "Signed in?",
               "if_true": [
                 {
-                  "type": "flow",
-                  "flow_id": "F-import-json"
-                },
-                {
-                  "type": "flow",
-                  "flow_id": "F-create-project"
-                },
-                {
-                  "type": "flow",
-                  "flow_id": "F-delete-project"
+                  "type": "junction",
+                  "label": "Which way in?",
+                  "cases": [
+                    {
+                      "label": "Create in a section (Hosted / Synked / Lokal)",
+                      "entries": [
+                        {
+                          "type": "flow",
+                          "flow_id": "F-create-project"
+                        }
+                      ]
+                    },
+                    {
+                      "label": "Import a JSON bundle",
+                      "entries": [
+                        {
+                          "type": "flow",
+                          "flow_id": "F-import-json"
+                        }
+                      ]
+                    },
+                    {
+                      "label": "Load an example project",
+                      "entries": [
+                        {
+                          "type": "flow",
+                          "flow_id": "F-import-example-projects"
+                        }
+                      ]
+                    },
+                    {
+                      "label": "Move a browser project into the account",
+                      "entries": [
+                        {
+                          "type": "flow",
+                          "flow_id": "F-move-to-account"
+                        }
+                      ]
+                    }
+                  ]
                 }
               ],
               "if_false": [
                 {
-                  "type": "flow",
-                  "flow_id": "F-import-example-projects"
-                },
-                {
-                  "type": "flow",
-                  "flow_id": "F-import-json"
-                },
-                {
-                  "type": "flow",
-                  "flow_id": "F-create-project"
+                  "type": "junction",
+                  "label": "Which way in?",
+                  "cases": [
+                    {
+                      "label": "Create a Lokal project",
+                      "entries": [
+                        {
+                          "type": "flow",
+                          "flow_id": "F-create-project"
+                        }
+                      ]
+                    },
+                    {
+                      "label": "Import a JSON bundle",
+                      "entries": [
+                        {
+                          "type": "flow",
+                          "flow_id": "F-import-json"
+                        }
+                      ]
+                    },
+                    {
+                      "label": "Load an example project",
+                      "entries": [
+                        {
+                          "type": "flow",
+                          "flow_id": "F-import-example-projects"
+                        }
+                      ]
+                    }
+                  ]
                 }
               ]
             }
           ]
         }
-      }
+      },
+      "project_id": "arkaik-self-map"
     },
     {
       "id": "F-import-json",
-      "project_id": "arkaik-self-map",
       "species": "flow",
-      "title": "Import JSON",
-      "description": "Import user-provided project JSON file.",
+      "title": "Import Project JSON",
+      "description": "Bring a project bundle in from a JSON file on the projects page — parsed, schema-migrated, validated with readable path-level errors, and landed locally under a collision-free id that can never squat the hosted or seed namespaces.",
       "status": "live",
-      "platforms": ["web"],
+      "platforms": [
+        "web"
+      ],
       "metadata": {
-        "playlist": { "entries": [] }
-      }
+        "product": "studio",
+        "playlist": {
+          "entries": [
+            {
+              "type": "view",
+              "view_id": "V-projects"
+            },
+            {
+              "type": "condition",
+              "label": "Bundle passes parse, migration, and validation?",
+              "if_true": [],
+              "if_false": []
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
     },
     {
       "id": "F-create-project",
-      "project_id": "arkaik-self-map",
       "species": "flow",
       "title": "Create Project",
-      "description": "Create a new empty project.",
+      "description": "Create a new empty project in a chosen section: Hosted goes straight to the account, Synked saves locally then backs up immediately, Lokal stays in this browser.",
       "status": "live",
-      "platforms": ["web"],
+      "platforms": [
+        "web"
+      ],
       "metadata": {
-        "playlist": { "entries": [] }
-      }
+        "product": "studio",
+        "playlist": {
+          "entries": [
+            {
+              "type": "view",
+              "view_id": "V-create-project-dialog"
+            },
+            {
+              "type": "junction",
+              "label": "Where does it land?",
+              "cases": [
+                {
+                  "label": "Hosted — in the account",
+                  "entries": []
+                },
+                {
+                  "label": "Synked — local, backed up now",
+                  "entries": []
+                },
+                {
+                  "label": "Lokal — this browser only",
+                  "entries": []
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
     },
     {
       "id": "F-delete-project",
-      "project_id": "arkaik-self-map",
       "species": "flow",
       "title": "Delete Project",
-      "description": "Archive a selected project from the list.",
+      "description": "Delete a project from its Settings danger zone — confirm by typing the title, then land back on the projects home.",
       "status": "live",
-      "platforms": ["web"],
+      "platforms": [
+        "web"
+      ],
       "metadata": {
-        "playlist": { "entries": [] }
-      }
+        "product": "studio",
+        "playlist": {
+          "entries": [
+            {
+              "type": "view",
+              "view_id": "V-project-settings"
+            },
+            {
+              "type": "condition",
+              "label": "Deletion confirmed?",
+              "if_true": [
+                {
+                  "type": "view",
+                  "view_id": "V-projects"
+                }
+              ],
+              "if_false": []
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
     },
     {
       "id": "F-import-example-projects",
-      "project_id": "arkaik-self-map",
       "species": "flow",
       "title": "Import Example Projects",
-      "description": "Import built-in example seed when no projects exist.",
+      "description": "Load a bundled example (Pebbles or Arkaik's own self-map) into this browser as a Lokal project, offered where the Lokal section or the signed-out page is empty.",
       "status": "live",
-      "platforms": ["web"],
+      "platforms": [
+        "web"
+      ],
       "metadata": {
-        "playlist": { "entries": [] }
-      }
-    },
-    {
-      "id": "API-local-list-projects",
-      "project_id": "arkaik-self-map",
-      "species": "api-endpoint",
-      "title": "localProvider.listProjects()",
-      "description": "Read non-archived projects from local storage.",
-      "status": "live",
-      "platforms": ["web"]
-    },
-    {
-      "id": "API-local-save-project",
-      "project_id": "arkaik-self-map",
-      "species": "api-endpoint",
-      "title": "localProvider.saveProject()",
-      "description": "Persist newly created project bundle.",
-      "status": "live",
-      "platforms": ["web"]
-    },
-    {
-      "id": "API-local-archive-project",
-      "project_id": "arkaik-self-map",
-      "species": "api-endpoint",
-      "title": "localProvider.archiveProject()",
-      "description": "Soft-delete project by setting archived_at.",
-      "status": "live",
-      "platforms": ["web"]
-    },
-    {
-      "id": "API-local-import-project",
-      "project_id": "arkaik-self-map",
-      "species": "api-endpoint",
-      "title": "localProvider.importProject()",
-      "description": "Import parsed bundle (JSON or example seed).",
-      "status": "live",
-      "platforms": ["web"]
-    },
-    {
-      "id": "DM-local-storage-store",
-      "project_id": "arkaik-self-map",
-      "species": "data-model",
-      "title": "LocalStorage Store",
-      "description": "Browser localStorage key arkaik:store.",
-      "status": "live",
-      "platforms": ["web"]
+        "product": "studio",
+        "playlist": {
+          "entries": [
+            {
+              "type": "junction",
+              "label": "Which example?",
+              "cases": [
+                {
+                  "label": "Pebbles",
+                  "entries": []
+                },
+                {
+                  "label": "Arkaik self-map",
+                  "entries": []
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
     },
     {
       "id": "DM-project-bundle",
-      "project_id": "arkaik-self-map",
       "species": "data-model",
       "title": "ProjectBundle",
-      "description": "project + nodes + edges payload persisted in store.",
+      "description": "The canonical, schema-versioned interchange document defined in @arkaik/schema: one project plus its nodes, edges, and an optional embedded journal, parsed and validated on every import and write.",
       "status": "live",
-      "platforms": ["web"]
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
     },
     {
       "id": "DEC-two-axes-stay",
@@ -211,6 +385,3482 @@
         "consequences": "A one-time, version-gated remap runs on any bundle below schema_version 3 and stamps the new version; the retired ids `prioritized` and `blocked` are accepted as permanent parse-time aliases from then on; journal history is never rewritten, so historical events keep their original vocabulary.",
         "decided_at": "2026-08-03"
       }
+    },
+    {
+      "id": "DM-project",
+      "species": "data-model",
+      "title": "Project",
+      "description": "The root identity of a bundle: id, title, optional version label, root_node_id, and metadata carrying maps, map display overrides, and product definitions.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DM-node",
+      "species": "data-model",
+      "title": "Node",
+      "description": "The atomic graph unit: one of six species (flow, view, data-model, api-endpoint, acceptance, decision) with a title, lifecycle status, platforms, and species-specific metadata.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DM-edge",
+      "species": "data-model",
+      "title": "Edge",
+      "description": "A typed directed relationship between two nodes — composes, calls, displays, queries, covers, supersedes, generates, or impacts — validated against per-type source/target rules.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DM-journal-event",
+      "species": "data-model",
+      "title": "JournalEvent",
+      "description": "A ULID-identified, append-only history event (node.created, node.status_changed, release.tagged, deliverable.shipped, ...) with timestamp and actor; history only ever grows.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DM-map-definition",
+      "species": "data-model",
+      "title": "MapDefinition",
+      "description": "A saved map stored in project.metadata.maps: kind (journey or system), species and edge-type filters, root anchor, product scope, layout hints, and card display options.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DM-product",
+      "species": "data-model",
+      "title": "Product",
+      "description": "A ProductDefinition in project.metadata.products that scopes flows, views, and acceptances into one product; membership for other species is derived by traversal.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DM-deliverable",
+      "species": "data-model",
+      "title": "Deliverable",
+      "description": "A projection computed from deliverable.shipped journal events: one unit of shipped work (typically a merged PR) with a summary, URL, and touched node ids, sitting between events and releases.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DM-projects",
+      "species": "data-model",
+      "title": "projects",
+      "description": "IndexedDB (Dexie) store with one row per local project, keyed by project id, holding the journal-less BundleSnapshot so a mutation rewrites only that project's row.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DM-journals",
+      "species": "data-model",
+      "title": "journals",
+      "description": "IndexedDB (Dexie) store with one row per project holding its embedded journal events; appends grow this row without ever re-serializing the graph snapshot.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DM-meta",
+      "species": "data-model",
+      "title": "meta",
+      "description": "Small IndexedDB key/value store for local-provider bookkeeping — currently just the one-time legacy localStorage migration flag.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DM-publik-snapshots",
+      "species": "data-model",
+      "title": "publik_snapshots",
+      "description": "Postgres table of immutable anonymous shares: the journal-stripped, schema-validated bundle as jsonb plus an owner-key hash, size, and report count; re-publishing creates a new id.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DM-publik-rate-limits",
+      "species": "data-model",
+      "title": "publik_rate_limits",
+      "description": "Postgres table of append-only throttle rows keyed by HMAC-hashed IP and action, counted over a sliding 1-hour window and pruned opportunistically — rate limiting with no Redis.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DM-users",
+      "species": "data-model",
+      "title": "users",
+      "description": "Auth.js adapter table of signed-in users, extended by arkaik with a tier column that selects the row in the TIER_LIMITS enforcement table.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DM-accounts",
+      "species": "data-model",
+      "title": "accounts",
+      "description": "Auth.js adapter table linking OAuth provider identities (GitHub at launch) to users, holding the provider's token response per linked account.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DM-sessions",
+      "species": "data-model",
+      "title": "sessions",
+      "description": "Auth.js adapter table for database sessions; unused on the request path because the session strategy is JWT, but created for adapter-schema completeness.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DM-verification-token",
+      "species": "data-model",
+      "title": "verification_token",
+      "description": "Auth.js adapter table for email magic-link verification tokens; the email provider is deferred, so the table exists for adapter-contract completeness.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DM-synk-projects",
+      "species": "data-model",
+      "title": "synk_projects",
+      "description": "Postgres table with one row per backed-up local project, keyed by the composite (user_id, client project id) so two users can back up projects that share an id.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DM-synk-backups",
+      "species": "data-model",
+      "title": "synk_backups",
+      "description": "Postgres table of retained backup versions: the full bundle with journal as jsonb plus a server-computed sha256 for content-hash dedupe, pruned by retention per tier.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DM-owners",
+      "species": "data-model",
+      "title": "owners",
+      "description": "Postgres table for the tenancy seam every hosted resource hangs off: today one derived personal owner per user (own-u<id>), forward-compatible with org owners.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DM-owner-members",
+      "species": "data-model",
+      "title": "owner_members",
+      "description": "Postgres membership table joining users to owners with a role; getCaller resolves a caller's owner ids through it on every authenticated request.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DM-api-tokens",
+      "species": "data-model",
+      "title": "api_tokens",
+      "description": "Postgres table of machine credentials (ark_<prefix>_<secret>): a clear unique prefix for one-read lookup, a sha256 hash of the secret, scoped permissions, and revocation/expiry timestamps.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DM-graph-projects",
+      "species": "data-model",
+      "title": "graph_projects",
+      "description": "Postgres table of hosted product graphs: an owner-scoped jsonb snapshot (project + nodes + edges, no journal) with an optimistic-concurrency version bumped on every accepted mutation.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DM-graph-events",
+      "species": "data-model",
+      "title": "graph_events",
+      "description": "Postgres append-only journal for hosted projects, keyed (project_id, event ULID) with a bigserial seq as the authoritative ordering — the server twin of the IndexedDB journals store.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DM-project-repos",
+      "species": "data-model",
+      "title": "project_repos",
+      "description": "Postgres table linking hosted projects to the GitHub repositories that implement them, with an optional platform and a path_prefix so one monorepo can scope different subtrees to different platforms.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DM-github-deliveries",
+      "species": "data-model",
+      "title": "github_deliveries",
+      "description": "Postgres webhook-delivery ledger: claiming a delivery id before applying it makes GitHub retries and manual redelivers idempotent, and rows older than a day are pruned on write.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "API-auth-nextauth",
+      "species": "api-endpoint",
+      "title": "GET/POST /api/auth/*",
+      "description": "Auth.js catch-all route handling sign-in, the GitHub OAuth callback, and session reads; its adapter writes users and linked accounts on sign-in.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "API-get-auth-status",
+      "species": "api-endpoint",
+      "title": "GET /api/auth/status",
+      "description": "Client-facing auth status: returns whether auth is configured plus the signed-in user's public profile from the JWT session, never touching the database.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "API-post-github-webhook",
+      "species": "api-endpoint",
+      "title": "POST /api/github/webhook",
+      "description": "The one endpoint accepting signed third-party requests: verifies the GitHub App HMAC over raw bytes, claims the delivery id for replay protection, then applies pull-request transitions to linked hosted projects.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "API-github",
+      "species": "api-endpoint",
+      "title": "GitHub API",
+      "description": "Third-party surface arkaik calls back into: the OAuth token exchange during sign-in, and the App-authenticated pulls/{number}/files read that path-scoped monorepo links need.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "API-graph-projects",
+      "species": "api-endpoint",
+      "title": "GET/POST /api/graph/projects",
+      "description": "Lists the caller's hosted graph projects and creates new ones from a validated bundle, enforcing the tier's project cap and seeding the event log.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "API-graph-project",
+      "species": "api-endpoint",
+      "title": "GET/PATCH/DELETE /api/graph/projects/{id}",
+      "description": "Reads one hosted project's snapshot, updates its project-level fields (journaling the change), or archives it — always scoped to the caller's owners.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "API-get-graph-project-nodes",
+      "species": "api-endpoint",
+      "title": "GET /api/graph/projects/{id}/nodes",
+      "description": "Read-only listing of a hosted project's nodes out of the stored snapshot, behind the shared graph:read guard chain.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "API-get-graph-project-edges",
+      "species": "api-endpoint",
+      "title": "GET /api/graph/projects/{id}/edges",
+      "description": "Read-only listing of a hosted project's edges out of the stored snapshot, behind the shared graph:read guard chain.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "API-get-graph-project-journal",
+      "species": "api-endpoint",
+      "title": "GET /api/graph/projects/{id}/journal",
+      "description": "Returns a hosted project's append-only journal in server seq order from the graph_events table.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "API-get-graph-project-export",
+      "species": "api-endpoint",
+      "title": "GET /api/graph/projects/{id}/export",
+      "description": "Assembles and returns the full ProjectBundle — snapshot plus journal — for download or migration back to local-first storage.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "API-post-graph-project-mutations",
+      "species": "api-endpoint",
+      "title": "POST /api/graph/projects/{id}/mutations",
+      "description": "The single write path for hosted graphs: applies validated mutation ops to the snapshot, bumps the concurrency version, and appends the emitted journal events atomically.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "API-graph-project-repos",
+      "species": "api-endpoint",
+      "title": "GET/POST/DELETE /api/graph/projects/{id}/repos",
+      "description": "Manages a hosted project's repository links — repo, optional platform, optional monorepo path prefix — after checking the project belongs to the caller.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "API-post-publik",
+      "species": "api-endpoint",
+      "title": "POST /api/publik",
+      "description": "Publishes an anonymous, immutable snapshot: strips the journal, validates the bundle, stores it under a fresh id, and returns a one-time owner key — rate-limited per hashed IP.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "API-publik-snapshot",
+      "species": "api-endpoint",
+      "title": "GET/DELETE /api/publik/{id}",
+      "description": "Serves a shared snapshot's bundle to anyone with the link, and deletes it for a caller presenting the matching owner key (verified against its stored hash).",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "API-post-publik-report",
+      "species": "api-endpoint",
+      "title": "POST /api/publik/{id}/report",
+      "description": "Flags a shared snapshot by incrementing its report count, rate-limited per hashed IP like snapshot creation.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "API-get-synk-projects",
+      "species": "api-endpoint",
+      "title": "GET /api/synk/projects",
+      "description": "Lists the signed-in user's backed-up projects with their latest backup info, read from the user-scoped Synk tables.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "API-synk-project",
+      "species": "api-endpoint",
+      "title": "PUT/DELETE /api/synk/projects/{id}",
+      "description": "Uploads a backup version of a local project — validated, sha256-deduped, journal included, tier limits enforced — or deletes the project and cascades away all its backups.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "API-get-synk-project-backups",
+      "species": "api-endpoint",
+      "title": "GET /api/synk/projects/{id}/backups",
+      "description": "Lists the retained backup versions of one of the user's projects, newest first, without re-parsing the stored bundles.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "API-get-synk-backup",
+      "species": "api-endpoint",
+      "title": "GET /api/synk/backups/{id}",
+      "description": "Downloads one backup's full bundle (journal intact) for restore, scoped to the session user's own rows.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "API-get-synk-ping",
+      "species": "api-endpoint",
+      "title": "GET /api/synk/ping",
+      "description": "Minimal session-guarded probe — 401 without a session, otherwise ok plus the user — the template every authenticated service handler copies.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "API-tokens",
+      "species": "api-endpoint",
+      "title": "GET/POST /api/tokens",
+      "description": "Session-only token management: lists an owner's API tokens and mints new scoped ones, returning the plaintext secret exactly once — a bearer token can never mint another token.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "API-delete-token",
+      "species": "api-endpoint",
+      "title": "DELETE /api/tokens/{id}",
+      "description": "Revokes an API token by stamping revoked_at, after verifying the session user belongs to the token's owner.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "V-create-project-dialog",
+      "species": "view",
+      "title": "Create Project Dialog",
+      "description": "Modal form capturing a title and optional description for a new empty project, destined for whichever section opened it.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio"
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "V-maps-index",
+      "species": "view",
+      "title": "Maps Index",
+      "description": "Card grid of every reading the project offers — the built-in Journey and System maps plus custom maps stored in project metadata, each counted through its own renderer, with edit/delete on custom cards and a New map action.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio"
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "V-journey-map",
+      "species": "view",
+      "title": "Journey Map Canvas",
+      "description": "The navigation-centered React Flow canvas: compose/playlist drill-down from the root with collapsible flows, visual duplication of reused views, full inline editing, a status/species minimap, and product-scoped empty states; the old /canvas URL redirects here.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio"
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "V-system-map",
+      "species": "view",
+      "title": "System Map Canvas",
+      "description": "The model-centered canvas joining views, API endpoints, and data models by cross-layer edges, with an organic/tiered layout switch, a hover-and-pin neighborhood spotlight that dims everything outside one node's relations, and the same minimap.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio"
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "V-map-editor-dialog",
+      "species": "view",
+      "title": "Map Editor Dialog",
+      "description": "Dialog for authoring a custom map definition — id, title, kind, species and edge filters, root anchor picked from the project's nodes, product scope, depth, and layout hints.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio"
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "V-map-display-popover",
+      "species": "view",
+      "title": "Map Display Popover",
+      "description": "Per-map Display button: toggle screenshot images on view cards, flow platform delivery as rings or bars, view platform availability as chips or rows, and whether minimap fills encode status or species — saved for this map alone.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio"
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "V-command-palette",
+      "species": "view",
+      "title": "Command Palette",
+      "description": "The Cmd+K overlay: type-ahead over pages, maps, library sections, and in-place actions, with ranked matching, keyword synonyms, Tab completion, and Enter to navigate or run.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio"
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "V-keyboard-shortcuts-dialog",
+      "species": "view",
+      "title": "Keyboard Shortcuts Dialog",
+      "description": "The Cmd+? reference dialog listing every chord the app answers to, grouped by scope, with the Mod key rendered as the running platform's own label.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio"
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "F-browse-maps",
+      "species": "flow",
+      "title": "Browse Maps",
+      "description": "Open the maps index, pick a reading, and land on its renderer — Journey for the navigation drill-down, System for the model-centered picture, custom maps through whichever kind they declare.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "playlist": {
+          "entries": [
+            {
+              "type": "view",
+              "view_id": "V-maps-index"
+            },
+            {
+              "type": "junction",
+              "label": "Which kind of map?",
+              "cases": [
+                {
+                  "label": "Journey",
+                  "entries": [
+                    {
+                      "type": "view",
+                      "view_id": "V-journey-map"
+                    }
+                  ]
+                },
+                {
+                  "label": "System",
+                  "entries": [
+                    {
+                      "type": "view",
+                      "view_id": "V-system-map"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "F-create-custom-map",
+      "species": "flow",
+      "title": "Create Custom Map",
+      "description": "Save a new reading of the graph from the maps index: open the editor dialog, name the map, choose kind, filters, anchor and scope, and the definition lands in project metadata as data an agent could equally have written.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "playlist": {
+          "entries": [
+            {
+              "type": "view",
+              "view_id": "V-maps-index"
+            },
+            {
+              "type": "view",
+              "view_id": "V-map-editor-dialog"
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "F-adjust-map-display",
+      "species": "flow",
+      "title": "Adjust Map Display",
+      "description": "Tune how one map's cards read — images on or off, rings or bars, chips or rows, minimap color by status or species — from the Display popover on the open renderer, without touching any other map.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "playlist": {
+          "entries": [
+            {
+              "type": "junction",
+              "label": "Which renderer is open?",
+              "cases": [
+                {
+                  "label": "Journey",
+                  "entries": [
+                    {
+                      "type": "view",
+                      "view_id": "V-journey-map"
+                    }
+                  ]
+                },
+                {
+                  "label": "System",
+                  "entries": [
+                    {
+                      "type": "view",
+                      "view_id": "V-system-map"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "view",
+              "view_id": "V-map-display-popover"
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "F-edit-graph-on-canvas",
+      "species": "flow",
+      "title": "Edit Graph On Canvas",
+      "description": "Grow the graph where it is drawn: add nodes, insert views between playlist steps, connect-to-create edges with a type prompt, and delete nodes or edges with confirmation, on either map canvas.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "playlist": {
+          "entries": [
+            {
+              "type": "junction",
+              "label": "Which map is open?",
+              "cases": [
+                {
+                  "label": "Journey",
+                  "entries": [
+                    {
+                      "type": "view",
+                      "view_id": "V-journey-map"
+                    }
+                  ]
+                },
+                {
+                  "label": "System",
+                  "entries": [
+                    {
+                      "type": "view",
+                      "view_id": "V-system-map"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "F-navigate-by-keyboard",
+      "species": "flow",
+      "title": "Navigate By Keyboard",
+      "description": "Reach anything without the mouse: Cmd+K opens the palette to jump to a page, map, or action, and Cmd+? opens the shortcuts dialog to learn every chord the app answers to.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "playlist": {
+          "entries": [
+            {
+              "type": "junction",
+              "label": "What do you need?",
+              "cases": [
+                {
+                  "label": "Jump somewhere or run a command",
+                  "entries": [
+                    {
+                      "type": "view",
+                      "view_id": "V-command-palette"
+                    }
+                  ]
+                },
+                {
+                  "label": "Learn the shortcuts",
+                  "entries": [
+                    {
+                      "type": "view",
+                      "view_id": "V-keyboard-shortcuts-dialog"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "V-node-detail-panel",
+      "species": "view",
+      "title": "Node Detail Panel",
+      "description": "A column in the push-panel stack showing one node's editable fields (title, description, status, blocked-by, product), refs, platform variants with screenshots, species-specific editors, connections, invocation, and journal history.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio"
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "V-raw-bundle-panel",
+      "species": "view",
+      "title": "Raw Bundle Panel",
+      "description": "A panel-stack column that views the whole project bundle as JSON or YAML and, in guarded edit mode, saves changes back through the validated import path — which for the public sandbox replaces its in-memory state in place.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio"
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "V-library",
+      "species": "view",
+      "title": "Library",
+      "description": "The all-nodes inventory with gallery and directory display modes, species/search/blocked filters, product-scoped visibility, and a selection bar for bulk-moving nodes between products.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio"
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "V-overview",
+      "species": "view",
+      "title": "Overview",
+      "description": "The deliberately read-only 'where does this product stand?' dashboard composing platform gauges, parity, pyramid, delivery snapshot, release pulse, backlog, inventory, health, and maps cards.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio"
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "V-pyramid",
+      "species": "view",
+      "title": "Value Pyramid",
+      "description": "The value-delivery radar: each value element carries status rings per platform, with a three-step filter and a switch between icon-led cards and one-line rows.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio"
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "V-acceptances-matrix",
+      "species": "view",
+      "title": "Acceptances Matrix",
+      "description": "The coverage matrix grouping acceptances by their covered anchors, with per-platform status columns, parity-gap highlighting, value badges, and a filter bar over status, value, anchor, and search.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio"
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "F-edit-node-details",
+      "species": "flow",
+      "title": "Edit Node Details",
+      "description": "Open any node in the panel stack, autosave title, description, status, blocked-by and product membership inline, and drill into connected nodes by stacking further panels.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "playlist": {
+          "entries": [
+            {
+              "type": "view",
+              "view_id": "V-node-detail-panel"
+            },
+            {
+              "type": "condition",
+              "label": "Editing a flow?",
+              "if_true": [
+                {
+                  "type": "flow",
+                  "flow_id": "F-edit-flow-playlist"
+                }
+              ],
+              "if_false": []
+            },
+            {
+              "type": "condition",
+              "label": "Editing an acceptance?",
+              "if_true": [
+                {
+                  "type": "flow",
+                  "flow_id": "F-edit-acceptance"
+                }
+              ],
+              "if_false": []
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "F-edit-flow-playlist",
+      "species": "flow",
+      "title": "Edit Flow Playlist",
+      "description": "Arrange a flow's ordered playlist in its detail panel — add views, sub-flows, conditions and junctions, create missing steps inline, and get cycle-blocked before a circular reference lands.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "playlist": {
+          "entries": [
+            {
+              "type": "view",
+              "view_id": "V-node-detail-panel"
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "F-edit-acceptance",
+      "species": "flow",
+      "title": "Edit Acceptance",
+      "description": "Refine an acceptance in its detail panel: write the Gherkin scenario, pick the value elements it serves, set per-platform statuses, attach or detach cover anchors, and split it in two.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "playlist": {
+          "entries": [
+            {
+              "type": "view",
+              "view_id": "V-node-detail-panel"
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "F-browse-library",
+      "species": "flow",
+      "title": "Browse Library",
+      "description": "Sweep the whole node inventory — filter by species, search, or blocked state, create new nodes, bulk-move a selection between products, and open any node for detail editing.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "playlist": {
+          "entries": [
+            {
+              "type": "view",
+              "view_id": "V-library"
+            },
+            {
+              "type": "condition",
+              "label": "Open a node?",
+              "if_true": [
+                {
+                  "type": "flow",
+                  "flow_id": "F-edit-node-details"
+                }
+              ],
+              "if_false": []
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "F-audit-value-coverage",
+      "species": "flow",
+      "title": "Audit Value Coverage",
+      "description": "Read the Overview, drill into the Value Pyramid, click an element through to its filtered acceptances in the matrix, and refine the ones that fall short.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "playlist": {
+          "entries": [
+            {
+              "type": "view",
+              "view_id": "V-overview"
+            },
+            {
+              "type": "view",
+              "view_id": "V-pyramid"
+            },
+            {
+              "type": "view",
+              "view_id": "V-acceptances-matrix"
+            },
+            {
+              "type": "condition",
+              "label": "Refine an acceptance?",
+              "if_true": [
+                {
+                  "type": "flow",
+                  "flow_id": "F-edit-acceptance"
+                }
+              ],
+              "if_false": []
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "F-edit-raw-bundle",
+      "species": "flow",
+      "title": "Edit Raw Bundle",
+      "description": "Open the project's raw bundle as JSON or YAML, edit it directly under an unsaved-changes guard, and save back only what the bundle validator accepts.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "playlist": {
+          "entries": [
+            {
+              "type": "view",
+              "view_id": "V-raw-bundle-panel"
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "V-changelog",
+      "species": "view",
+      "title": "Changelog",
+      "description": "Two-panel project changelog: a Design funnel (backlog, commitments, decision activity) beside a Delivery panel of unreleased deliverables and release cards grouped by tagged version.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio"
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "V-history",
+      "species": "view",
+      "title": "History",
+      "description": "Granular newest-first feed of every journal event, filterable by family chips (nodes, edges, decisions, delivery, ideas & requests, references).",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio"
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "V-decision-log",
+      "species": "view",
+      "title": "Decision Log",
+      "description": "ADR-style list of the project's decision nodes ordered by decided date, filterable by decision status, with a dialog to log a new decision.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio"
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "V-decision-editor",
+      "species": "view",
+      "title": "Decision Editor",
+      "description": "Detail panel for one decision: autosaving context, consequences, and decided-at fields plus a decision-status select that keeps the lifecycle status in sync.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio"
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "V-delivery-board",
+      "species": "view",
+      "title": "Delivery Board",
+      "description": "Kanban of nodes as per-platform delivery items in lifecycle-status columns, with platform, species, status-preset, and search filters and node creation.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio"
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "F-review-changelog",
+      "species": "flow",
+      "title": "Review Changelog",
+      "description": "Scan what the project has shipped and committed to — releases, deliverables, backlog, and decision activity — and jump into a decision straight from the feed.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "playlist": {
+          "entries": [
+            {
+              "type": "view",
+              "view_id": "V-changelog"
+            },
+            {
+              "type": "condition",
+              "label": "Open a decision from the feed?",
+              "if_true": [
+                {
+                  "type": "view",
+                  "view_id": "V-decision-editor"
+                }
+              ],
+              "if_false": []
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "F-audit-history",
+      "species": "flow",
+      "title": "Audit Project History",
+      "description": "Trace exactly what happened and when by browsing the full journal event feed and narrowing it to one event family.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "playlist": {
+          "entries": [
+            {
+              "type": "view",
+              "view_id": "V-history"
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "F-log-decision",
+      "species": "flow",
+      "title": "Log a Decision",
+      "description": "Record a product decision from the Decision Log — name the What, then fill in context, consequences, status, and decided date in its editor.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "playlist": {
+          "entries": [
+            {
+              "type": "view",
+              "view_id": "V-decision-log"
+            },
+            {
+              "type": "view",
+              "view_id": "V-decision-editor"
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "F-track-delivery",
+      "species": "flow",
+      "title": "Track Delivery Status",
+      "description": "Follow work across the lifecycle on the delivery board, filtering by platform, species, or search to find and update the items that matter.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "playlist": {
+          "entries": [
+            {
+              "type": "view",
+              "view_id": "V-delivery-board"
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "V-publik-snapshot",
+      "species": "view",
+      "title": "Public Snapshot Page",
+      "description": "The /p/{id} preview page for a shared Publik snapshot — title, node/edge counts, format-level badge, no-retention disclaimer, and an Import into arkaik action.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "platform"
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "V-publik-publish-dialog",
+      "species": "view",
+      "title": "Publish Dialog",
+      "description": "Two-stage confirm/result dialog that publishes a project to Publik and shows the share URL and one-time owner key, surfacing validation findings, rate limits, and size errors.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "platform"
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "V-synk-onboarding-banner",
+      "species": "view",
+      "title": "Synk Onboarding Banner",
+      "description": "Dismissible banner on the projects page offering one-click Synk backup for each browser-held project after sign-in — the Lokal-to-Synk conversion funnel.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "platform"
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "V-synk-restore-dialog",
+      "species": "view",
+      "title": "Synk Restore Dialog",
+      "description": "Dialog that lists the account's Synk projects and their backups, and restores a chosen backup's bundle into this browser.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "platform"
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "V-account-menu",
+      "species": "view",
+      "title": "Account Menu",
+      "description": "Sign-in button / account dropdown in the app chrome — GitHub sign-in, profile, a link to agent tokens, and sign-out; renders nothing when auth is unconfigured.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "platform"
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "V-agent-tokens",
+      "species": "view",
+      "title": "Agent Tokens Settings",
+      "description": "The /settings/tokens page where the user creates (shown once, stored hashed) and revokes tokens that let the arkaik CLI and MCP server act as them.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "platform"
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "V-generate-prompt",
+      "species": "view",
+      "title": "Generate With AI",
+      "description": "The /generate prompt builder — pick a mode (from pitch, from plan, extend map), configure the project, and copy an assembled LLM prompt that yields an importable bundle.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "platform"
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "F-publish-to-publik",
+      "species": "flow",
+      "title": "Publish to Publik",
+      "description": "Share a project anonymously: confirm what becomes public, publish the bundle (journal stripped server-side), save the one-time owner key, and open the unlisted snapshot page.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "platform",
+        "playlist": {
+          "entries": [
+            {
+              "type": "view",
+              "view_id": "V-publik-publish-dialog"
+            },
+            {
+              "type": "condition",
+              "label": "Open the share link?",
+              "if_true": [
+                {
+                  "type": "view",
+                  "view_id": "V-publik-snapshot"
+                }
+              ],
+              "if_false": []
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "F-sign-in",
+      "species": "flow",
+      "title": "Sign In with GitHub",
+      "description": "Authenticate via the GitHub OAuth dance from the account menu; signing in changes nothing but this button — no local feature is account-gated.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "platform",
+        "playlist": {
+          "entries": [
+            {
+              "type": "view",
+              "view_id": "V-account-menu"
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "F-synk-backup-restore",
+      "species": "flow",
+      "title": "Back Up with Synk",
+      "description": "Keep browser-held projects backed up to the account: accept the onboarding offer (or use per-project Back up now), then restore a backup into any browser later.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "platform",
+        "playlist": {
+          "entries": [
+            {
+              "type": "junction",
+              "label": "Back up or restore?",
+              "cases": [
+                {
+                  "label": "Back up",
+                  "entries": [
+                    {
+                      "type": "view",
+                      "view_id": "V-synk-onboarding-banner"
+                    }
+                  ]
+                },
+                {
+                  "label": "Restore",
+                  "entries": [
+                    {
+                      "type": "view",
+                      "view_id": "V-synk-restore-dialog"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "F-move-to-account",
+      "species": "flow",
+      "title": "Move Project to Account",
+      "description": "Promote a browser-held project to a hosted one from its card (shown only when signed in): the bundle is copied to the server under a new prj_ id, the local original stays, and the agent plane opens up.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "platform",
+        "playlist": {
+          "entries": [
+            {
+              "type": "view",
+              "view_id": "V-projects"
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "F-generate-with-ai",
+      "species": "flow",
+      "title": "Generate Map with AI",
+      "description": "Acceptance-first intake for a new map: build a tailored LLM prompt from an idea or plan, run it elsewhere, then hand off to import with the intended destination preserved.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "platform",
+        "playlist": {
+          "entries": [
+            {
+              "type": "view",
+              "view_id": "V-generate-prompt"
+            },
+            {
+              "type": "flow",
+              "flow_id": "F-import-json"
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "F-export-bundle",
+      "species": "flow",
+      "title": "Export Project Bundle",
+      "description": "Get the whole project out as a portable JSON bundle — download it from the project menu (with a size warning past 4 MB), or inspect and copy it in the raw bundle panel.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "playlist": {
+          "entries": [
+            {
+              "type": "junction",
+              "label": "How do you want the bundle?",
+              "cases": [
+                {
+                  "label": "Download a JSON file",
+                  "entries": []
+                },
+                {
+                  "label": "Open the raw bundle panel",
+                  "entries": [
+                    {
+                      "type": "view",
+                      "view_id": "V-raw-bundle-panel"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "F-explore-sandbox",
+      "species": "flow",
+      "title": "Explore Public Sandbox",
+      "description": "Open Arkaik's own map from the Explore section — signed in or out — and play with everything for real in per-tab memory: refresh resets to the pristine seed, or keep what you built by importing a copy.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "playlist": {
+          "entries": [
+            {
+              "type": "view",
+              "view_id": "V-projects"
+            },
+            {
+              "type": "view",
+              "view_id": "V-sandbox-notice"
+            },
+            {
+              "type": "junction",
+              "label": "Done playing?",
+              "cases": [
+                {
+                  "label": "Reset sandbox (reload restores the seed)",
+                  "entries": []
+                },
+                {
+                  "label": "Import a copy as a real local project",
+                  "entries": [
+                    {
+                      "type": "flow",
+                      "flow_id": "F-import-json"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "V-sandbox-notice",
+      "species": "view",
+      "title": "Sandbox Notice",
+      "description": "The amber sidebar notice on the public self-map telling visitors changes stay in this tab and vanish on refresh; the Reset and Import-a-copy actions live in the project switcher menu.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio"
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "F-browse-docs",
+      "species": "flow",
+      "title": "Browse Documentation",
+      "description": "Read Arkaik's in-app docs site, reached from the project menu, with sidebar navigation and full-text search across pages.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "playlist": {
+          "entries": [
+            {
+              "type": "view",
+              "view_id": "V-docs-site"
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "V-docs-site",
+      "species": "view",
+      "title": "Documentation Site",
+      "description": "The /docs pages — server-rendered markdown with a collapsible sidebar tree and a search box over the cached page index.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio"
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "V-cli-terminal",
+      "species": "view",
+      "title": "CLI Terminal",
+      "description": "The terminal surface of the arkaik CLI — usage text, command output, validation findings, and journal listings rendered to stdout.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "toolchain"
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "V-arkaik-skill",
+      "species": "view",
+      "title": "Arkaik Agent Skill",
+      "description": "The generated SKILL.md doctrine an agent reads — installed by arkaik init or the Claude Code plugin, with its schema reference and standalone validator alongside.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "toolchain"
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "V-mcp-tool-catalog",
+      "species": "view",
+      "title": "MCP Tool Catalog",
+      "description": "The arkaik-mcp server's agent-facing surface — fourteen read and write tools whose JSON results are the same projections humans see as pages.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "toolchain"
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "F-init-repo",
+      "species": "flow",
+      "title": "Initialize Repo Map",
+      "description": "arkaik init scaffolds docs/arkaik/ (bundle, journal, assets), writes the union-merge rule, and installs the templated agent skill into the repo (--update upgrades).",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "toolchain",
+        "playlist": {
+          "entries": [
+            {
+              "type": "view",
+              "view_id": "V-cli-terminal"
+            },
+            {
+              "type": "view",
+              "view_id": "V-arkaik-skill"
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "F-validate-bundle",
+      "species": "flow",
+      "title": "Validate Bundle",
+      "description": "arkaik validate (and the zero-dependency validate-bundle.js artifact) runs @arkaik/schema shape, semantic, and snapshot-journal cross-checks as the toolchain's hard gate.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "toolchain",
+        "playlist": {
+          "entries": [
+            {
+              "type": "view",
+              "view_id": "V-cli-terminal"
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "F-journal-release",
+      "species": "flow",
+      "title": "Journal & Release",
+      "description": "arkaik log prints the project changelog or a node timeline, arkaik release tags a version and drafts its notes, and arkaik deliverable records a shipped deliverable.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "toolchain",
+        "playlist": {
+          "entries": [
+            {
+              "type": "view",
+              "view_id": "V-cli-terminal"
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "F-sync-refs",
+      "species": "flow",
+      "title": "Sync External Refs",
+      "description": "arkaik sync mirrors GitHub issue and PR status into node refs, updating external_status/synced_at and appending ref.status_changed events.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "toolchain",
+        "playlist": {
+          "entries": [
+            {
+              "type": "view",
+              "view_id": "V-cli-terminal"
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "F-share-map",
+      "species": "flow",
+      "title": "Pack, Open & Push",
+      "description": "arkaik pack produces a single self-contained interchange bundle, arkaik open validates and hands it to arkaik.app import, and arkaik push publishes it to Publik (or deletes a snapshot with its owner key).",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "toolchain",
+        "playlist": {
+          "entries": [
+            {
+              "type": "view",
+              "view_id": "V-cli-terminal"
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "F-link-hosted",
+      "species": "flow",
+      "title": "Link Hosted Project",
+      "description": "arkaik link points the repo at a hosted account project by writing docs/arkaik/arkaik.json, listing and verifying the projects an ARKAIK_TOKEN can reach.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "toolchain",
+        "playlist": {
+          "entries": [
+            {
+              "type": "view",
+              "view_id": "V-cli-terminal"
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "F-mcp-agent-session",
+      "species": "flow",
+      "title": "MCP Agent Session",
+      "description": "An agent host spawns arkaik-mcp over stdio and reads or mutates the map through validator-gated dual-write tools, against the repo bundle or a linked hosted project.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "toolchain",
+        "playlist": {
+          "entries": [
+            {
+              "type": "condition",
+              "label": "Serving a hosted project?",
+              "if_true": [
+                {
+                  "type": "flow",
+                  "flow_id": "F-link-hosted"
+                },
+                {
+                  "type": "view",
+                  "view_id": "V-mcp-tool-catalog"
+                }
+              ],
+              "if_false": [
+                {
+                  "type": "view",
+                  "view_id": "V-mcp-tool-catalog"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "V-project-settings",
+      "species": "view",
+      "title": "Project Settings",
+      "description": "The project's settings page: linked repositories for PR-driven transitions, the product manager, and the delete danger zone.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio"
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "V-landing",
+      "species": "view",
+      "title": "Landing Page",
+      "description": "The signed-out front door — living logo, ASCII terrain, and a Start building call to action; signed-in visitors are redirected straight to the projects home.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio"
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "F-manage-products",
+      "species": "flow",
+      "title": "Manage Products",
+      "description": "Declare, rename, and remove the project's products and their platform menus from the Settings page.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "playlist": {
+          "entries": [
+            {
+              "type": "view",
+              "view_id": "V-project-settings"
+            }
+          ]
+        }
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-sections-mirror-project-homes",
+      "species": "acceptance",
+      "title": "Sections mirror where projects live",
+      "description": "Signed in, the projects page groups every project under Hosted, Synked, or Lokal according to where it actually lives — a browser project counts as Synked only when Synk really holds a backup for it.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given a signed-in user with an account-hosted project, a browser project backed up to Synk, and a browser-only project\nWhen the projects page loads\nThen the three projects appear under the Hosted, Synked, and Lokal sections respectively, each heading showing its count",
+        "values": [
+          "organizes",
+          "informs"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-delete-behind-confirmation",
+      "species": "acceptance",
+      "title": "Deletion cannot happen by accident",
+      "description": "A project can only be deleted from its Settings page's Danger zone, behind a confirmation dialog — the listing card carries no delete button at all.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given a user on the Settings page of a project they own\nWhen they click \"Delete project\" in the Danger zone\nThen a confirmation dialog names the project and asks first, and only confirming archives it and returns them to the projects listing",
+        "values": [
+          "reduces-risk"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-public-map-undeletable",
+      "species": "acceptance",
+      "title": "Public map cannot be deleted",
+      "description": "The built-in public self-map offers no delete control anywhere — its Settings page renders no Danger zone, so the shared fixture cannot be removed even deliberately.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given the Settings page of the built-in public self-map project\nWhen the user looks for a way to delete it\nThen no Danger zone, delete button, or confirmation dialog is offered",
+        "values": [
+          "reduces-anxiety"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-example-projects-one-click",
+      "species": "acceptance",
+      "title": "Examples are one click away",
+      "description": "An empty Lokal shelf — including the signed-out empty state — offers the example project picker, and choosing one imports the bundle into this browser and opens it immediately.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given a visitor with no Lokal projects on the projects page\nWhen they pick \"Pebbles\" or \"Arkaik\" from the \"Import example project\" select\nThen the example bundle is imported into this browser as a Lokal project and the app navigates straight into it",
+        "values": [
+          "saves-time",
+          "informs"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-signed-in-skips-landing",
+      "species": "acceptance",
+      "title": "Signed in skips the pitch",
+      "description": "A signed-in visitor to the landing page is redirected straight to their projects instead of being asked to press \"Start building\" again.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given a visitor with a valid session\nWhen they open the landing page at \"/\"\nThen they are redirected to /projects without seeing the pitch or pressing \"Start building\"",
+        "values": [
+          "saves-time",
+          "avoids-hassles"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-create-lands-in-chosen-home",
+      "species": "acceptance",
+      "title": "Create lands where you asked",
+      "description": "Creating a project from a section's menu makes the new project in that section's home — account, Synk-backed browser, or this browser only — and opens it right away.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given the create dialog opened from the Synked section's create menu\nWhen the user enters a title and submits\nThen an empty project is created in this browser with a Synk backup, appears under Synked, and the app navigates into it",
+        "values": [
+          "reduces-effort"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-sign-in-adds-never-rearranges",
+      "species": "acceptance",
+      "title": "Signing in adds, never rearranges",
+      "description": "Projects held in this browser stay exactly where they are when the user signs in — Hosted and Synked sections appear alongside Lokal rather than absorbing or moving anything.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given a signed-out visitor with projects stored in this browser\nWhen they sign in and return to the projects page\nThen every browser project is still listed under Lokal, untouched, with Hosted and Synked sections added around it",
+        "values": [
+          "reduces-anxiety"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-move-to-account-copies",
+      "species": "acceptance",
+      "title": "Move to account keeps the original",
+      "description": "Moving a browser-held project to the account is a copy, not a transfer — the hosted twin gets its own id and the local original stays put, so a failure loses nothing.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given a signed-in user viewing a browser-held project's card\nWhen they click \"Move to account\"\nThen a copy with a new server-owned id appears under Hosted and the original project remains in this browser",
+        "values": [
+          "reduces-risk",
+          "integrates"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-products-named-in-settings",
+      "species": "acceptance",
+      "title": "Products are named in Settings",
+      "description": "The Settings page's Products panel lets a project name the family of apps sharing its graph, so every other page can scope to one product.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given a project's Settings page\nWhen the user adds a product in the Products panel\nThen the product joins the project's product list with its member count, and product-scoped pages can select it",
+        "values": [
+          "organizes"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-honest-map-counts",
+      "species": "acceptance",
+      "title": "Map cards count honestly",
+      "description": "A map card on the index never advertises a node or edge count the map it links to does not show, because each map is counted through the renderer that draws it.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given a project with a stored journey map anchored below the project root\nWhen the maps index renders its cards\nThen each card's node and edge counts come from the same selection the map's own renderer draws, and opening the map shows at least the counted nodes",
+        "values": [
+          "informs",
+          "quality"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-drill-down-in-place",
+      "species": "acceptance",
+      "title": "Drill down without leaving",
+      "description": "Expanding a flow on the Journey map unfolds its playlist inline on the same canvas, and collapsing it restores the overview without a page change.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given the Journey map with a top-level flow collapsed\nWhen the user clicks to expand that flow\nThen its playlist unfolds in place on the same canvas, any other expanded top-level journey collapses, and collapsing it again returns to the overview with no navigation",
+        "values": [
+          "simplifies",
+          "organizes"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-scoped-journey-never-lies",
+      "species": "acceptance",
+      "title": "Scoped journey never lies",
+      "description": "A journey whose anchor does not resolve inside the named product renders an empty state that names the reason and offers the System map, never another product's graph.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given a product scope is active and the journey's anchor is missing or not part of that product\nWhen the Journey map renders\nThen the canvas is replaced by an empty state saying which of the two went wrong, with a link to the System map, and no other product's nodes are drawn",
+        "values": [
+          "reduces-risk",
+          "informs"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-display-persists-per-map",
+      "species": "acceptance",
+      "title": "Display choices stick per map",
+      "description": "A display option flipped in the popover is saved against that map's id alone, survives a reload, and leaves every other map's rendering untouched.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given the Journey map showing screenshot images on view cards\nWhen the user hides images from the Display popover and reloads the page\nThen the Journey still hides images while the System map and every custom map keep their own display, because the choice was stored under this map's id only",
+        "values": [
+          "avoids-hassles"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-no-cyclic-playlists",
+      "species": "acceptance",
+      "title": "No circular playlists",
+      "description": "Inserting a flow into a playlist that would make it contain itself, directly or indirectly, is refused with a circular-reference message and leaves the graph unchanged.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given flow A already appears in flow B's playlist chain\nWhen the user tries to add B into A's playlist from the canvas\nThen the insertion is refused with a message naming the circular reference, and a node created for the attempt is rolled back so the graph stays valid",
+        "values": [
+          "reduces-risk"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-valid-edge-types-only",
+      "species": "acceptance",
+      "title": "Only valid connections offered",
+      "description": "Dragging a connection between two cards opens a dialog that offers only the relationship types that ordered species pair admits.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given the user drags a connection from a view card onto a data-model card on either canvas\nWhen the edge-type dialog opens\nThen it lists only the edge types valid for that source and target species, so an invalid relationship cannot be created by hand",
+        "values": [
+          "reduces-risk",
+          "simplifies"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-delete-asks-first",
+      "species": "acceptance",
+      "title": "Deletion always asks first",
+      "description": "Deleting a node from the canvas or with the Delete key opens a confirmation that names the node, counts its descendants, and makes cascade an explicit opt-in.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given a flow with descendant nodes and its panel open on the Journey map\nWhen the user presses Delete or chooses to delete it\nThen a confirmation dialog names the node, offers \"Also delete N child node(s)\" as an unchecked option, and nothing is removed until the user confirms",
+        "values": [
+          "reduces-anxiety",
+          "reduces-risk"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-insert-between-steps",
+      "species": "acceptance",
+      "title": "Insert between playlist steps",
+      "description": "A view, flow, condition, or junction can be inserted between two playlist steps right on the canvas, landing at that exact position with its compose edge created when missing.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given an expanded flow on the Journey map\nWhen the user inserts a view between two of its playlist steps\nThen the entry is placed at exactly that position in the playlist and a composes edge from the flow is added if one did not already exist",
+        "values": [
+          "reduces-effort",
+          "saves-time"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-custom-map-as-data",
+      "species": "acceptance",
+      "title": "Custom maps are saved data",
+      "description": "Saving the New map dialog writes a map definition into project metadata — reserved built-in ids and duplicates refused by name — and the map appears in the index, the sidebar, and the command palette.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given the New map dialog filled with a title, a kind, and an anchor picked by search\nWhen the user saves\nThen the definition lands in project metadata as data an agent could equally write, ids shadowing \"journey\" or \"system\" or an existing map are refused with a named error, and the new map shows up on the maps index and in the command palette",
+        "values": [
+          "organizes",
+          "integrates"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-palette-jump-anywhere",
+      "species": "acceptance",
+      "title": "Jump anywhere from keyboard",
+      "description": "The command palette ranks every project destination as you type, matches the synonyms people actually use, completes with Tab, and navigates or runs on Enter.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given the command palette opened with the mod key and K\nWhen the user types \"screens\"\nThen the Views destination ranks first through its synonym, Tab fills the input with the active row's wording, and Enter lands on the library filtered to views",
+        "values": [
+          "saves-time",
+          "simplifies"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-shortcuts-no-dead-keys",
+      "species": "acceptance",
+      "title": "Shortcut list tells no lies",
+      "description": "The shortcuts dialog lists every chord the current surface actually answers to — project and map chords are hidden outside a project — and renders the mod key as the running platform's own label.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given the shortcuts dialog opened from the docs shell, outside any project\nWhen its groups render\nThen only chords live everywhere are listed, project-only and map-only chords are absent, and the Mod token shows as the platform's own key label",
+        "values": [
+          "informs"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-viewport-stays-put",
+      "species": "acceptance",
+      "title": "Canvas stays where left",
+      "description": "The viewport never jumps while you work: editing data re-lays the graph without moving your framing, and the canvas re-frames only on changes you asked for, like a layout switch or a panel opening.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given the System map panned and zoomed onto one corner of the graph\nWhen the user edits a node so the layout recomputes\nThen the viewport keeps its position, and it re-frames only after an asked-for change such as switching the layout rendition or opening or closing a panel",
+        "values": [
+          "avoids-hassles",
+          "quality"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-spotlight-neighborhood",
+      "species": "acceptance",
+      "title": "Spotlight one node's relations",
+      "description": "On the dense System map, hovering a node — or having one selected in a panel — dims everything outside its direct relations so one node's neighborhood stays readable in the whole-product picture.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given the System map showing the whole product\nWhen the user hovers a data-model card, or a node is pinned by its open panel\nThen every node and edge outside that node's direct relations dims, and moving the pointer away restores the full picture",
+        "values": [
+          "simplifies",
+          "informs"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-system-two-renditions",
+      "species": "acceptance",
+      "title": "Two readings of the system",
+      "description": "The System map re-draws the same nodes as either an organic cluster layout or tiered species rows — views over endpoints over data models — and re-frames the viewport on each switch.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given the System map open in its default organic rendition\nWhen the user switches the layout select to Tiered\nThen the same nodes re-lay out into species tiers with views above API endpoints above data models, the viewport re-frames to the new layout, and switching back restores the organic clustering",
+        "values": [
+          "variety",
+          "informs"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-details-autosave-on-pause",
+      "species": "acceptance",
+      "title": "Detail edits autosave",
+      "description": "Title, description, and blocked-by edits in the detail panel persist on a short debounce — there is no save button to forget.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given the detail panel is open on a node\nWhen the user edits the title or description and pauses typing for 350ms\nThen the change is persisted without pressing any save button and survives closing and reopening the panel",
+        "values": [
+          "reduces-anxiety",
+          "reduces-effort"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-playlist-cycle-blocked",
+      "species": "acceptance",
+      "title": "Playlists cannot loop",
+      "description": "Adding a sub-flow that would make a flow contain itself, directly or through intermediates, is refused with an explanation instead of corrupting the graph.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given a flow's playlist editor is open\nWhen the user adds a sub-flow entry that would make the flow contain itself, directly or via intermediate flows\nThen the entry is not added and an error toast names the flow that would create the circular reference",
+        "values": [
+          "reduces-risk"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-playlist-branching-entries",
+      "species": "acceptance",
+      "title": "Playlists branch inline",
+      "description": "A flow's playlist mixes views, sub-flows, binary conditions, and multi-way junctions, edited in place from the detail panel.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given a flow's playlist editor is open\nWhen the user adds a condition entry with a question label and fills its true and false branches\nThen the branch structure persists in the flow's playlist and each referenced view or sub-flow resolves to a real node",
+        "values": [
+          "organizes"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-raw-edits-validated",
+      "species": "acceptance",
+      "title": "Raw edits gated by validation",
+      "description": "Saving from the raw bundle panel parses the draft and runs it through the same validated import path — malformed JSON or YAML never reaches storage.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given the raw bundle panel is in edit mode with a draft containing invalid syntax or a schema violation\nWhen the user confirms save\nThen the save is rejected with a specific error message and the stored bundle is unchanged",
+        "values": [
+          "reduces-risk"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-raw-format-switch-roundtrips",
+      "species": "acceptance",
+      "title": "Format switch preserves draft",
+      "description": "Switching the raw panel between JSON and YAML re-serializes the current draft; a draft that cannot parse blocks the switch instead of mangling the text.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given the raw bundle panel is in edit mode with unsaved edits\nWhen the user switches between JSON and YAML\nThen a parseable draft is carried over re-serialized in the new format, and an unparseable draft blocks the switch with an error toast leaving the text intact",
+        "values": [
+          "avoids-hassles"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-raw-close-guard",
+      "species": "acceptance",
+      "title": "Unsaved raw edits guarded",
+      "description": "Closing or cancelling the raw bundle panel with unsaved edits asks for confirmation before anything is discarded.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given the raw bundle panel is in edit mode with unsaved changes\nWhen the user cancels or closes the panel\nThen a confirmation dialog intercepts the action and the draft is only discarded after the user confirms",
+        "values": [
+          "reduces-anxiety"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-acceptance-how-why-inline",
+      "species": "acceptance",
+      "title": "Gherkin and values inline",
+      "description": "An acceptance's Given/When/Then scenario and its value elements are edited in place in the acceptance editor, debounce-saved like every other detail field.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given the acceptance editor is open on an acceptance node\nWhen the user edits the gherkin text and toggles value elements in the value picker\nThen both persist without a save button and a concurrent status edit is not overwritten by the debounced gherkin save",
+        "values": [
+          "simplifies"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-split-carries-context",
+      "species": "acceptance",
+      "title": "Split keeps the context",
+      "description": "Splitting one acceptance into several pieces carries the covers edges, platforms, and product to every piece — and says so on screen before you commit.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given the split dialog is open on an acceptance covering n nodes\nWhen the user names at least two pieces and confirms the split\nThen each new acceptance covers the same n nodes with the same platforms and product, and the dialog stated that carry-over before submission",
+        "values": [
+          "reduces-effort"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-parity-gap-at-a-glance",
+      "species": "acceptance",
+      "title": "Parity gaps surface themselves",
+      "description": "An acceptance carries per-platform statuses, and the matrix's parity-gap toggle narrows to exactly the acceptances whose platforms disagree.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given an acceptance whose platforms resolve to different statuses\nWhen the user enables the parity-gap filter on the acceptances matrix\nThen that acceptance remains listed while acceptances with uniform platform statuses are filtered out, and each anchor group shows its gap count",
+        "values": [
+          "informs",
+          "saves-time"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-matrix-groups-by-anchor",
+      "species": "acceptance",
+      "title": "Matrix groups by anchor",
+      "description": "The acceptances matrix groups every promise under the view or flow it covers, with unanchored intake ideas kept last and reachable by a dedicated filter.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given a project with acceptances covering views and flows plus some covering nothing\nWhen the user opens the acceptances matrix\nThen acceptances appear under each anchor they cover (once per anchor), anchor groups sort by title, and the Unanchored bucket is last and selectable via the anchor filter",
+        "values": [
+          "organizes"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-pyramid-coverage-glance",
+      "species": "acceptance",
+      "title": "Value coverage at a glance",
+      "description": "The pyramid lays out the 30 value elements by tier, each showing how many acceptances serve it and their status rollup.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given a project whose acceptances carry value elements\nWhen the user opens the pyramid page\nThen every value element appears in its tier with its acceptance count and a status rollup labelled in acceptances, and served elements are visually distinct from unserved ones",
+        "values": [
+          "informs"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-pyramid-gap-filter",
+      "species": "acceptance",
+      "title": "Unserved values filterable",
+      "description": "The pyramid toolbar steps between empty, all, and addressed elements, so the value elements no acceptance serves are one click away.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given the pyramid page is open\nWhen the user steps the toolbar filter to 'empty'\nThen only value elements with zero covering acceptances remain visible, exposing where the product currently makes no promise",
+        "values": [
+          "informs"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-library-bulk-move-honest",
+      "species": "acceptance",
+      "title": "Bulk selection stays honest",
+      "description": "Library selection survives filter changes, the action bar counts by species, and it warns how many selected nodes the current filter is hiding before a bulk product move.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given several nodes are selected in the library and the search filter then hides some of them\nWhen the user reads the selection bar and moves the selection to a product\nThen the bar states how many selected nodes are hidden by the filter and the move touches every selected node, not just the visible ones",
+        "values": [
+          "saves-time",
+          "organizes"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-overview-health-indicators",
+      "species": "acceptance",
+      "title": "Doc health always visible",
+      "description": "The overview reports the map's blind spots — nodes unreachable from root, views without screenshots, missing descriptions, disconnected nodes, open backlog — as counted indicators.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given a project with an orphan flow, a view without a screenshot, and a node without a description\nWhen the user opens the overview page\nThen each health indicator reports the offending count against its denominator and lists the offending node ids deterministically",
+        "values": [
+          "informs"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-history-never-rewritten",
+      "species": "acceptance",
+      "title": "History Never Rewritten",
+      "description": "The journal is append-only: recorded events are read as written forever, even legacy status ids from before a rename.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given a project journal containing a status event recorded with a pre-v3 status id\nWhen I open the History page after later changes to the same node\nThen the original event still reads exactly as it was written, with no rewritten or deleted lines",
+        "values": [
+          "reduces-risk",
+          "reduces-anxiety"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-history-family-filter",
+      "species": "acceptance",
+      "title": "Filter History by Family",
+      "description": "The full event feed narrows to one event family — nodes, edges, decisions, delivery, ideas and requests, or references — with a single chip.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given a History page showing events of several types\nWhen I click the Decisions family chip\nThen only decision events remain in the feed, and clicking the chip again returns to all events",
+        "values": [
+          "saves-time"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-changelog-design-delivery-split",
+      "species": "acceptance",
+      "title": "Design and Delivery Apart",
+      "description": "The changelog separates the design funnel (backlog, commitments, decisions) from the delivery record (unreleased work, releases) into two side-by-side panels.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given a project with open backlog items, commitment transitions, and shipped deliverables\nWhen I open the Changelog page\nThen a Design panel shows backlog, commitments, and decisions, and a separate Delivery panel shows unreleased work and releases",
+        "values": [
+          "organizes",
+          "informs"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-deliverable-anchored-first-ship",
+      "species": "acceptance",
+      "title": "Deliverables Anchor When Shipped",
+      "description": "A deliverable belongs to the release whose slice contains its first occurrence; later edits update its content without ever moving it between releases.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given a deliverable first recorded between the 1.2.0 and 1.3.0 release tags\nWhen the same deliverable id is re-appended later with an edited summary\nThen the 1.3.0 release card shows the updated summary and the deliverable still belongs to 1.3.0",
+        "values": [
+          "organizes",
+          "reduces-risk"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-unreleased-work-visible",
+      "species": "acceptance",
+      "title": "Unreleased Work Stays Visible",
+      "description": "Deliverables shipped after the most recent release tag surface under an Unreleased heading instead of disappearing until the next version.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given deliverables recorded after the most recent release tag\nWhen I open the Changelog's Delivery panel\nThen those deliverables appear under an Unreleased heading, above the releases, until a new version is tagged",
+        "values": [
+          "informs"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-decision-keeps-why-how",
+      "species": "acceptance",
+      "title": "Decisions Keep Their Why",
+      "description": "A decision records its context (why), consequences (how), and the date it was decided, and keeps all three on every future read.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given a decision node open in the detail panel\nWhen I fill in Context, Consequences, and a Decided-on date and close the panel\nThen reopening the decision later shows the same why, how, and date",
+        "values": [
+          "informs",
+          "reduces-risk"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-decision-edits-autosave",
+      "species": "acceptance",
+      "title": "Decision Edits Save Themselves",
+      "description": "Context, consequences, and date edits autosave shortly after typing stops — there is no save button, and concurrent edits to different fields never clobber each other.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given I am typing into a decision's Context field\nWhen I pause typing without pressing any save button\nThen the edit persists automatically, and an edit made to Consequences at the same time is not lost",
+        "values": [
+          "reduces-effort",
+          "avoids-hassles"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-superseded-chain-traceable",
+      "species": "acceptance",
+      "title": "Superseded Decisions Stay Traceable",
+      "description": "A replaced decision is never deleted: it nests dimmed under the decision that superseded it, and its full record stays one click away.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given decision B supersedes decision A\nWhen I view the Decision Log\nThen A appears nested and dimmed under B rather than removed, and opening A still shows its full record",
+        "values": [
+          "organizes"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-decision-status-filter",
+      "species": "acceptance",
+      "title": "Filter Decisions by Status",
+      "description": "Status chips with live counts narrow the decision log to one decision state, shown as a flat list.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given a Decision Log holding decisions in several decision states\nWhen I click a status filter chip\nThen only decisions in that state are listed, flat, and each chip's count matches the log",
+        "values": [
+          "simplifies"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-board-mirrors-lifecycle",
+      "species": "acceptance",
+      "title": "Board Mirrors the Lifecycle",
+      "description": "The delivery board groups every node into the column of its current lifecycle status, narrowed by species, platform, and search filters.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given nodes spread across the lifecycle from idea to live\nWhen I open the Delivery board\nThen each item sits in the column of its current status, and the species, platform, and search filters narrow the board",
+        "values": [
+          "organizes",
+          "saves-time"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-board-item-per-platform",
+      "species": "acceptance",
+      "title": "One Card per Platform",
+      "description": "A node appears once per platform it targets, each card in that platform's own status column — uneven delivery is visible, not averaged away.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given a view that is live on web but in development on iOS\nWhen I view the Delivery board with all platforms shown\nThen the view appears as two cards — one in the Live column for web and one in the Development column for iOS",
+        "values": [
+          "informs"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-empty-journal-calm",
+      "species": "acceptance",
+      "title": "Empty History Is Calm",
+      "description": "A bundle without a journal renders a quiet empty state on the changelog and history pages — never an error.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given a project whose bundle carries no journal events\nWhen I open the Changelog or History page\nThen I see a gentle empty state explaining history will appear once recorded, not an error",
+        "values": [
+          "avoids-hassles",
+          "reduces-anxiety"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-publish-never-leaks-journal",
+      "species": "acceptance",
+      "title": "Publishing never leaks history",
+      "description": "A Publik snapshot never contains the project's journal: the strip is enforced server-side, not left to client behavior.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "platform",
+        "gherkin": "Given a local project whose bundle embeds a journal of change events\nWhen the user publishes it from the publish dialog (which sends no include_journal opt-in)\nThen the snapshot stored and served at /api/publik/{id} contains no journal[] — the server strips it unless a request explicitly asks ?include_journal=true",
+        "values": [
+          "reduces-risk"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-owner-key-shown-once",
+      "species": "acceptance",
+      "title": "Owner key shown once",
+      "description": "After publishing, the dialog shows the share URL and owner key exactly once, with copy buttons and a save-this-key warning — the server keeps only a hash.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "platform",
+        "gherkin": "Given a publish just succeeded\nWhen the success stage of the publish dialog renders\nThen the share URL and owner key appear with copy buttons and a warning that the key will not be shown again — the server stores only its SHA-256 hash and can never return it",
+        "values": [
+          "informs",
+          "reduces-risk"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-snapshot-delete-needs-key",
+      "species": "acceptance",
+      "title": "Deletion gated by key",
+      "description": "Only the holder of the owner key can delete a snapshot, and snapshots are immutable — so a leaked link can neither edit nor remove what you shared.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "platform",
+        "gherkin": "Given a published snapshot\nWhen DELETE /api/publik/{id} arrives with a bearer key whose SHA-256 does not match the stored hash\nThen the server answers 403 and the snapshot is untouched — and because snapshots have no update endpoint, nobody can edit one either; re-publishing mints a new id",
+        "values": [
+          "reduces-risk"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-publish-without-account",
+      "species": "acceptance",
+      "title": "Publish without an account",
+      "description": "Sharing a graph requires no sign-up: publishing is anonymous and the snapshot lives at an unguessable, unlisted URL.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "platform",
+        "gherkin": "Given a visitor with no arkaik account and no session\nWhen they publish a project from the publish dialog\nThen the snapshot is created with no sign-in step anywhere in the flow, at a server-generated URL-safe id of at least 64 bits of randomness, and there is no public listing that could reveal it",
+        "values": [
+          "provides-access",
+          "simplifies"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-snapshot-imports-as-copy",
+      "species": "acceptance",
+      "title": "Anyone imports a copy",
+      "description": "Anyone with a snapshot URL can import it as a fresh local project — the shared original and any existing local projects are never disturbed.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "platform",
+        "gherkin": "Given anyone opens /p/{id} for a shared snapshot\nWhen they click \"Import into arkaik\"\nThen the bundle is fetched client-side and imported through the same funnel as a manual JSON import, with ID-collision rewriting, so it lands as a new local project and overwrites nothing",
+        "values": [
+          "provides-access",
+          "connects"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-backups-run-themselves",
+      "species": "acceptance",
+      "title": "Backups run themselves",
+      "description": "Once a project is backed up to Synk, every later edit is backed up automatically about a minute after you stop typing — no button to remember.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "platform",
+        "gherkin": "Given a signed-in user editing a local project that Synk backs up\nWhen roughly 60 seconds pass after their last mutation\nThen the sync engine exports, canonically serializes, and PUTs the bundle to /api/synk/projects/{id} with no user action, and the project's visible status becomes \"backed up\"",
+        "values": [
+          "reduces-effort",
+          "reduces-anxiety"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-backups-dedupe-by-content",
+      "species": "acceptance",
+      "title": "Backups dedupe by content",
+      "description": "A backup whose canonical bytes match the latest stored version records nothing, so the version list only ever contains real changes.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "platform",
+        "gherkin": "Given a project whose latest Synk backup has SHA-256 hash H\nWhen a backup attempt PUTs a bundle whose canonical serialization also hashes to H\nThen the server answers 200 with { deduped: true } and stores no new version, so the restore dialog's version list holds only genuinely different states",
+        "values": [
+          "organizes"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-backup-failure-loses-nothing",
+      "species": "acceptance",
+      "title": "Failed backups lose nothing",
+      "description": "A network failure or tier-limit refusal never touches the local data: the bundle stays in the browser and the next edit or a manual retry backs it up.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "platform",
+        "gherkin": "Given a backup attempt that fails with a network error or a 403 limit response\nWhen the failure lands\nThen the local bundle in IndexedDB is untouched, the project status shows the error (with structured limit/actual/tier details on a 403), and the next mutation or an explicit \"Back up now\" retries — the engine never writes server state into local storage",
+        "values": [
+          "reduces-risk"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-restore-never-overwrites",
+      "species": "acceptance",
+      "title": "Restore never overwrites",
+      "description": "Restoring a retained version always creates a new local project — it can never clobber the live project you restored from.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "platform",
+        "gherkin": "Given a signed-in user who picked a retained version in the restore dialog\nWhen they click Restore\nThen the backup's bundle is imported through the standard import funnel with ID-collision rewriting, landing as a NEW local project the app navigates to — the existing local project is never overwritten in place",
+        "values": [
+          "reduces-anxiety",
+          "reduces-risk"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-one-click-backup-offer",
+      "species": "acceptance",
+      "title": "One-click backup offer",
+      "description": "After signing in, each local project without a backup is offered for backup with a single click — the data never moves, it only gains a copy.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "platform",
+        "gherkin": "Given a signed-in user whose projects page lists local projects with no Synk backup\nWhen the page renders\nThen a dismissible banner offers one \"Back up\" button per candidate — excluding hosted projects, the seed sandbox, and already-backed-up ones — and the banner disappears on its own once no candidates remain and never shows to signed-out users",
+        "values": [
+          "simplifies",
+          "reduces-effort"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-move-keeps-local-copy",
+      "species": "acceptance",
+      "title": "Moving keeps local copy",
+      "description": "\"Move to account\" is a copy: the hosted project gets a new server-owned id and the browser-held original stays exactly where it was.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "platform",
+        "gherkin": "Given a browser-held project and a signed-in user who clicks \"Move to account\"\nWhen the hosted copy is created\nThen it receives a new server-owned id (prj_…) while the local original remains untouched in the browser — and if the move fails midway, nothing has been lost or deleted",
+        "values": [
+          "reduces-risk",
+          "reduces-anxiety"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-agent-token-shown-once",
+      "species": "acceptance",
+      "title": "Token secret shown once",
+      "description": "An agent token's plaintext appears exactly once at mint, scoped to what you chose, and a leaked token can never mint another or widen its own scopes.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "platform",
+        "gherkin": "Given a signed-in user on /settings/tokens who names a token and picks its scopes\nWhen the mint succeeds\nThen the plaintext secret is shown once in a dismissable panel that says it cannot be recovered, the server stores only a hash, and the token stays revocable from the list — token management itself is session-only, so the token cannot manage tokens",
+        "values": [
+          "integrates",
+          "reduces-risk"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-signin-never-gates-local",
+      "species": "acceptance",
+      "title": "Sign-in never gates local",
+      "description": "Every local-first surface works with no account and even with no auth configured — services degrade to absent instead of breaking the app.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "platform",
+        "gherkin": "Given a deployment with no auth environment variables set\nWhen the app boots\nThen every local-first surface works normally while the sign-in button, account menu, and token settings render nothing at all — and on a configured deployment, staying signed out still gates no local feature",
+        "values": [
+          "avoids-hassles",
+          "provides-access"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-prompt-for-any-llm",
+      "species": "acceptance",
+      "title": "One prompt, any LLM",
+      "description": "The generate page assembles a complete, copyable prompt for whatever LLM you already use — arkaik calls no AI and needs no API key — then hands you back to import the result.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "platform",
+        "gherkin": "Given a user on /generate who chose a use case, platforms, and target LLM\nWhen they click Copy or Download\nThen a complete prompt with a token estimate lands on the clipboard or as a .txt file to paste into any LLM, and the \"I've got my JSON — import it\" handoff returns them to /projects with the right import target preselected",
+        "values": [
+          "integrates",
+          "saves-time"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-legacy-bundle-migrates",
+      "species": "acceptance",
+      "title": "Old Bundles Still Import",
+      "description": "A bundle exported under an older status vocabulary imports through the lenient parse + migrate path instead of being refused.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given a bundle exported under a pre-v3 status vocabulary\nWhen the user imports the JSON file\nThen the shape parse accepts the legacy statuses, migrates them to the current vocabulary before validation, and the project opens with every node intact",
+        "values": [
+          "reduces-risk"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-broken-import-explains",
+      "species": "acceptance",
+      "title": "Broken Imports Explain Themselves",
+      "description": "An invalid bundle is refused with a readable, path-specific message rather than a silent failure or a corrupted project.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given a JSON file whose bundle has a duplicate node id and a dangling edge reference\nWhen the user imports it\nThen the import is refused with a message naming each failing path and its problem, capped at five findings so the error stays readable",
+        "values": [
+          "informs",
+          "reduces-risk"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-reserved-ids-stay-reserved",
+      "species": "acceptance",
+      "title": "Reserved IDs Stay Reserved",
+      "description": "An imported bundle can never squat the public seed id or the hosted prj_ namespace, so id-based routing stays a total function.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given a bundle whose project id is \"arkaik-self-map\" or starts with \"prj_\"\nWhen the user imports it\nThen a fresh unique id is minted and rewritten across the project, its nodes, and its edges, and the reserved namespaces remain untouched",
+        "values": [
+          "reduces-risk"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-export-full-bundle",
+      "species": "acceptance",
+      "title": "Your Map Leaves With You",
+      "description": "One click downloads the complete project — nodes, edges, and journal — as a portable JSON bundle, so the data is never locked in.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given an open project\nWhen the user exports it\nThen a JSON file named \"<title>-<id>.json\" downloads containing the project metadata, all nodes, all edges, and the app-emitted journal",
+        "values": [
+          "reduces-risk",
+          "integrates"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-export-reimports-cleanly",
+      "species": "acceptance",
+      "title": "Exports Re-import Cleanly",
+      "description": "An exported bundle round-trips: importing the file back yields a working copy with no manual fix-up.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given a project exported to a JSON file\nWhen that same file is imported back\nThen a working copy opens with identical nodes and edges, under a freshly minted id when the original id is already taken",
+        "values": [
+          "integrates",
+          "avoids-hassles"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-sandbox-resets-pristine",
+      "species": "acceptance",
+      "title": "Refresh Restores Pristine Seed",
+      "description": "Nothing done in the public self-map sandbox persists — a page refresh restores the pristine seed, so it cannot be broken.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given a visitor has created, edited, and deleted nodes in the public self-map sandbox\nWhen they refresh the page\nThen the pristine seed is restored and none of their changes were persisted to IndexedDB or the network",
+        "values": [
+          "reduces-anxiety",
+          "fun-entertainment"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-sandbox-edits-are-real",
+      "species": "acceptance",
+      "title": "Sandbox Edits Are Real",
+      "description": "The public self-map is the full product, not a demo reel: every editor works and writes append journal events in memory like any project.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given an anonymous visitor opens /project/arkaik-self-map\nWhen they create a node and rewire an edge\nThen the changes apply immediately in the tab with journal events appended, exactly as on a real project",
+        "values": [
+          "provides-access",
+          "fun-entertainment"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-sandbox-rules-stated-plainly",
+      "species": "acceptance",
+      "title": "Sandbox Rules Stated Plainly",
+      "description": "A persistent sidebar notice tells the visitor their changes are tab-local and vanish on refresh, before any surprise can happen.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given the public self-map is open\nWhen the project sidebar renders\nThen a notice states that changes stay in this tab and vanish on refresh",
+        "values": [
+          "informs",
+          "reduces-anxiety"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-docs-live-in-app",
+      "species": "acceptance",
+      "title": "Docs Live In App",
+      "description": "The repo's documentation renders inside the product at /docs, with the README as Overview and every page reachable by navigation or search.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "studio",
+        "gherkin": "Given a visitor opens /docs\nWhen the page loads\nThen the repo README renders as the Overview and every documentation page is reachable from the sidebar navigation and the search palette",
+        "values": [
+          "informs",
+          "simplifies"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-one-command-repo-setup",
+      "species": "acceptance",
+      "title": "One Command Repo Setup",
+      "description": "A single `npx arkaik init` gives any repo a valid bundle, a journal wired for union merge, and the installed agent skill.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "toolchain",
+        "gherkin": "Given a repository with no Arkaik artifacts\nWhen the user runs `npx arkaik init`\nThen docs/arkaik/bundle.json (a valid empty bundle), journal.jsonl, the assets dir, the .gitattributes union-merge rule, and .claude/skills/arkaik/SKILL.md all exist after the one command",
+        "values": [
+          "simplifies",
+          "saves-time"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-init-rerun-never-clobbers",
+      "species": "acceptance",
+      "title": "Re-run Init Safely",
+      "description": "Re-running init never overwrites an existing bundle, journal, or locally edited skill; only `--update` upgrades the skill, gated on its version stamp, and even then never touches the bundle or journal.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "toolchain",
+        "gherkin": "Given a repo where `arkaik init` already ran and the bundle has local edits\nWhen the user runs `arkaik init` again\nThen every existing artifact is reported as skipped and no file content changes, and a subsequent `arkaik init --update` with the same packaged skill version is a no-op",
+        "values": [
+          "reduces-risk",
+          "avoids-hassles"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-one-skill-doctrine-everywhere",
+      "species": "acceptance",
+      "title": "One Skill Doctrine Everywhere",
+      "description": "The agent skill installed by `arkaik init` and the one shipped in the Claude Code plugin are renders of the same source, with schema reference and validator generated from @arkaik/schema and drift-checked in CI.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "toolchain",
+        "gherkin": "Given the skill assets generated from @arkaik/schema\nWhen a schema change lands without regenerating the CLI's packaged skill assets and the plugin's copies\nThen the CI drift check fails the build, so `arkaik init` installs and the plugin ships cannot teach different doctrines",
+        "values": [
+          "integrates",
+          "quality"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-validator-blocks-broken-bundle",
+      "species": "acceptance",
+      "title": "Validator Blocks Broken Bundles",
+      "description": "`arkaik validate` exits non-zero with pathed findings on any shape or semantic error — duplicate ids, dangling edges, playlist cycles — so a broken bundle is caught before it is committed; warnings never fail the run.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "toolchain",
+        "gherkin": "Given a bundle where an edge's target_id references a node that does not exist\nWhen the user runs `arkaik validate docs/arkaik/bundle.json`\nThen the command prints an ERROR finding with the rule and path, reports INVALID, and exits 1 without modifying any file",
+        "values": [
+          "reduces-risk"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-bad-line-cannot-corrupt-history",
+      "species": "acceptance",
+      "title": "Bad Line Damages Nothing",
+      "description": "A malformed journal line invalidates exactly one event — the validator reports it by line number — and can never damage existing history or the snapshot, because one JSONL line is one self-contained event.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "toolchain",
+        "gherkin": "Given a journal.jsonl containing one truncated JSON line among valid events\nWhen the user runs `arkaik validate` on the sibling bundle\nThen the report names the malformed line by number as a single finding, every other event still parses, and the bundle snapshot is untouched",
+        "values": [
+          "reduces-anxiety",
+          "reduces-risk"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-parallel-appends-merge-clean",
+      "species": "acceptance",
+      "title": "Parallel Appends Merge Cleanly",
+      "description": "Because init writes the journal's merge=union rule and every event is one self-contained line, two branches that each appended events merge in git without conflict, and consumers reorder by timestamp and id.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "toolchain",
+        "gherkin": "Given two git branches that each appended different events to journal.jsonl\nWhen the branches are merged\nThen git's union merge combines both sets of lines with no conflict markers and `arkaik validate` still reports the journal as parseable",
+        "values": [
+          "avoids-hassles",
+          "integrates"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-release-notes-draft-themselves",
+      "species": "acceptance",
+      "title": "Release Notes Draft Themselves",
+      "description": "`arkaik release <version>` appends exactly one validated release.tagged marker to the journal and prints a release-note draft of everything since the previous release — the bundle file is never rewritten, so validate stays green.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "toolchain",
+        "gherkin": "Given a journal with events accumulated since the last release marker\nWhen the user runs `arkaik release 1.2.0`\nThen journal.jsonl grows by exactly one release.tagged line, a draft listing the since-last-release deliverables and events is printed, and the bundle file's bytes are unchanged",
+        "values": [
+          "saves-time",
+          "informs"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-linked-repo-fails-loud",
+      "species": "acceptance",
+      "title": "Linked Repo Fails Loud",
+      "description": "A repo linked to a hosted project but missing its token exits non-zero instead of silently falling back to the local bundle — an agent is never served a stale graph that looks fine.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "toolchain",
+        "gherkin": "Given a repo with docs/arkaik/arkaik.json linking a hosted project and no ARKAIK_TOKEN in the environment\nWhen an agent session starts arkaik-mcp\nThen the server exits non-zero with an explicit token error and never answers tool calls from the repo's local bundle",
+        "values": [
+          "reduces-risk"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-sync-mirrors-not-authority",
+      "species": "acceptance",
+      "title": "Sync Mirrors, Never Overrides",
+      "description": "`arkaik sync` mirrors each external ref's live status into external_status/synced_at and appends one ref.status_changed event per change, while node.status is never touched and unchanged or unknown refs are left alone.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "toolchain",
+        "gherkin": "Given a node whose GitHub PR ref is mirrored as \"open\" and the PR has since merged\nWhen the user runs `arkaik sync` with a GitHub token in the environment\nThen the ref's external_status becomes \"merged\" with a fresh synced_at, exactly one ref.status_changed event is appended, and the node's own status field is unchanged",
+        "values": [
+          "integrates",
+          "reduces-effort"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-share-validated-history-private",
+      "species": "acceptance",
+      "title": "Share Validated, History Private",
+      "description": "`arkaik push` publishes a shareable snapshot URL straight from the terminal, but only after the full validation gate passes — and the journal is stripped by default, so history never leaves the repo unless explicitly included.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "toolchain",
+        "gherkin": "Given a valid repo bundle with a journal.jsonl sidecar\nWhen the user runs `arkaik push` without --include-journal\nThen the command validates first, POSTs a packed bundle containing no journal bytes, and prints the shareable URL with the one-time owner key — while an invalid bundle would print findings and send nothing",
+        "values": [
+          "connects",
+          "reduces-anxiety"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-hosted-token-never-on-disk",
+      "species": "acceptance",
+      "title": "Token Never Touches Disk",
+      "description": "`arkaik link` writes only the project id and instance origin to a commit-safe file; the access token is read from the environment at run time and is never written anywhere git could remember it.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "toolchain",
+        "gherkin": "Given ARKAIK_TOKEN exported in the shell\nWhen the user runs `arkaik link --project prj_123`\nThen docs/arkaik/arkaik.json contains only the project_id and remote origin, and the token string appears in no file the command wrote",
+        "values": [
+          "reduces-risk"
+        ]
+      },
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "AC-mcp-validated-dual-write",
+      "species": "acceptance",
+      "title": "Agents Write Validator-Gated",
+      "description": "Every mutating MCP tool applies the change in memory, runs the full validator, and only on success persists journal events plus the canonical snapshot — a rejected mutation returns pathed findings and writes nothing.",
+      "status": "live",
+      "platforms": [
+        "web"
+      ],
+      "metadata": {
+        "product": "toolchain",
+        "gherkin": "Given an agent session connected to arkaik-mcp over a repo bundle\nWhen the agent calls add_edge with a source/target pair the schema's edge semantics forbid\nThen the tool result is a refusal carrying the validator's pathed findings, and neither bundle.json nor journal.jsonl was modified — while a valid mutation appends its events and rewrites the snapshot canonically in the same call",
+        "values": [
+          "integrates",
+          "reduces-risk"
+        ]
+      },
+      "project_id": "arkaik-self-map"
     }
   ],
   "edges": [
@@ -250,74 +3900,11 @@
       "edge_type": "composes"
     },
     {
-      "id": "e-V-projects-API-local-list-projects",
-      "project_id": "arkaik-self-map",
-      "source_id": "V-projects",
-      "target_id": "API-local-list-projects",
-      "edge_type": "calls"
-    },
-    {
-      "id": "e-F-import-json-API-local-import-project",
-      "project_id": "arkaik-self-map",
-      "source_id": "F-import-json",
-      "target_id": "API-local-import-project",
-      "edge_type": "calls"
-    },
-    {
-      "id": "e-F-import-example-projects-API-local-import-project",
-      "project_id": "arkaik-self-map",
-      "source_id": "F-import-example-projects",
-      "target_id": "API-local-import-project",
-      "edge_type": "calls"
-    },
-    {
-      "id": "e-F-create-project-API-local-save-project",
-      "project_id": "arkaik-self-map",
-      "source_id": "F-create-project",
-      "target_id": "API-local-save-project",
-      "edge_type": "calls"
-    },
-    {
-      "id": "e-F-delete-project-API-local-archive-project",
-      "project_id": "arkaik-self-map",
-      "source_id": "F-delete-project",
-      "target_id": "API-local-archive-project",
-      "edge_type": "calls"
-    },
-    {
       "id": "e-V-projects-DM-project-bundle",
       "project_id": "arkaik-self-map",
       "source_id": "V-projects",
       "target_id": "DM-project-bundle",
       "edge_type": "displays"
-    },
-    {
-      "id": "e-API-local-list-projects-DM-project-bundle",
-      "project_id": "arkaik-self-map",
-      "source_id": "API-local-list-projects",
-      "target_id": "DM-project-bundle",
-      "edge_type": "queries"
-    },
-    {
-      "id": "e-API-local-save-project-DM-project-bundle",
-      "project_id": "arkaik-self-map",
-      "source_id": "API-local-save-project",
-      "target_id": "DM-project-bundle",
-      "edge_type": "queries"
-    },
-    {
-      "id": "e-API-local-archive-project-DM-project-bundle",
-      "project_id": "arkaik-self-map",
-      "source_id": "API-local-archive-project",
-      "target_id": "DM-project-bundle",
-      "edge_type": "queries"
-    },
-    {
-      "id": "e-API-local-import-project-DM-project-bundle",
-      "project_id": "arkaik-self-map",
-      "source_id": "API-local-import-project",
-      "target_id": "DM-project-bundle",
-      "edge_type": "queries"
     },
     {
       "id": "e-DEC-two-axes-stay-DM-project-bundle",
@@ -334,21 +3921,2589 @@
       "edge_type": "impacts"
     },
     {
-      "id": "e-DEC-migration-hard-cutover-API-local-save-project",
+      "id": "e-API-auth-nextauth-DM-users",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-auth-nextauth",
+      "target_id": "DM-users",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-auth-nextauth-DM-accounts",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-auth-nextauth",
+      "target_id": "DM-accounts",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-auth-nextauth-API-github",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-auth-nextauth",
+      "target_id": "API-github",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-API-post-github-webhook-DM-github-deliveries",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-post-github-webhook",
+      "target_id": "DM-github-deliveries",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-post-github-webhook-DM-project-repos",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-post-github-webhook",
+      "target_id": "DM-project-repos",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-post-github-webhook-DM-graph-projects",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-post-github-webhook",
+      "target_id": "DM-graph-projects",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-post-github-webhook-DM-graph-events",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-post-github-webhook",
+      "target_id": "DM-graph-events",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-post-github-webhook-API-github",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-post-github-webhook",
+      "target_id": "API-github",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-API-graph-projects-DM-graph-projects",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-graph-projects",
+      "target_id": "DM-graph-projects",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-graph-projects-DM-graph-events",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-graph-projects",
+      "target_id": "DM-graph-events",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-graph-projects-DM-users",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-graph-projects",
+      "target_id": "DM-users",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-graph-project-DM-graph-projects",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-graph-project",
+      "target_id": "DM-graph-projects",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-graph-project-DM-graph-events",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-graph-project",
+      "target_id": "DM-graph-events",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-get-graph-project-nodes-DM-graph-projects",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-get-graph-project-nodes",
+      "target_id": "DM-graph-projects",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-get-graph-project-edges-DM-graph-projects",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-get-graph-project-edges",
+      "target_id": "DM-graph-projects",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-get-graph-project-journal-DM-graph-events",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-get-graph-project-journal",
+      "target_id": "DM-graph-events",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-get-graph-project-export-DM-graph-projects",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-get-graph-project-export",
+      "target_id": "DM-graph-projects",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-get-graph-project-export-DM-graph-events",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-get-graph-project-export",
+      "target_id": "DM-graph-events",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-post-graph-project-mutations-DM-graph-projects",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-post-graph-project-mutations",
+      "target_id": "DM-graph-projects",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-post-graph-project-mutations-DM-graph-events",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-post-graph-project-mutations",
+      "target_id": "DM-graph-events",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-post-graph-project-mutations-DM-users",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-post-graph-project-mutations",
+      "target_id": "DM-users",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-graph-project-repos-DM-project-repos",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-graph-project-repos",
+      "target_id": "DM-project-repos",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-graph-project-repos-DM-graph-projects",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-graph-project-repos",
+      "target_id": "DM-graph-projects",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-post-publik-DM-publik-snapshots",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-post-publik",
+      "target_id": "DM-publik-snapshots",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-post-publik-DM-publik-rate-limits",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-post-publik",
+      "target_id": "DM-publik-rate-limits",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-publik-snapshot-DM-publik-snapshots",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-publik-snapshot",
+      "target_id": "DM-publik-snapshots",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-post-publik-report-DM-publik-snapshots",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-post-publik-report",
+      "target_id": "DM-publik-snapshots",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-post-publik-report-DM-publik-rate-limits",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-post-publik-report",
+      "target_id": "DM-publik-rate-limits",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-get-synk-projects-DM-synk-projects",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-get-synk-projects",
+      "target_id": "DM-synk-projects",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-get-synk-projects-DM-synk-backups",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-get-synk-projects",
+      "target_id": "DM-synk-backups",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-synk-project-DM-synk-projects",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-synk-project",
+      "target_id": "DM-synk-projects",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-synk-project-DM-synk-backups",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-synk-project",
+      "target_id": "DM-synk-backups",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-synk-project-DM-users",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-synk-project",
+      "target_id": "DM-users",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-get-synk-project-backups-DM-synk-backups",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-get-synk-project-backups",
+      "target_id": "DM-synk-backups",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-get-synk-project-backups-DM-synk-projects",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-get-synk-project-backups",
+      "target_id": "DM-synk-projects",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-get-synk-backup-DM-synk-backups",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-get-synk-backup",
+      "target_id": "DM-synk-backups",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-tokens-DM-api-tokens",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-tokens",
+      "target_id": "DM-api-tokens",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-tokens-DM-owners",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-tokens",
+      "target_id": "DM-owners",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-tokens-DM-owner-members",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-tokens",
+      "target_id": "DM-owner-members",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-delete-token-DM-api-tokens",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-delete-token",
+      "target_id": "DM-api-tokens",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-API-delete-token-DM-owner-members",
+      "project_id": "arkaik-self-map",
+      "source_id": "API-delete-token",
+      "target_id": "DM-owner-members",
+      "edge_type": "queries"
+    },
+    {
+      "id": "e-F-projects-routing-F-move-to-account",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-projects-routing",
+      "target_id": "F-move-to-account",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-create-project-V-create-project-dialog",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-create-project",
+      "target_id": "V-create-project-dialog",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-delete-project-V-projects",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-delete-project",
+      "target_id": "V-projects",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-move-to-account-V-projects",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-move-to-account",
+      "target_id": "V-projects",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-V-projects-API-graph-projects",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-projects",
+      "target_id": "API-graph-projects",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-projects-API-get-synk-projects",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-projects",
+      "target_id": "API-get-synk-projects",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-projects-API-get-auth-status",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-projects",
+      "target_id": "API-get-auth-status",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-F-create-project-API-graph-projects",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-create-project",
+      "target_id": "API-graph-projects",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-F-create-project-API-synk-project",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-create-project",
+      "target_id": "API-synk-project",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-F-move-to-account-API-graph-projects",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-move-to-account",
+      "target_id": "API-graph-projects",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-F-delete-project-API-graph-project",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-delete-project",
+      "target_id": "API-graph-project",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-projects-DM-project",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-projects",
+      "target_id": "DM-project",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-F-delete-project-V-project-settings",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-delete-project",
+      "target_id": "V-project-settings",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-browse-maps-V-maps-index",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-browse-maps",
+      "target_id": "V-maps-index",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-browse-maps-V-journey-map",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-browse-maps",
+      "target_id": "V-journey-map",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-browse-maps-V-system-map",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-browse-maps",
+      "target_id": "V-system-map",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-create-custom-map-V-maps-index",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-create-custom-map",
+      "target_id": "V-maps-index",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-create-custom-map-V-map-editor-dialog",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-create-custom-map",
+      "target_id": "V-map-editor-dialog",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-adjust-map-display-V-journey-map",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-adjust-map-display",
+      "target_id": "V-journey-map",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-adjust-map-display-V-system-map",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-adjust-map-display",
+      "target_id": "V-system-map",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-adjust-map-display-V-map-display-popover",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-adjust-map-display",
+      "target_id": "V-map-display-popover",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-edit-graph-on-canvas-V-journey-map",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-edit-graph-on-canvas",
+      "target_id": "V-journey-map",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-edit-graph-on-canvas-V-system-map",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-edit-graph-on-canvas",
+      "target_id": "V-system-map",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-navigate-by-keyboard-V-command-palette",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-navigate-by-keyboard",
+      "target_id": "V-command-palette",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-navigate-by-keyboard-V-keyboard-shortcuts-dialog",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-navigate-by-keyboard",
+      "target_id": "V-keyboard-shortcuts-dialog",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-V-maps-index-API-graph-project",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-maps-index",
+      "target_id": "API-graph-project",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-maps-index-API-get-graph-project-nodes",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-maps-index",
+      "target_id": "API-get-graph-project-nodes",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-maps-index-API-get-graph-project-edges",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-maps-index",
+      "target_id": "API-get-graph-project-edges",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-journey-map-API-get-graph-project-nodes",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-journey-map",
+      "target_id": "API-get-graph-project-nodes",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-journey-map-API-get-graph-project-edges",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-journey-map",
+      "target_id": "API-get-graph-project-edges",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-journey-map-API-get-graph-project-journal",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-journey-map",
+      "target_id": "API-get-graph-project-journal",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-journey-map-API-post-graph-project-mutations",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-journey-map",
+      "target_id": "API-post-graph-project-mutations",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-system-map-API-get-graph-project-nodes",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-system-map",
+      "target_id": "API-get-graph-project-nodes",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-system-map-API-get-graph-project-edges",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-system-map",
+      "target_id": "API-get-graph-project-edges",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-system-map-API-get-graph-project-journal",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-system-map",
+      "target_id": "API-get-graph-project-journal",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-system-map-API-post-graph-project-mutations",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-system-map",
+      "target_id": "API-post-graph-project-mutations",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-maps-index-DM-map-definition",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-maps-index",
+      "target_id": "DM-map-definition",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-V-journey-map-DM-node",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-journey-map",
+      "target_id": "DM-node",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-V-journey-map-DM-edge",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-journey-map",
+      "target_id": "DM-edge",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-V-system-map-DM-node",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-system-map",
+      "target_id": "DM-node",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-V-system-map-DM-edge",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-system-map",
+      "target_id": "DM-edge",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-V-map-editor-dialog-DM-map-definition",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-map-editor-dialog",
+      "target_id": "DM-map-definition",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-V-map-editor-dialog-DM-node",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-map-editor-dialog",
+      "target_id": "DM-node",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-V-map-display-popover-DM-map-definition",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-map-display-popover",
+      "target_id": "DM-map-definition",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-V-journey-map-API-graph-project",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-journey-map",
+      "target_id": "API-graph-project",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-system-map-API-graph-project",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-system-map",
+      "target_id": "API-graph-project",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-F-edit-node-details-V-node-detail-panel",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-edit-node-details",
+      "target_id": "V-node-detail-panel",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-edit-node-details-F-edit-flow-playlist",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-edit-node-details",
+      "target_id": "F-edit-flow-playlist",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-edit-node-details-F-edit-acceptance",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-edit-node-details",
+      "target_id": "F-edit-acceptance",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-edit-flow-playlist-V-node-detail-panel",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-edit-flow-playlist",
+      "target_id": "V-node-detail-panel",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-edit-acceptance-V-node-detail-panel",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-edit-acceptance",
+      "target_id": "V-node-detail-panel",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-browse-library-V-library",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-browse-library",
+      "target_id": "V-library",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-browse-library-F-edit-node-details",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-browse-library",
+      "target_id": "F-edit-node-details",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-audit-value-coverage-V-overview",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-audit-value-coverage",
+      "target_id": "V-overview",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-audit-value-coverage-V-pyramid",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-audit-value-coverage",
+      "target_id": "V-pyramid",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-audit-value-coverage-V-acceptances-matrix",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-audit-value-coverage",
+      "target_id": "V-acceptances-matrix",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-audit-value-coverage-F-edit-acceptance",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-audit-value-coverage",
+      "target_id": "F-edit-acceptance",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-edit-raw-bundle-V-raw-bundle-panel",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-edit-raw-bundle",
+      "target_id": "V-raw-bundle-panel",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-V-library-API-get-graph-project-nodes",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-library",
+      "target_id": "API-get-graph-project-nodes",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-library-API-get-graph-project-edges",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-library",
+      "target_id": "API-get-graph-project-edges",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-library-API-get-graph-project-journal",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-library",
+      "target_id": "API-get-graph-project-journal",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-overview-API-get-graph-project-nodes",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-overview",
+      "target_id": "API-get-graph-project-nodes",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-overview-API-get-graph-project-edges",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-overview",
+      "target_id": "API-get-graph-project-edges",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-overview-API-get-graph-project-journal",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-overview",
+      "target_id": "API-get-graph-project-journal",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-pyramid-API-get-graph-project-nodes",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-pyramid",
+      "target_id": "API-get-graph-project-nodes",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-pyramid-API-get-graph-project-edges",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-pyramid",
+      "target_id": "API-get-graph-project-edges",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-acceptances-matrix-API-get-graph-project-nodes",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-acceptances-matrix",
+      "target_id": "API-get-graph-project-nodes",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-acceptances-matrix-API-get-graph-project-edges",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-acceptances-matrix",
+      "target_id": "API-get-graph-project-edges",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-acceptances-matrix-API-get-graph-project-journal",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-acceptances-matrix",
+      "target_id": "API-get-graph-project-journal",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-acceptances-matrix-API-post-graph-project-mutations",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-acceptances-matrix",
+      "target_id": "API-post-graph-project-mutations",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-node-detail-panel-API-post-graph-project-mutations",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-node-detail-panel",
+      "target_id": "API-post-graph-project-mutations",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-F-browse-library-API-post-graph-project-mutations",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-browse-library",
+      "target_id": "API-post-graph-project-mutations",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-raw-bundle-panel-API-get-graph-project-export",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-raw-bundle-panel",
+      "target_id": "API-get-graph-project-export",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-raw-bundle-panel-API-graph-projects",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-raw-bundle-panel",
+      "target_id": "API-graph-projects",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-node-detail-panel-DM-node",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-node-detail-panel",
+      "target_id": "DM-node",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-V-node-detail-panel-DM-edge",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-node-detail-panel",
+      "target_id": "DM-edge",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-V-node-detail-panel-DM-journal-event",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-node-detail-panel",
+      "target_id": "DM-journal-event",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-V-library-DM-node",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-library",
+      "target_id": "DM-node",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-V-library-DM-product",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-library",
+      "target_id": "DM-product",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-V-overview-DM-node",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-overview",
+      "target_id": "DM-node",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-V-overview-DM-journal-event",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-overview",
+      "target_id": "DM-journal-event",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-V-overview-DM-map-definition",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-overview",
+      "target_id": "DM-map-definition",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-V-pyramid-DM-node",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-pyramid",
+      "target_id": "DM-node",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-V-acceptances-matrix-DM-node",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-acceptances-matrix",
+      "target_id": "DM-node",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-V-acceptances-matrix-DM-edge",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-acceptances-matrix",
+      "target_id": "DM-edge",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-V-raw-bundle-panel-DM-project-bundle",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-raw-bundle-panel",
+      "target_id": "DM-project-bundle",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-F-review-changelog-V-changelog",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-review-changelog",
+      "target_id": "V-changelog",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-review-changelog-V-decision-editor",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-review-changelog",
+      "target_id": "V-decision-editor",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-audit-history-V-history",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-audit-history",
+      "target_id": "V-history",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-log-decision-V-decision-log",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-log-decision",
+      "target_id": "V-decision-log",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-log-decision-V-decision-editor",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-log-decision",
+      "target_id": "V-decision-editor",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-track-delivery-V-delivery-board",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-track-delivery",
+      "target_id": "V-delivery-board",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-V-changelog-V-decision-log",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-changelog",
+      "target_id": "V-decision-log",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-V-decision-log-V-decision-editor",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-decision-log",
+      "target_id": "V-decision-editor",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-V-changelog-API-get-graph-project-journal",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-changelog",
+      "target_id": "API-get-graph-project-journal",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-changelog-API-get-graph-project-nodes",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-changelog",
+      "target_id": "API-get-graph-project-nodes",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-history-API-get-graph-project-journal",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-history",
+      "target_id": "API-get-graph-project-journal",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-history-API-get-graph-project-nodes",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-history",
+      "target_id": "API-get-graph-project-nodes",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-decision-log-API-get-graph-project-nodes",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-decision-log",
+      "target_id": "API-get-graph-project-nodes",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-decision-log-API-get-graph-project-edges",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-decision-log",
+      "target_id": "API-get-graph-project-edges",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-decision-log-API-get-graph-project-journal",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-decision-log",
+      "target_id": "API-get-graph-project-journal",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-decision-log-API-post-graph-project-mutations",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-decision-log",
+      "target_id": "API-post-graph-project-mutations",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-decision-editor-API-post-graph-project-mutations",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-decision-editor",
+      "target_id": "API-post-graph-project-mutations",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-delivery-board-API-get-graph-project-nodes",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-delivery-board",
+      "target_id": "API-get-graph-project-nodes",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-delivery-board-API-get-graph-project-edges",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-delivery-board",
+      "target_id": "API-get-graph-project-edges",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-delivery-board-API-get-graph-project-journal",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-delivery-board",
+      "target_id": "API-get-graph-project-journal",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-delivery-board-API-post-graph-project-mutations",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-delivery-board",
+      "target_id": "API-post-graph-project-mutations",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-changelog-DM-journal-event",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-changelog",
+      "target_id": "DM-journal-event",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-V-changelog-DM-deliverable",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-changelog",
+      "target_id": "DM-deliverable",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-V-history-DM-journal-event",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-history",
+      "target_id": "DM-journal-event",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-V-decision-log-DM-node",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-decision-log",
+      "target_id": "DM-node",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-V-decision-editor-DM-node",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-decision-editor",
+      "target_id": "DM-node",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-V-delivery-board-DM-node",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-delivery-board",
+      "target_id": "DM-node",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-F-publish-to-publik-V-publik-publish-dialog",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-publish-to-publik",
+      "target_id": "V-publik-publish-dialog",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-publish-to-publik-V-publik-snapshot",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-publish-to-publik",
+      "target_id": "V-publik-snapshot",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-sign-in-V-account-menu",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-sign-in",
+      "target_id": "V-account-menu",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-synk-backup-restore-V-synk-onboarding-banner",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-synk-backup-restore",
+      "target_id": "V-synk-onboarding-banner",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-synk-backup-restore-V-synk-restore-dialog",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-synk-backup-restore",
+      "target_id": "V-synk-restore-dialog",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-generate-with-ai-V-generate-prompt",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-generate-with-ai",
+      "target_id": "V-generate-prompt",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-V-account-menu-V-agent-tokens",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-account-menu",
+      "target_id": "V-agent-tokens",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-V-publik-publish-dialog-API-post-publik",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-publik-publish-dialog",
+      "target_id": "API-post-publik",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-publik-snapshot-API-publik-snapshot",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-publik-snapshot",
+      "target_id": "API-publik-snapshot",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-synk-restore-dialog-API-get-synk-projects",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-synk-restore-dialog",
+      "target_id": "API-get-synk-projects",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-synk-restore-dialog-API-get-synk-project-backups",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-synk-restore-dialog",
+      "target_id": "API-get-synk-project-backups",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-synk-restore-dialog-API-get-synk-backup",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-synk-restore-dialog",
+      "target_id": "API-get-synk-backup",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-synk-onboarding-banner-API-synk-project",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-synk-onboarding-banner",
+      "target_id": "API-synk-project",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-account-menu-API-get-auth-status",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-account-menu",
+      "target_id": "API-get-auth-status",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-F-sign-in-API-auth-nextauth",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-sign-in",
+      "target_id": "API-auth-nextauth",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-agent-tokens-API-tokens",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-agent-tokens",
+      "target_id": "API-tokens",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-agent-tokens-API-delete-token",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-agent-tokens",
+      "target_id": "API-delete-token",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-publik-snapshot-DM-publik-snapshots",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-publik-snapshot",
+      "target_id": "DM-publik-snapshots",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-V-synk-restore-dialog-DM-synk-projects",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-synk-restore-dialog",
+      "target_id": "DM-synk-projects",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-V-synk-restore-dialog-DM-synk-backups",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-synk-restore-dialog",
+      "target_id": "DM-synk-backups",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-V-agent-tokens-DM-api-tokens",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-agent-tokens",
+      "target_id": "DM-api-tokens",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-V-account-menu-DM-users",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-account-menu",
+      "target_id": "DM-users",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-F-generate-with-ai-F-import-json",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-generate-with-ai",
+      "target_id": "F-import-json",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-import-json-V-projects",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-import-json",
+      "target_id": "V-projects",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-export-bundle-V-raw-bundle-panel",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-export-bundle",
+      "target_id": "V-raw-bundle-panel",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-explore-sandbox-V-projects",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-explore-sandbox",
+      "target_id": "V-projects",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-explore-sandbox-V-sandbox-notice",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-explore-sandbox",
+      "target_id": "V-sandbox-notice",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-explore-sandbox-F-import-json",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-explore-sandbox",
+      "target_id": "F-import-json",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-browse-docs-V-docs-site",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-browse-docs",
+      "target_id": "V-docs-site",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-export-bundle-API-get-graph-project-export",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-export-bundle",
+      "target_id": "API-get-graph-project-export",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-F-init-repo-V-cli-terminal",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-init-repo",
+      "target_id": "V-cli-terminal",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-init-repo-V-arkaik-skill",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-init-repo",
+      "target_id": "V-arkaik-skill",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-validate-bundle-V-cli-terminal",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-validate-bundle",
+      "target_id": "V-cli-terminal",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-journal-release-V-cli-terminal",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-journal-release",
+      "target_id": "V-cli-terminal",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-sync-refs-V-cli-terminal",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-sync-refs",
+      "target_id": "V-cli-terminal",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-share-map-V-cli-terminal",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-share-map",
+      "target_id": "V-cli-terminal",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-link-hosted-V-cli-terminal",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-link-hosted",
+      "target_id": "V-cli-terminal",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-mcp-agent-session-V-mcp-tool-catalog",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-mcp-agent-session",
+      "target_id": "V-mcp-tool-catalog",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-mcp-agent-session-F-link-hosted",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-mcp-agent-session",
+      "target_id": "F-link-hosted",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-V-arkaik-skill-F-validate-bundle",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-arkaik-skill",
+      "target_id": "F-validate-bundle",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-sync-refs-API-github",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-sync-refs",
+      "target_id": "API-github",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-F-share-map-API-post-publik",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-share-map",
+      "target_id": "API-post-publik",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-F-share-map-API-publik-snapshot",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-share-map",
+      "target_id": "API-publik-snapshot",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-F-link-hosted-API-graph-projects",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-link-hosted",
+      "target_id": "API-graph-projects",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-F-link-hosted-API-graph-project",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-link-hosted",
+      "target_id": "API-graph-project",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-F-mcp-agent-session-API-graph-project",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-mcp-agent-session",
+      "target_id": "API-graph-project",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-F-mcp-agent-session-API-get-graph-project-journal",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-mcp-agent-session",
+      "target_id": "API-get-graph-project-journal",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-F-mcp-agent-session-API-post-graph-project-mutations",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-mcp-agent-session",
+      "target_id": "API-post-graph-project-mutations",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-cli-terminal-DM-project-bundle",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-cli-terminal",
+      "target_id": "DM-project-bundle",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-V-cli-terminal-DM-journal-event",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-cli-terminal",
+      "target_id": "DM-journal-event",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-V-mcp-tool-catalog-DM-project-bundle",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-mcp-tool-catalog",
+      "target_id": "DM-project-bundle",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-V-project-settings-API-graph-project-repos",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-project-settings",
+      "target_id": "API-graph-project-repos",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-project-settings-API-graph-project",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-project-settings",
+      "target_id": "API-graph-project",
+      "edge_type": "calls"
+    },
+    {
+      "id": "e-V-project-settings-DM-project-repos",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-project-settings",
+      "target_id": "DM-project-repos",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-V-project-settings-DM-product",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-project-settings",
+      "target_id": "DM-product",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-V-landing-V-projects",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-landing",
+      "target_id": "V-projects",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-F-manage-products-V-project-settings",
+      "project_id": "arkaik-self-map",
+      "source_id": "F-manage-products",
+      "target_id": "V-project-settings",
+      "edge_type": "composes"
+    },
+    {
+      "id": "e-V-projects-DM-projects",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-projects",
+      "target_id": "DM-projects",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-V-history-DM-journals",
+      "project_id": "arkaik-self-map",
+      "source_id": "V-history",
+      "target_id": "DM-journals",
+      "edge_type": "displays"
+    },
+    {
+      "id": "e-DEC-migration-hard-cutover-DM-project-bundle",
       "project_id": "arkaik-self-map",
       "source_id": "DEC-migration-hard-cutover",
-      "target_id": "API-local-save-project",
+      "target_id": "DM-project-bundle",
       "edge_type": "impacts"
     },
     {
-      "id": "e-DEC-migration-hard-cutover-API-local-import-project",
+      "id": "e-AC-sections-mirror-project-homes-V-projects",
       "project_id": "arkaik-self-map",
-      "source_id": "DEC-migration-hard-cutover",
-      "target_id": "API-local-import-project",
-      "edge_type": "impacts"
+      "source_id": "AC-sections-mirror-project-homes",
+      "target_id": "V-projects",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-delete-behind-confirmation-V-project-settings",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-delete-behind-confirmation",
+      "target_id": "V-project-settings",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-delete-behind-confirmation-F-delete-project",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-delete-behind-confirmation",
+      "target_id": "F-delete-project",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-public-map-undeletable-V-project-settings",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-public-map-undeletable",
+      "target_id": "V-project-settings",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-public-map-undeletable-F-delete-project",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-public-map-undeletable",
+      "target_id": "F-delete-project",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-example-projects-one-click-V-projects",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-example-projects-one-click",
+      "target_id": "V-projects",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-example-projects-one-click-F-import-example-projects",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-example-projects-one-click",
+      "target_id": "F-import-example-projects",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-signed-in-skips-landing-V-landing",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-signed-in-skips-landing",
+      "target_id": "V-landing",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-signed-in-skips-landing-F-projects-routing",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-signed-in-skips-landing",
+      "target_id": "F-projects-routing",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-create-lands-in-chosen-home-V-create-project-dialog",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-create-lands-in-chosen-home",
+      "target_id": "V-create-project-dialog",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-create-lands-in-chosen-home-F-create-project",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-create-lands-in-chosen-home",
+      "target_id": "F-create-project",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-sign-in-adds-never-rearranges-V-projects",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-sign-in-adds-never-rearranges",
+      "target_id": "V-projects",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-move-to-account-copies-V-projects",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-move-to-account-copies",
+      "target_id": "V-projects",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-products-named-in-settings-V-project-settings",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-products-named-in-settings",
+      "target_id": "V-project-settings",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-products-named-in-settings-F-manage-products",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-products-named-in-settings",
+      "target_id": "F-manage-products",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-honest-map-counts-V-maps-index",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-honest-map-counts",
+      "target_id": "V-maps-index",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-honest-map-counts-F-browse-maps",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-honest-map-counts",
+      "target_id": "F-browse-maps",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-drill-down-in-place-V-journey-map",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-drill-down-in-place",
+      "target_id": "V-journey-map",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-drill-down-in-place-F-browse-maps",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-drill-down-in-place",
+      "target_id": "F-browse-maps",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-scoped-journey-never-lies-V-journey-map",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-scoped-journey-never-lies",
+      "target_id": "V-journey-map",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-display-persists-per-map-V-map-display-popover",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-display-persists-per-map",
+      "target_id": "V-map-display-popover",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-display-persists-per-map-F-adjust-map-display",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-display-persists-per-map",
+      "target_id": "F-adjust-map-display",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-no-cyclic-playlists-V-journey-map",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-no-cyclic-playlists",
+      "target_id": "V-journey-map",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-no-cyclic-playlists-F-edit-graph-on-canvas",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-no-cyclic-playlists",
+      "target_id": "F-edit-graph-on-canvas",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-valid-edge-types-only-F-edit-graph-on-canvas",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-valid-edge-types-only",
+      "target_id": "F-edit-graph-on-canvas",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-delete-asks-first-F-edit-graph-on-canvas",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-delete-asks-first",
+      "target_id": "F-edit-graph-on-canvas",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-insert-between-steps-V-journey-map",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-insert-between-steps",
+      "target_id": "V-journey-map",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-insert-between-steps-F-edit-graph-on-canvas",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-insert-between-steps",
+      "target_id": "F-edit-graph-on-canvas",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-custom-map-as-data-V-map-editor-dialog",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-custom-map-as-data",
+      "target_id": "V-map-editor-dialog",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-custom-map-as-data-F-create-custom-map",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-custom-map-as-data",
+      "target_id": "F-create-custom-map",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-palette-jump-anywhere-V-command-palette",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-palette-jump-anywhere",
+      "target_id": "V-command-palette",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-palette-jump-anywhere-F-navigate-by-keyboard",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-palette-jump-anywhere",
+      "target_id": "F-navigate-by-keyboard",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-shortcuts-no-dead-keys-V-keyboard-shortcuts-dialog",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-shortcuts-no-dead-keys",
+      "target_id": "V-keyboard-shortcuts-dialog",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-shortcuts-no-dead-keys-F-navigate-by-keyboard",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-shortcuts-no-dead-keys",
+      "target_id": "F-navigate-by-keyboard",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-viewport-stays-put-V-system-map",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-viewport-stays-put",
+      "target_id": "V-system-map",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-viewport-stays-put-V-journey-map",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-viewport-stays-put",
+      "target_id": "V-journey-map",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-spotlight-neighborhood-V-system-map",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-spotlight-neighborhood",
+      "target_id": "V-system-map",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-system-two-renditions-V-system-map",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-system-two-renditions",
+      "target_id": "V-system-map",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-details-autosave-on-pause-V-node-detail-panel",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-details-autosave-on-pause",
+      "target_id": "V-node-detail-panel",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-details-autosave-on-pause-F-edit-node-details",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-details-autosave-on-pause",
+      "target_id": "F-edit-node-details",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-playlist-cycle-blocked-F-edit-flow-playlist",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-playlist-cycle-blocked",
+      "target_id": "F-edit-flow-playlist",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-playlist-branching-entries-F-edit-flow-playlist",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-playlist-branching-entries",
+      "target_id": "F-edit-flow-playlist",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-playlist-branching-entries-V-node-detail-panel",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-playlist-branching-entries",
+      "target_id": "V-node-detail-panel",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-raw-edits-validated-V-raw-bundle-panel",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-raw-edits-validated",
+      "target_id": "V-raw-bundle-panel",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-raw-edits-validated-F-edit-raw-bundle",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-raw-edits-validated",
+      "target_id": "F-edit-raw-bundle",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-raw-format-switch-roundtrips-V-raw-bundle-panel",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-raw-format-switch-roundtrips",
+      "target_id": "V-raw-bundle-panel",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-raw-close-guard-V-raw-bundle-panel",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-raw-close-guard",
+      "target_id": "V-raw-bundle-panel",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-raw-close-guard-F-edit-raw-bundle",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-raw-close-guard",
+      "target_id": "F-edit-raw-bundle",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-acceptance-how-why-inline-F-edit-acceptance",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-acceptance-how-why-inline",
+      "target_id": "F-edit-acceptance",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-acceptance-how-why-inline-V-node-detail-panel",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-acceptance-how-why-inline",
+      "target_id": "V-node-detail-panel",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-split-carries-context-F-edit-acceptance",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-split-carries-context",
+      "target_id": "F-edit-acceptance",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-parity-gap-at-a-glance-V-acceptances-matrix",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-parity-gap-at-a-glance",
+      "target_id": "V-acceptances-matrix",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-parity-gap-at-a-glance-F-edit-acceptance",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-parity-gap-at-a-glance",
+      "target_id": "F-edit-acceptance",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-matrix-groups-by-anchor-V-acceptances-matrix",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-matrix-groups-by-anchor",
+      "target_id": "V-acceptances-matrix",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-pyramid-coverage-glance-V-pyramid",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-pyramid-coverage-glance",
+      "target_id": "V-pyramid",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-pyramid-coverage-glance-F-audit-value-coverage",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-pyramid-coverage-glance",
+      "target_id": "F-audit-value-coverage",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-pyramid-gap-filter-V-pyramid",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-pyramid-gap-filter",
+      "target_id": "V-pyramid",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-pyramid-gap-filter-F-audit-value-coverage",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-pyramid-gap-filter",
+      "target_id": "F-audit-value-coverage",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-library-bulk-move-honest-V-library",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-library-bulk-move-honest",
+      "target_id": "V-library",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-library-bulk-move-honest-F-browse-library",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-library-bulk-move-honest",
+      "target_id": "F-browse-library",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-overview-health-indicators-V-overview",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-overview-health-indicators",
+      "target_id": "V-overview",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-history-never-rewritten-V-history",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-history-never-rewritten",
+      "target_id": "V-history",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-history-never-rewritten-F-audit-history",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-history-never-rewritten",
+      "target_id": "F-audit-history",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-history-family-filter-V-history",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-history-family-filter",
+      "target_id": "V-history",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-history-family-filter-F-audit-history",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-history-family-filter",
+      "target_id": "F-audit-history",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-changelog-design-delivery-split-V-changelog",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-changelog-design-delivery-split",
+      "target_id": "V-changelog",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-changelog-design-delivery-split-F-review-changelog",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-changelog-design-delivery-split",
+      "target_id": "F-review-changelog",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-deliverable-anchored-first-ship-V-changelog",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-deliverable-anchored-first-ship",
+      "target_id": "V-changelog",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-deliverable-anchored-first-ship-F-review-changelog",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-deliverable-anchored-first-ship",
+      "target_id": "F-review-changelog",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-unreleased-work-visible-V-changelog",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-unreleased-work-visible",
+      "target_id": "V-changelog",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-unreleased-work-visible-F-track-delivery",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-unreleased-work-visible",
+      "target_id": "F-track-delivery",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-decision-keeps-why-how-V-decision-editor",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-decision-keeps-why-how",
+      "target_id": "V-decision-editor",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-decision-keeps-why-how-F-log-decision",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-decision-keeps-why-how",
+      "target_id": "F-log-decision",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-decision-edits-autosave-V-decision-editor",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-decision-edits-autosave",
+      "target_id": "V-decision-editor",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-superseded-chain-traceable-V-decision-log",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-superseded-chain-traceable",
+      "target_id": "V-decision-log",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-superseded-chain-traceable-F-log-decision",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-superseded-chain-traceable",
+      "target_id": "F-log-decision",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-decision-status-filter-V-decision-log",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-decision-status-filter",
+      "target_id": "V-decision-log",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-board-mirrors-lifecycle-V-delivery-board",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-board-mirrors-lifecycle",
+      "target_id": "V-delivery-board",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-board-mirrors-lifecycle-F-track-delivery",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-board-mirrors-lifecycle",
+      "target_id": "F-track-delivery",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-board-item-per-platform-V-delivery-board",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-board-item-per-platform",
+      "target_id": "V-delivery-board",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-board-item-per-platform-F-track-delivery",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-board-item-per-platform",
+      "target_id": "F-track-delivery",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-empty-journal-calm-V-changelog",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-empty-journal-calm",
+      "target_id": "V-changelog",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-empty-journal-calm-V-history",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-empty-journal-calm",
+      "target_id": "V-history",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-publish-never-leaks-journal-F-publish-to-publik",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-publish-never-leaks-journal",
+      "target_id": "F-publish-to-publik",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-publish-never-leaks-journal-V-publik-publish-dialog",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-publish-never-leaks-journal",
+      "target_id": "V-publik-publish-dialog",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-owner-key-shown-once-V-publik-publish-dialog",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-owner-key-shown-once",
+      "target_id": "V-publik-publish-dialog",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-snapshot-delete-needs-key-F-publish-to-publik",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-snapshot-delete-needs-key",
+      "target_id": "F-publish-to-publik",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-publish-without-account-F-publish-to-publik",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-publish-without-account",
+      "target_id": "F-publish-to-publik",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-snapshot-imports-as-copy-V-publik-snapshot",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-snapshot-imports-as-copy",
+      "target_id": "V-publik-snapshot",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-backups-run-themselves-F-synk-backup-restore",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-backups-run-themselves",
+      "target_id": "F-synk-backup-restore",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-backups-dedupe-by-content-F-synk-backup-restore",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-backups-dedupe-by-content",
+      "target_id": "F-synk-backup-restore",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-backup-failure-loses-nothing-F-synk-backup-restore",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-backup-failure-loses-nothing",
+      "target_id": "F-synk-backup-restore",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-restore-never-overwrites-V-synk-restore-dialog",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-restore-never-overwrites",
+      "target_id": "V-synk-restore-dialog",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-restore-never-overwrites-F-synk-backup-restore",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-restore-never-overwrites",
+      "target_id": "F-synk-backup-restore",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-one-click-backup-offer-V-synk-onboarding-banner",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-one-click-backup-offer",
+      "target_id": "V-synk-onboarding-banner",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-move-keeps-local-copy-F-move-to-account",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-move-keeps-local-copy",
+      "target_id": "F-move-to-account",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-agent-token-shown-once-V-agent-tokens",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-agent-token-shown-once",
+      "target_id": "V-agent-tokens",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-signin-never-gates-local-F-sign-in",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-signin-never-gates-local",
+      "target_id": "F-sign-in",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-signin-never-gates-local-V-account-menu",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-signin-never-gates-local",
+      "target_id": "V-account-menu",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-prompt-for-any-llm-V-generate-prompt",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-prompt-for-any-llm",
+      "target_id": "V-generate-prompt",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-prompt-for-any-llm-F-generate-with-ai",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-prompt-for-any-llm",
+      "target_id": "F-generate-with-ai",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-legacy-bundle-migrates-F-import-json",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-legacy-bundle-migrates",
+      "target_id": "F-import-json",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-broken-import-explains-F-import-json",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-broken-import-explains",
+      "target_id": "F-import-json",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-reserved-ids-stay-reserved-F-import-json",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-reserved-ids-stay-reserved",
+      "target_id": "F-import-json",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-export-full-bundle-F-export-bundle",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-export-full-bundle",
+      "target_id": "F-export-bundle",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-export-reimports-cleanly-F-export-bundle",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-export-reimports-cleanly",
+      "target_id": "F-export-bundle",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-export-reimports-cleanly-F-import-json",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-export-reimports-cleanly",
+      "target_id": "F-import-json",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-sandbox-resets-pristine-F-explore-sandbox",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-sandbox-resets-pristine",
+      "target_id": "F-explore-sandbox",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-sandbox-edits-are-real-F-explore-sandbox",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-sandbox-edits-are-real",
+      "target_id": "F-explore-sandbox",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-sandbox-rules-stated-plainly-V-sandbox-notice",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-sandbox-rules-stated-plainly",
+      "target_id": "V-sandbox-notice",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-docs-live-in-app-F-browse-docs",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-docs-live-in-app",
+      "target_id": "F-browse-docs",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-docs-live-in-app-V-docs-site",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-docs-live-in-app",
+      "target_id": "V-docs-site",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-one-command-repo-setup-F-init-repo",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-one-command-repo-setup",
+      "target_id": "F-init-repo",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-one-command-repo-setup-V-cli-terminal",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-one-command-repo-setup",
+      "target_id": "V-cli-terminal",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-init-rerun-never-clobbers-F-init-repo",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-init-rerun-never-clobbers",
+      "target_id": "F-init-repo",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-one-skill-doctrine-everywhere-V-arkaik-skill",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-one-skill-doctrine-everywhere",
+      "target_id": "V-arkaik-skill",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-one-skill-doctrine-everywhere-F-init-repo",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-one-skill-doctrine-everywhere",
+      "target_id": "F-init-repo",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-validator-blocks-broken-bundle-F-validate-bundle",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-validator-blocks-broken-bundle",
+      "target_id": "F-validate-bundle",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-validator-blocks-broken-bundle-V-cli-terminal",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-validator-blocks-broken-bundle",
+      "target_id": "V-cli-terminal",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-bad-line-cannot-corrupt-history-F-validate-bundle",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-bad-line-cannot-corrupt-history",
+      "target_id": "F-validate-bundle",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-bad-line-cannot-corrupt-history-F-journal-release",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-bad-line-cannot-corrupt-history",
+      "target_id": "F-journal-release",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-parallel-appends-merge-clean-F-init-repo",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-parallel-appends-merge-clean",
+      "target_id": "F-init-repo",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-parallel-appends-merge-clean-F-journal-release",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-parallel-appends-merge-clean",
+      "target_id": "F-journal-release",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-release-notes-draft-themselves-F-journal-release",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-release-notes-draft-themselves",
+      "target_id": "F-journal-release",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-release-notes-draft-themselves-V-cli-terminal",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-release-notes-draft-themselves",
+      "target_id": "V-cli-terminal",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-linked-repo-fails-loud-F-link-hosted",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-linked-repo-fails-loud",
+      "target_id": "F-link-hosted",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-linked-repo-fails-loud-F-mcp-agent-session",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-linked-repo-fails-loud",
+      "target_id": "F-mcp-agent-session",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-sync-mirrors-not-authority-F-sync-refs",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-sync-mirrors-not-authority",
+      "target_id": "F-sync-refs",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-share-validated-history-private-F-share-map",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-share-validated-history-private",
+      "target_id": "F-share-map",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-share-validated-history-private-V-cli-terminal",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-share-validated-history-private",
+      "target_id": "V-cli-terminal",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-hosted-token-never-on-disk-F-link-hosted",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-hosted-token-never-on-disk",
+      "target_id": "F-link-hosted",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-mcp-validated-dual-write-F-mcp-agent-session",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-mcp-validated-dual-write",
+      "target_id": "F-mcp-agent-session",
+      "edge_type": "covers"
+    },
+    {
+      "id": "e-AC-mcp-validated-dual-write-V-mcp-tool-catalog",
+      "project_id": "arkaik-self-map",
+      "source_id": "AC-mcp-validated-dual-write",
+      "target_id": "V-mcp-tool-catalog",
+      "edge_type": "covers"
     }
   ],
   "journal": [
+    {
+      "id": "012603191945460000000054",
+      "ts": "2026-03-19T19:45:46Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-journey-map",
+      "species": "view",
+      "title": "Journey Map Canvas"
+    },
+    {
+      "id": "012603191945460000000127",
+      "ts": "2026-03-19T19:45:46Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-scoped-journey-never-lies",
+      "species": "acceptance",
+      "title": "Scoped journey never lies"
+    },
+    {
+      "id": "012603192048160000000005",
+      "ts": "2026-03-19T20:48:16Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-project",
+      "species": "data-model",
+      "title": "Project"
+    },
+    {
+      "id": "012603192048160000000006",
+      "ts": "2026-03-19T20:48:16Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-node",
+      "species": "data-model",
+      "title": "Node"
+    },
+    {
+      "id": "012603192048160000000007",
+      "ts": "2026-03-19T20:48:16Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-edge",
+      "species": "data-model",
+      "title": "Edge"
+    },
+    {
+      "id": "012603201834580000000065",
+      "ts": "2026-03-20T18:34:58Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-node-detail-panel",
+      "species": "view",
+      "title": "Node Detail Panel"
+    },
+    {
+      "id": "012603201852510000000071",
+      "ts": "2026-03-20T18:52:51Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-edit-node-details",
+      "species": "flow",
+      "title": "Edit Node Details"
+    },
+    {
+      "id": "012603201852510000000139",
+      "ts": "2026-03-20T18:52:51Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-details-autosave-on-pause",
+      "species": "acceptance",
+      "title": "Detail edits autosave"
+    },
+    {
+      "id": "012603202011020000000063",
+      "ts": "2026-03-20T20:11:02Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-edit-graph-on-canvas",
+      "species": "flow",
+      "title": "Edit Graph On Canvas"
+    },
+    {
+      "id": "012603202011020000000129",
+      "ts": "2026-03-20T20:11:02Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-no-cyclic-playlists",
+      "species": "acceptance",
+      "title": "No circular playlists"
+    },
+    {
+      "id": "012603202011020000000130",
+      "ts": "2026-03-20T20:11:02Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-valid-edge-types-only",
+      "species": "acceptance",
+      "title": "Only valid connections offered"
+    },
+    {
+      "id": "012603202011020000000131",
+      "ts": "2026-03-20T20:11:02Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-delete-asks-first",
+      "species": "acceptance",
+      "title": "Deletion always asks first"
+    },
+    {
+      "id": "012603202011020000000132",
+      "ts": "2026-03-20T20:11:02Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-insert-between-steps",
+      "species": "acceptance",
+      "title": "Insert between playlist steps"
+    },
+    {
+      "id": "012603202248400000000114",
+      "ts": "2026-03-20T22:48:40Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-landing",
+      "species": "view",
+      "title": "Landing Page"
+    },
+    {
+      "id": "012603202248400000000116",
+      "ts": "2026-03-20T22:48:40Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-sections-mirror-project-homes",
+      "species": "acceptance",
+      "title": "Sections mirror where projects live"
+    },
+    {
+      "id": "012603202248400000000122",
+      "ts": "2026-03-20T22:48:40Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-sign-in-adds-never-rearranges",
+      "species": "acceptance",
+      "title": "Signing in adds, never rearranges"
+    },
+    {
+      "id": "012603202248400000000123",
+      "ts": "2026-03-20T22:48:40Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-move-to-account-copies",
+      "species": "acceptance",
+      "title": "Move to account keeps the original"
+    },
     {
       "id": "01K0SELFMAPSEED00000000001",
       "ts": "2026-03-21T00:00:00.000Z",
@@ -485,6 +6640,1446 @@
       "title": "Status migrations: hard cutover + permanent aliases"
     },
     {
+      "id": "012603210900460000000052",
+      "ts": "2026-03-21T09:00:46Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-create-project-dialog",
+      "species": "view",
+      "title": "Create Project Dialog"
+    },
+    {
+      "id": "012603210900460000000120",
+      "ts": "2026-03-21T09:00:46Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-signed-in-skips-landing",
+      "species": "acceptance",
+      "title": "Signed in skips the pitch"
+    },
+    {
+      "id": "012603210900460000000121",
+      "ts": "2026-03-21T09:00:46Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-create-lands-in-chosen-home",
+      "species": "acceptance",
+      "title": "Create lands where you asked"
+    },
+    {
+      "id": "012603210913160000000098",
+      "ts": "2026-03-21T09:13:16Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-export-bundle",
+      "species": "flow",
+      "title": "Export Project Bundle"
+    },
+    {
+      "id": "012603210913160000000182",
+      "ts": "2026-03-21T09:13:16Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-export-full-bundle",
+      "species": "acceptance",
+      "title": "Your Map Leaves With You"
+    },
+    {
+      "id": "012603210924360000000179",
+      "ts": "2026-03-21T09:24:36Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-legacy-bundle-migrates",
+      "species": "acceptance",
+      "title": "Old Bundles Still Import"
+    },
+    {
+      "id": "012603210924360000000180",
+      "ts": "2026-03-21T09:24:36Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-broken-import-explains",
+      "species": "acceptance",
+      "title": "Broken Imports Explain Themselves"
+    },
+    {
+      "id": "012603210924360000000181",
+      "ts": "2026-03-21T09:24:36Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-reserved-ids-stay-reserved",
+      "species": "acceptance",
+      "title": "Reserved IDs Stay Reserved"
+    },
+    {
+      "id": "012603210924360000000183",
+      "ts": "2026-03-21T09:24:36Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-export-reimports-cleanly",
+      "species": "acceptance",
+      "title": "Exports Re-import Cleanly"
+    },
+    {
+      "id": "012603211043430000000064",
+      "ts": "2026-03-21T10:43:43Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-navigate-by-keyboard",
+      "species": "flow",
+      "title": "Navigate By Keyboard"
+    },
+    {
+      "id": "012603211759410000000072",
+      "ts": "2026-03-21T17:59:41Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-edit-flow-playlist",
+      "species": "flow",
+      "title": "Edit Flow Playlist"
+    },
+    {
+      "id": "012603211759410000000140",
+      "ts": "2026-03-21T17:59:41Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-playlist-cycle-blocked",
+      "species": "acceptance",
+      "title": "Playlists cannot loop"
+    },
+    {
+      "id": "012603211759410000000141",
+      "ts": "2026-03-21T17:59:41Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-playlist-branching-entries",
+      "species": "acceptance",
+      "title": "Playlists branch inline"
+    },
+    {
+      "id": "012603211938480000000066",
+      "ts": "2026-03-21T19:38:48Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-raw-bundle-panel",
+      "species": "view",
+      "title": "Raw Bundle Panel"
+    },
+    {
+      "id": "012603211938480000000143",
+      "ts": "2026-03-21T19:38:48Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-raw-format-switch-roundtrips",
+      "species": "acceptance",
+      "title": "Format switch preserves draft"
+    },
+    {
+      "id": "012603212021030000000119",
+      "ts": "2026-03-21T20:21:03Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-example-projects-one-click",
+      "species": "acceptance",
+      "title": "Examples are one click away"
+    },
+    {
+      "id": "012603220019020000000067",
+      "ts": "2026-03-22T00:19:02Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-library",
+      "species": "view",
+      "title": "Library"
+    },
+    {
+      "id": "012603220019020000000074",
+      "ts": "2026-03-22T00:19:02Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-browse-library",
+      "species": "flow",
+      "title": "Browse Library"
+    },
+    {
+      "id": "012603220019020000000151",
+      "ts": "2026-03-22T00:19:02Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-library-bulk-move-honest",
+      "species": "acceptance",
+      "title": "Bulk selection stays honest"
+    },
+    {
+      "id": "012603221054470000000101",
+      "ts": "2026-03-22T10:54:47Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-browse-docs",
+      "species": "flow",
+      "title": "Browse Documentation"
+    },
+    {
+      "id": "012603221054470000000102",
+      "ts": "2026-03-22T10:54:47Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-docs-site",
+      "species": "view",
+      "title": "Documentation Site"
+    },
+    {
+      "id": "012603221054470000000187",
+      "ts": "2026-03-22T10:54:47Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-docs-live-in-app",
+      "species": "acceptance",
+      "title": "Docs Live In App"
+    },
+    {
+      "id": "012603240544220000000092",
+      "ts": "2026-03-24T05:44:22Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-generate-prompt",
+      "species": "view",
+      "title": "Generate With AI"
+    },
+    {
+      "id": "012603240544220000000097",
+      "ts": "2026-03-24T05:44:22Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-generate-with-ai",
+      "species": "flow",
+      "title": "Generate Map with AI"
+    },
+    {
+      "id": "012603240544220000000178",
+      "ts": "2026-03-24T05:44:22Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-prompt-for-any-llm",
+      "species": "acceptance",
+      "title": "One prompt, any LLM"
+    },
+    {
+      "id": "012607111417360000000104",
+      "ts": "2026-07-11T14:17:36Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-arkaik-skill",
+      "species": "view",
+      "title": "Arkaik Agent Skill"
+    },
+    {
+      "id": "012607112307110000000008",
+      "ts": "2026-07-11T23:07:11Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-journal-event",
+      "species": "data-model",
+      "title": "JournalEvent"
+    },
+    {
+      "id": "012607112355590000000077",
+      "ts": "2026-07-11T23:55:59Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-changelog",
+      "species": "view",
+      "title": "Changelog"
+    },
+    {
+      "id": "012607112355590000000082",
+      "ts": "2026-07-11T23:55:59Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-review-changelog",
+      "species": "flow",
+      "title": "Review Changelog"
+    },
+    {
+      "id": "012607112355590000000155",
+      "ts": "2026-07-11T23:55:59Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-changelog-design-delivery-split",
+      "species": "acceptance",
+      "title": "Design and Delivery Apart"
+    },
+    {
+      "id": "012607112355590000000156",
+      "ts": "2026-07-11T23:55:59Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-deliverable-anchored-first-ship",
+      "species": "acceptance",
+      "title": "Deliverables Anchor When Shipped"
+    },
+    {
+      "id": "012607120822310000000103",
+      "ts": "2026-07-12T08:22:31Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-cli-terminal",
+      "species": "view",
+      "title": "CLI Terminal"
+    },
+    {
+      "id": "012607120822310000000107",
+      "ts": "2026-07-12T08:22:31Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-validate-bundle",
+      "species": "flow",
+      "title": "Validate Bundle"
+    },
+    {
+      "id": "012607120822310000000191",
+      "ts": "2026-07-12T08:22:31Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-validator-blocks-broken-bundle",
+      "species": "acceptance",
+      "title": "Validator Blocks Broken Bundles"
+    },
+    {
+      "id": "012607120835260000000106",
+      "ts": "2026-07-12T08:35:26Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-init-repo",
+      "species": "flow",
+      "title": "Initialize Repo Map"
+    },
+    {
+      "id": "012607120835260000000188",
+      "ts": "2026-07-12T08:35:26Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-one-command-repo-setup",
+      "species": "acceptance",
+      "title": "One Command Repo Setup"
+    },
+    {
+      "id": "012607120835260000000189",
+      "ts": "2026-07-12T08:35:26Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-init-rerun-never-clobbers",
+      "species": "acceptance",
+      "title": "Re-run Init Safely"
+    },
+    {
+      "id": "012607120835260000000190",
+      "ts": "2026-07-12T08:35:26Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-one-skill-doctrine-everywhere",
+      "species": "acceptance",
+      "title": "One Skill Doctrine Everywhere"
+    },
+    {
+      "id": "012607120855430000000108",
+      "ts": "2026-07-12T08:55:43Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-journal-release",
+      "species": "flow",
+      "title": "Journal & Release"
+    },
+    {
+      "id": "012607120855430000000192",
+      "ts": "2026-07-12T08:55:43Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-bad-line-cannot-corrupt-history",
+      "species": "acceptance",
+      "title": "Bad Line Damages Nothing"
+    },
+    {
+      "id": "012607120855430000000193",
+      "ts": "2026-07-12T08:55:43Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-parallel-appends-merge-clean",
+      "species": "acceptance",
+      "title": "Parallel Appends Merge Cleanly"
+    },
+    {
+      "id": "012607120855430000000194",
+      "ts": "2026-07-12T08:55:43Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-release-notes-draft-themselves",
+      "species": "acceptance",
+      "title": "Release Notes Draft Themselves"
+    },
+    {
+      "id": "012607120913150000000109",
+      "ts": "2026-07-12T09:13:15Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-sync-refs",
+      "species": "flow",
+      "title": "Sync External Refs"
+    },
+    {
+      "id": "012607120913150000000196",
+      "ts": "2026-07-12T09:13:15Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-sync-mirrors-not-authority",
+      "species": "acceptance",
+      "title": "Sync Mirrors, Never Overrides"
+    },
+    {
+      "id": "012607120930290000000110",
+      "ts": "2026-07-12T09:30:29Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-share-map",
+      "species": "flow",
+      "title": "Pack, Open & Push"
+    },
+    {
+      "id": "012607120930290000000197",
+      "ts": "2026-07-12T09:30:29Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-share-validated-history-private",
+      "species": "acceptance",
+      "title": "Share Validated, History Private"
+    },
+    {
+      "id": "012607121237290000000012",
+      "ts": "2026-07-12T12:37:29Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-projects",
+      "species": "data-model",
+      "title": "projects"
+    },
+    {
+      "id": "012607121237290000000013",
+      "ts": "2026-07-12T12:37:29Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-journals",
+      "species": "data-model",
+      "title": "journals"
+    },
+    {
+      "id": "012607121237290000000014",
+      "ts": "2026-07-12T12:37:29Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-meta",
+      "species": "data-model",
+      "title": "meta"
+    },
+    {
+      "id": "012607122247470000000015",
+      "ts": "2026-07-12T22:47:47Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-publik-snapshots",
+      "species": "data-model",
+      "title": "publik_snapshots"
+    },
+    {
+      "id": "012607122308470000000016",
+      "ts": "2026-07-12T23:08:47Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-publik-rate-limits",
+      "species": "data-model",
+      "title": "publik_rate_limits"
+    },
+    {
+      "id": "012607122308470000000042",
+      "ts": "2026-07-12T23:08:47Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-post-publik",
+      "species": "api-endpoint",
+      "title": "POST /api/publik"
+    },
+    {
+      "id": "012607122308470000000043",
+      "ts": "2026-07-12T23:08:47Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-publik-snapshot",
+      "species": "api-endpoint",
+      "title": "GET/DELETE /api/publik/{id}"
+    },
+    {
+      "id": "012607122308470000000044",
+      "ts": "2026-07-12T23:08:47Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-post-publik-report",
+      "species": "api-endpoint",
+      "title": "POST /api/publik/{id}/report"
+    },
+    {
+      "id": "012607122323040000000017",
+      "ts": "2026-07-12T23:23:04Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-users",
+      "species": "data-model",
+      "title": "users"
+    },
+    {
+      "id": "012607122323040000000018",
+      "ts": "2026-07-12T23:23:04Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-accounts",
+      "species": "data-model",
+      "title": "accounts"
+    },
+    {
+      "id": "012607122323040000000019",
+      "ts": "2026-07-12T23:23:04Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-sessions",
+      "species": "data-model",
+      "title": "sessions"
+    },
+    {
+      "id": "012607122323040000000020",
+      "ts": "2026-07-12T23:23:04Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-verification-token",
+      "species": "data-model",
+      "title": "verification_token"
+    },
+    {
+      "id": "012607122323040000000030",
+      "ts": "2026-07-12T23:23:04Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-auth-nextauth",
+      "species": "api-endpoint",
+      "title": "GET/POST /api/auth/*"
+    },
+    {
+      "id": "012607122323040000000031",
+      "ts": "2026-07-12T23:23:04Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-get-auth-status",
+      "species": "api-endpoint",
+      "title": "GET /api/auth/status"
+    },
+    {
+      "id": "012607122323040000000033",
+      "ts": "2026-07-12T23:23:04Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-github",
+      "species": "api-endpoint",
+      "title": "GitHub API"
+    },
+    {
+      "id": "012607122323040000000049",
+      "ts": "2026-07-12T23:23:04Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-get-synk-ping",
+      "species": "api-endpoint",
+      "title": "GET /api/synk/ping"
+    },
+    {
+      "id": "012607122323040000000090",
+      "ts": "2026-07-12T23:23:04Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-account-menu",
+      "species": "view",
+      "title": "Account Menu"
+    },
+    {
+      "id": "012607122323040000000094",
+      "ts": "2026-07-12T23:23:04Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-sign-in",
+      "species": "flow",
+      "title": "Sign In with GitHub"
+    },
+    {
+      "id": "012607122323040000000177",
+      "ts": "2026-07-12T23:23:04Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-signin-never-gates-local",
+      "species": "acceptance",
+      "title": "Sign-in never gates local"
+    },
+    {
+      "id": "012607130821140000000021",
+      "ts": "2026-07-13T08:21:14Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-synk-projects",
+      "species": "data-model",
+      "title": "synk_projects"
+    },
+    {
+      "id": "012607130821140000000022",
+      "ts": "2026-07-13T08:21:14Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-synk-backups",
+      "species": "data-model",
+      "title": "synk_backups"
+    },
+    {
+      "id": "012607130821140000000045",
+      "ts": "2026-07-13T08:21:14Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-get-synk-projects",
+      "species": "api-endpoint",
+      "title": "GET /api/synk/projects"
+    },
+    {
+      "id": "012607130821140000000046",
+      "ts": "2026-07-13T08:21:14Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-synk-project",
+      "species": "api-endpoint",
+      "title": "PUT/DELETE /api/synk/projects/{id}"
+    },
+    {
+      "id": "012607130821140000000047",
+      "ts": "2026-07-13T08:21:14Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-get-synk-project-backups",
+      "species": "api-endpoint",
+      "title": "GET /api/synk/projects/{id}/backups"
+    },
+    {
+      "id": "012607130821140000000048",
+      "ts": "2026-07-13T08:21:14Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-get-synk-backup",
+      "species": "api-endpoint",
+      "title": "GET /api/synk/backups/{id}"
+    },
+    {
+      "id": "012607130824430000000086",
+      "ts": "2026-07-13T08:24:43Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-publik-snapshot",
+      "species": "view",
+      "title": "Public Snapshot Page"
+    },
+    {
+      "id": "012607130824430000000087",
+      "ts": "2026-07-13T08:24:43Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-publik-publish-dialog",
+      "species": "view",
+      "title": "Publish Dialog"
+    },
+    {
+      "id": "012607130824430000000093",
+      "ts": "2026-07-13T08:24:43Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-publish-to-publik",
+      "species": "flow",
+      "title": "Publish to Publik"
+    },
+    {
+      "id": "012607130824430000000165",
+      "ts": "2026-07-13T08:24:43Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-publish-never-leaks-journal",
+      "species": "acceptance",
+      "title": "Publishing never leaks history"
+    },
+    {
+      "id": "012607130824430000000166",
+      "ts": "2026-07-13T08:24:43Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-owner-key-shown-once",
+      "species": "acceptance",
+      "title": "Owner key shown once"
+    },
+    {
+      "id": "012607130824430000000167",
+      "ts": "2026-07-13T08:24:43Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-snapshot-delete-needs-key",
+      "species": "acceptance",
+      "title": "Deletion gated by key"
+    },
+    {
+      "id": "012607130824430000000168",
+      "ts": "2026-07-13T08:24:43Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-publish-without-account",
+      "species": "acceptance",
+      "title": "Publish without an account"
+    },
+    {
+      "id": "012607130824430000000169",
+      "ts": "2026-07-13T08:24:43Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-snapshot-imports-as-copy",
+      "species": "acceptance",
+      "title": "Anyone imports a copy"
+    },
+    {
+      "id": "012607130859240000000088",
+      "ts": "2026-07-13T08:59:24Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-synk-onboarding-banner",
+      "species": "view",
+      "title": "Synk Onboarding Banner"
+    },
+    {
+      "id": "012607130859240000000089",
+      "ts": "2026-07-13T08:59:24Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-synk-restore-dialog",
+      "species": "view",
+      "title": "Synk Restore Dialog"
+    },
+    {
+      "id": "012607130859240000000095",
+      "ts": "2026-07-13T08:59:24Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-synk-backup-restore",
+      "species": "flow",
+      "title": "Back Up with Synk"
+    },
+    {
+      "id": "012607130859240000000170",
+      "ts": "2026-07-13T08:59:24Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-backups-run-themselves",
+      "species": "acceptance",
+      "title": "Backups run themselves"
+    },
+    {
+      "id": "012607130859240000000171",
+      "ts": "2026-07-13T08:59:24Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-backups-dedupe-by-content",
+      "species": "acceptance",
+      "title": "Backups dedupe by content"
+    },
+    {
+      "id": "012607130859240000000172",
+      "ts": "2026-07-13T08:59:24Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-backup-failure-loses-nothing",
+      "species": "acceptance",
+      "title": "Failed backups lose nothing"
+    },
+    {
+      "id": "012607130859240000000173",
+      "ts": "2026-07-13T08:59:24Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-restore-never-overwrites",
+      "species": "acceptance",
+      "title": "Restore never overwrites"
+    },
+    {
+      "id": "012607130859240000000174",
+      "ts": "2026-07-13T08:59:24Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-one-click-backup-offer",
+      "species": "acceptance",
+      "title": "One-click backup offer"
+    },
+    {
+      "id": "012607132304430000000009",
+      "ts": "2026-07-13T23:04:43Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-map-definition",
+      "species": "data-model",
+      "title": "MapDefinition"
+    },
+    {
+      "id": "012607132304430000000081",
+      "ts": "2026-07-13T23:04:43Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-delivery-board",
+      "species": "view",
+      "title": "Delivery Board"
+    },
+    {
+      "id": "012607132304430000000085",
+      "ts": "2026-07-13T23:04:43Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-track-delivery",
+      "species": "flow",
+      "title": "Track Delivery Status"
+    },
+    {
+      "id": "012607132304430000000157",
+      "ts": "2026-07-13T23:04:43Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-unreleased-work-visible",
+      "species": "acceptance",
+      "title": "Unreleased Work Stays Visible"
+    },
+    {
+      "id": "012607132304430000000162",
+      "ts": "2026-07-13T23:04:43Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-board-mirrors-lifecycle",
+      "species": "acceptance",
+      "title": "Board Mirrors the Lifecycle"
+    },
+    {
+      "id": "012607132304430000000163",
+      "ts": "2026-07-13T23:04:43Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-board-item-per-platform",
+      "species": "acceptance",
+      "title": "One Card per Platform"
+    },
+    {
+      "id": "012607140850090000000053",
+      "ts": "2026-07-14T08:50:09Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-maps-index",
+      "species": "view",
+      "title": "Maps Index"
+    },
+    {
+      "id": "012607140850090000000055",
+      "ts": "2026-07-14T08:50:09Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-system-map",
+      "species": "view",
+      "title": "System Map Canvas"
+    },
+    {
+      "id": "012607140850090000000056",
+      "ts": "2026-07-14T08:50:09Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-map-editor-dialog",
+      "species": "view",
+      "title": "Map Editor Dialog"
+    },
+    {
+      "id": "012607140850090000000060",
+      "ts": "2026-07-14T08:50:09Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-browse-maps",
+      "species": "flow",
+      "title": "Browse Maps"
+    },
+    {
+      "id": "012607140850090000000061",
+      "ts": "2026-07-14T08:50:09Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-create-custom-map",
+      "species": "flow",
+      "title": "Create Custom Map"
+    },
+    {
+      "id": "012607140850090000000076",
+      "ts": "2026-07-14T08:50:09Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-edit-raw-bundle",
+      "species": "flow",
+      "title": "Edit Raw Bundle"
+    },
+    {
+      "id": "012607140850090000000125",
+      "ts": "2026-07-14T08:50:09Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-honest-map-counts",
+      "species": "acceptance",
+      "title": "Map cards count honestly"
+    },
+    {
+      "id": "012607140850090000000126",
+      "ts": "2026-07-14T08:50:09Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-drill-down-in-place",
+      "species": "acceptance",
+      "title": "Drill down without leaving"
+    },
+    {
+      "id": "012607140850090000000133",
+      "ts": "2026-07-14T08:50:09Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-custom-map-as-data",
+      "species": "acceptance",
+      "title": "Custom maps are saved data"
+    },
+    {
+      "id": "012607140850090000000136",
+      "ts": "2026-07-14T08:50:09Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-viewport-stays-put",
+      "species": "acceptance",
+      "title": "Canvas stays where left"
+    },
+    {
+      "id": "012607140850090000000137",
+      "ts": "2026-07-14T08:50:09Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-spotlight-neighborhood",
+      "species": "acceptance",
+      "title": "Spotlight one node's relations"
+    },
+    {
+      "id": "012607140850090000000138",
+      "ts": "2026-07-14T08:50:09Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-system-two-renditions",
+      "species": "acceptance",
+      "title": "Two readings of the system"
+    },
+    {
+      "id": "012607140850090000000142",
+      "ts": "2026-07-14T08:50:09Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-raw-edits-validated",
+      "species": "acceptance",
+      "title": "Raw edits gated by validation"
+    },
+    {
+      "id": "012607140850090000000144",
+      "ts": "2026-07-14T08:50:09Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-raw-close-guard",
+      "species": "acceptance",
+      "title": "Unsaved raw edits guarded"
+    },
+    {
+      "id": "012607141106120000000068",
+      "ts": "2026-07-14T11:06:12Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-overview",
+      "species": "view",
+      "title": "Overview"
+    },
+    {
+      "id": "012607141106120000000152",
+      "ts": "2026-07-14T11:06:12Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-overview-health-indicators",
+      "species": "acceptance",
+      "title": "Doc health always visible"
+    },
+    {
+      "id": "012607141807170000000105",
+      "ts": "2026-07-14T18:07:17Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-mcp-tool-catalog",
+      "species": "view",
+      "title": "MCP Tool Catalog"
+    },
+    {
+      "id": "012607141807170000000112",
+      "ts": "2026-07-14T18:07:17Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-mcp-agent-session",
+      "species": "flow",
+      "title": "MCP Agent Session"
+    },
+    {
+      "id": "012607141807170000000199",
+      "ts": "2026-07-14T18:07:17Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-mcp-validated-dual-write",
+      "species": "acceptance",
+      "title": "Agents Write Validator-Gated"
+    },
+    {
+      "id": "012607191312540000000070",
+      "ts": "2026-07-19T13:12:54Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-acceptances-matrix",
+      "species": "view",
+      "title": "Acceptances Matrix"
+    },
+    {
+      "id": "012607191312540000000073",
+      "ts": "2026-07-19T13:12:54Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-edit-acceptance",
+      "species": "flow",
+      "title": "Edit Acceptance"
+    },
+    {
+      "id": "012607191312540000000145",
+      "ts": "2026-07-19T13:12:54Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-acceptance-how-why-inline",
+      "species": "acceptance",
+      "title": "Gherkin and values inline"
+    },
+    {
+      "id": "012607191312540000000146",
+      "ts": "2026-07-19T13:12:54Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-split-carries-context",
+      "species": "acceptance",
+      "title": "Split keeps the context"
+    },
+    {
+      "id": "012607191312540000000147",
+      "ts": "2026-07-19T13:12:54Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-parity-gap-at-a-glance",
+      "species": "acceptance",
+      "title": "Parity gaps surface themselves"
+    },
+    {
+      "id": "012607191312540000000148",
+      "ts": "2026-07-19T13:12:54Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-matrix-groups-by-anchor",
+      "species": "acceptance",
+      "title": "Matrix groups by anchor"
+    },
+    {
+      "id": "012607191641580000000069",
+      "ts": "2026-07-19T16:41:58Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-pyramid",
+      "species": "view",
+      "title": "Value Pyramid"
+    },
+    {
+      "id": "012607191641580000000075",
+      "ts": "2026-07-19T16:41:58Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-audit-value-coverage",
+      "species": "flow",
+      "title": "Audit Value Coverage"
+    },
+    {
+      "id": "012607191641580000000149",
+      "ts": "2026-07-19T16:41:58Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-pyramid-coverage-glance",
+      "species": "acceptance",
+      "title": "Value coverage at a glance"
+    },
+    {
+      "id": "012607191641580000000150",
+      "ts": "2026-07-19T16:41:58Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-pyramid-gap-filter",
+      "species": "acceptance",
+      "title": "Unserved values filterable"
+    },
+    {
+      "id": "012607270651570000000023",
+      "ts": "2026-07-27T06:51:57Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-owners",
+      "species": "data-model",
+      "title": "owners"
+    },
+    {
+      "id": "012607270651570000000024",
+      "ts": "2026-07-27T06:51:57Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-owner-members",
+      "species": "data-model",
+      "title": "owner_members"
+    },
+    {
+      "id": "012607270651570000000025",
+      "ts": "2026-07-27T06:51:57Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-api-tokens",
+      "species": "data-model",
+      "title": "api_tokens"
+    },
+    {
+      "id": "012607270651570000000050",
+      "ts": "2026-07-27T06:51:57Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-tokens",
+      "species": "api-endpoint",
+      "title": "GET/POST /api/tokens"
+    },
+    {
+      "id": "012607270651570000000051",
+      "ts": "2026-07-27T06:51:57Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-delete-token",
+      "species": "api-endpoint",
+      "title": "DELETE /api/tokens/{id}"
+    },
+    {
+      "id": "012607270651570000000091",
+      "ts": "2026-07-27T06:51:57Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-agent-tokens",
+      "species": "view",
+      "title": "Agent Tokens Settings"
+    },
+    {
+      "id": "012607270651570000000176",
+      "ts": "2026-07-27T06:51:57Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-agent-token-shown-once",
+      "species": "acceptance",
+      "title": "Token secret shown once"
+    },
+    {
+      "id": "012607271318310000000026",
+      "ts": "2026-07-27T13:18:31Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-graph-projects",
+      "species": "data-model",
+      "title": "graph_projects"
+    },
+    {
+      "id": "012607271318310000000027",
+      "ts": "2026-07-27T13:18:31Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-graph-events",
+      "species": "data-model",
+      "title": "graph_events"
+    },
+    {
+      "id": "012607271318310000000034",
+      "ts": "2026-07-27T13:18:31Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-graph-projects",
+      "species": "api-endpoint",
+      "title": "GET/POST /api/graph/projects"
+    },
+    {
+      "id": "012607271318310000000035",
+      "ts": "2026-07-27T13:18:31Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-graph-project",
+      "species": "api-endpoint",
+      "title": "GET/PATCH/DELETE /api/graph/projects/{id}"
+    },
+    {
+      "id": "012607271318310000000036",
+      "ts": "2026-07-27T13:18:31Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-get-graph-project-nodes",
+      "species": "api-endpoint",
+      "title": "GET /api/graph/projects/{id}/nodes"
+    },
+    {
+      "id": "012607271318310000000037",
+      "ts": "2026-07-27T13:18:31Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-get-graph-project-edges",
+      "species": "api-endpoint",
+      "title": "GET /api/graph/projects/{id}/edges"
+    },
+    {
+      "id": "012607271318310000000038",
+      "ts": "2026-07-27T13:18:31Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-get-graph-project-journal",
+      "species": "api-endpoint",
+      "title": "GET /api/graph/projects/{id}/journal"
+    },
+    {
+      "id": "012607271318310000000039",
+      "ts": "2026-07-27T13:18:31Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-get-graph-project-export",
+      "species": "api-endpoint",
+      "title": "GET /api/graph/projects/{id}/export"
+    },
+    {
+      "id": "012607271318310000000040",
+      "ts": "2026-07-27T13:18:31Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-post-graph-project-mutations",
+      "species": "api-endpoint",
+      "title": "POST /api/graph/projects/{id}/mutations"
+    },
+    {
+      "id": "012607271328490000000111",
+      "ts": "2026-07-27T13:28:49Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-link-hosted",
+      "species": "flow",
+      "title": "Link Hosted Project"
+    },
+    {
+      "id": "012607271328490000000195",
+      "ts": "2026-07-27T13:28:49Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-linked-repo-fails-loud",
+      "species": "acceptance",
+      "title": "Linked Repo Fails Loud"
+    },
+    {
+      "id": "012607271328490000000198",
+      "ts": "2026-07-27T13:28:49Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-hosted-token-never-on-disk",
+      "species": "acceptance",
+      "title": "Token Never Touches Disk"
+    },
+    {
+      "id": "012607271333010000000028",
+      "ts": "2026-07-27T13:33:01Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-project-repos",
+      "species": "data-model",
+      "title": "project_repos"
+    },
+    {
+      "id": "012607271333010000000029",
+      "ts": "2026-07-27T13:33:01Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-github-deliveries",
+      "species": "data-model",
+      "title": "github_deliveries"
+    },
+    {
+      "id": "012607271333010000000032",
+      "ts": "2026-07-27T13:33:01Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-post-github-webhook",
+      "species": "api-endpoint",
+      "title": "POST /api/github/webhook"
+    },
+    {
+      "id": "012607271333010000000041",
+      "ts": "2026-07-27T13:33:01Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "API-graph-project-repos",
+      "species": "api-endpoint",
+      "title": "GET/POST/DELETE /api/graph/projects/{id}/repos"
+    },
+    {
+      "id": "012608011241070000000096",
+      "ts": "2026-08-01T12:41:07Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-move-to-account",
+      "species": "flow",
+      "title": "Move Project to Account"
+    },
+    {
+      "id": "012608011241070000000175",
+      "ts": "2026-08-01T12:41:07Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-move-keeps-local-copy",
+      "species": "acceptance",
+      "title": "Moving keeps local copy"
+    },
+    {
+      "id": "012608011626040000000113",
+      "ts": "2026-08-01T16:26:04Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-project-settings",
+      "species": "view",
+      "title": "Project Settings"
+    },
+    {
+      "id": "012608011626040000000117",
+      "ts": "2026-08-01T16:26:04Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-delete-behind-confirmation",
+      "species": "acceptance",
+      "title": "Deletion cannot happen by accident"
+    },
+    {
+      "id": "012608011626040000000118",
+      "ts": "2026-08-01T16:26:04Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-public-map-undeletable",
+      "species": "acceptance",
+      "title": "Public map cannot be deleted"
+    },
+    {
+      "id": "012608020601400000000058",
+      "ts": "2026-08-02T06:01:40Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-command-palette",
+      "species": "view",
+      "title": "Command Palette"
+    },
+    {
+      "id": "012608020601400000000134",
+      "ts": "2026-08-02T06:01:40Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-palette-jump-anywhere",
+      "species": "acceptance",
+      "title": "Jump anywhere from keyboard"
+    },
+    {
+      "id": "012608020730270000000057",
+      "ts": "2026-08-02T07:30:27Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-map-display-popover",
+      "species": "view",
+      "title": "Map Display Popover"
+    },
+    {
+      "id": "012608020730270000000062",
+      "ts": "2026-08-02T07:30:27Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-adjust-map-display",
+      "species": "flow",
+      "title": "Adjust Map Display"
+    },
+    {
+      "id": "012608020730270000000128",
+      "ts": "2026-08-02T07:30:27Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-display-persists-per-map",
+      "species": "acceptance",
+      "title": "Display choices stick per map"
+    },
+    {
+      "id": "012608022136340000000010",
+      "ts": "2026-08-02T21:36:34Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-product",
+      "species": "data-model",
+      "title": "Product"
+    },
+    {
+      "id": "012608022136340000000115",
+      "ts": "2026-08-02T21:36:34Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-manage-products",
+      "species": "flow",
+      "title": "Manage Products"
+    },
+    {
+      "id": "012608022136340000000124",
+      "ts": "2026-08-02T21:36:34Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-products-named-in-settings",
+      "species": "acceptance",
+      "title": "Products are named in Settings"
+    },
+    {
+      "id": "012608030536510000000059",
+      "ts": "2026-08-03T05:36:51Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-keyboard-shortcuts-dialog",
+      "species": "view",
+      "title": "Keyboard Shortcuts Dialog"
+    },
+    {
+      "id": "012608030536510000000135",
+      "ts": "2026-08-03T05:36:51Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-shortcuts-no-dead-keys",
+      "species": "acceptance",
+      "title": "Shortcut list tells no lies"
+    },
+    {
       "id": "01K0SELFMAPSEED00000000900",
       "ts": "2026-08-03T12:00:00.000Z",
       "actor": "claude-code",
@@ -503,7 +8098,11 @@
       "title": "Decisions species",
       "summary": "ADR records as first-class graph nodes, with supersedes/generates/impacts edges.",
       "url": "https://github.com/alexisbohns/arkaik/pull/335",
-      "node_ids": ["DEC-two-axes-stay", "DEC-blocked-is-a-flag", "DEC-migration-hard-cutover"]
+      "node_ids": [
+        "DEC-two-axes-stay",
+        "DEC-blocked-is-a-flag",
+        "DEC-migration-hard-cutover"
+      ]
     },
     {
       "id": "01K0SELFMAPSEED00000000910",
@@ -531,6 +8130,203 @@
       "node_id": "DEC-migration-hard-cutover",
       "from": "proposed",
       "to": "enacted"
+    },
+    {
+      "id": "012608031845570000000079",
+      "ts": "2026-08-03T18:45:57Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-decision-log",
+      "species": "view",
+      "title": "Decision Log"
+    },
+    {
+      "id": "012608031845570000000080",
+      "ts": "2026-08-03T18:45:57Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-decision-editor",
+      "species": "view",
+      "title": "Decision Editor"
+    },
+    {
+      "id": "012608031845570000000084",
+      "ts": "2026-08-03T18:45:57Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-log-decision",
+      "species": "flow",
+      "title": "Log a Decision"
+    },
+    {
+      "id": "012608031845570000000158",
+      "ts": "2026-08-03T18:45:57Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-decision-keeps-why-how",
+      "species": "acceptance",
+      "title": "Decisions Keep Their Why"
+    },
+    {
+      "id": "012608031845570000000159",
+      "ts": "2026-08-03T18:45:57Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-decision-edits-autosave",
+      "species": "acceptance",
+      "title": "Decision Edits Save Themselves"
+    },
+    {
+      "id": "012608031845570000000160",
+      "ts": "2026-08-03T18:45:57Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-superseded-chain-traceable",
+      "species": "acceptance",
+      "title": "Superseded Decisions Stay Traceable"
+    },
+    {
+      "id": "012608031845570000000161",
+      "ts": "2026-08-03T18:45:57Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-decision-status-filter",
+      "species": "acceptance",
+      "title": "Filter Decisions by Status"
+    },
+    {
+      "id": "012608032243550000000011",
+      "ts": "2026-08-03T22:43:55Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DM-deliverable",
+      "species": "data-model",
+      "title": "Deliverable"
+    },
+    {
+      "id": "012608032243550000000078",
+      "ts": "2026-08-03T22:43:55Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-history",
+      "species": "view",
+      "title": "History"
+    },
+    {
+      "id": "012608032243550000000083",
+      "ts": "2026-08-03T22:43:55Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-audit-history",
+      "species": "flow",
+      "title": "Audit Project History"
+    },
+    {
+      "id": "012608032243550000000153",
+      "ts": "2026-08-03T22:43:55Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-history-never-rewritten",
+      "species": "acceptance",
+      "title": "History Never Rewritten"
+    },
+    {
+      "id": "012608032243550000000154",
+      "ts": "2026-08-03T22:43:55Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-history-family-filter",
+      "species": "acceptance",
+      "title": "Filter History by Family"
+    },
+    {
+      "id": "012608032243550000000164",
+      "ts": "2026-08-03T22:43:55Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-empty-journal-calm",
+      "species": "acceptance",
+      "title": "Empty History Is Calm"
+    },
+    {
+      "id": "012608040657050000000099",
+      "ts": "2026-08-04T06:57:05Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "F-explore-sandbox",
+      "species": "flow",
+      "title": "Explore Public Sandbox"
+    },
+    {
+      "id": "012608040657050000000100",
+      "ts": "2026-08-04T06:57:05Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "V-sandbox-notice",
+      "species": "view",
+      "title": "Sandbox Notice"
+    },
+    {
+      "id": "012608040657050000000184",
+      "ts": "2026-08-04T06:57:05Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-sandbox-resets-pristine",
+      "species": "acceptance",
+      "title": "Refresh Restores Pristine Seed"
+    },
+    {
+      "id": "012608040657050000000185",
+      "ts": "2026-08-04T06:57:05Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-sandbox-edits-are-real",
+      "species": "acceptance",
+      "title": "Sandbox Edits Are Real"
+    },
+    {
+      "id": "012608040657050000000186",
+      "ts": "2026-08-04T06:57:05Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "AC-sandbox-rules-stated-plainly",
+      "species": "acceptance",
+      "title": "Sandbox Rules Stated Plainly"
+    },
+    {
+      "id": "012608041100000000000000",
+      "ts": "2026-08-04T11:00:00.000Z",
+      "actor": "claude-code",
+      "type": "node.deleted",
+      "node_id": "API-local-list-projects"
+    },
+    {
+      "id": "012608041100000000000001",
+      "ts": "2026-08-04T11:00:00.000Z",
+      "actor": "claude-code",
+      "type": "node.deleted",
+      "node_id": "API-local-save-project"
+    },
+    {
+      "id": "012608041100000000000002",
+      "ts": "2026-08-04T11:00:00.000Z",
+      "actor": "claude-code",
+      "type": "node.deleted",
+      "node_id": "API-local-archive-project"
+    },
+    {
+      "id": "012608041100000000000003",
+      "ts": "2026-08-04T11:00:00.000Z",
+      "actor": "claude-code",
+      "type": "node.deleted",
+      "node_id": "API-local-import-project"
+    },
+    {
+      "id": "012608041100000000000004",
+      "ts": "2026-08-04T11:00:00.000Z",
+      "actor": "claude-code",
+      "type": "node.deleted",
+      "node_id": "DM-local-storage-store"
     }
   ]
 }


### PR DESCRIPTION
Cycle 5 (PR A of two) of the [self-map program](docs/superpowers/specs/2026-08-03-self-map-program.md): the public sandbox project now contains the **whole product**, mapped. Spec: [content-population design](docs/superpowers/specs/2026-08-04-content-population-design.md) (committed here, with the plan).

## What the seed now holds

- **205 nodes**: 34 views, 36 flows, 26 data models, 22 API endpoints, **84 acceptances** — each acceptance with one Given/When/Then and 1–3 Bain value elements (top element `reduces-risk` at an honest 21%; no inflated pyramid tiers).
- **355 edges**, all within the legal semantics table; every flow has a real playlist with matching `composes` edges.
- **Three products** — `studio` (the core app), `platform` (Publik / Synk / auth / generate), `toolchain` (CLI / MCP / plugin / skill) — so the product filter demos itself.
- **Four curated maps**: Studio journey, Platform wiring, Data spine, Promise coverage.
- **Journal**: one `node.created` per node carrying the real merge date of the PR that first shipped that surface (2026-03-19 → 2026-08-04), plus honest `node.deleted` events for the five remodeled beachhead ids. Status-arc history, deliverables, releases, and decisions land in PR B.

## How it was built

Corpus-first subagent fan-out per the spec: a data-layer inventory agent, seven parallel area agents, an adversarial anatomy review (findings all applied — project Settings and landing pages added, a phantom edge removed, journey gating fixed), a node-dating agent over the 192-PR corpus, seven acceptance agents, and a values-balance review. Agents wrote fragments; a deterministic merge script owned ID uniqueness and referential integrity. `validate-bundle.js` passes **warning-clean**.

Deliberate exclusions, on the record: `/llms-full.txt` (agent-facing route, arguable surface), `DM-meta` / `DM-sessions` / `DM-verification_token` stay edge-less (their descriptions say why), and toolchain views carry `platforms: ["web"]` because the platform enum has no terminal/stdio value — a schema nit, not a mapping error.

## Visual pass checklist (Alexis)

- [ ] `/projects` → Explore → open the sandbox: canvas legible at 205 nodes; drill-down still smooth
- [ ] Product filter: studio / platform / toolchain each read as a coherent sub-map
- [ ] Maps index: the four curated maps open and read well (Promise coverage especially)
- [ ] Pyramid page: value distribution looks credible; acceptance matrix navigable
- [ ] Library: species counts match the numbers above; no obviously wrong titles
- [ ] History page: node.created feed reads as the real timeline (March foundation → August self-map)
- [ ] Seed sandbox mechanics unchanged: banner, reset, import-a-copy

## Lab Note

```yaml
en:
  title: "Arkaik's own map just got real"
  summary: "The sandbox project on the projects page now holds the whole product — every screen, journey, and promise Arkaik makes, wired to the value it serves. Open it and wander."
fr:
  title: "La carte d'Arkaik devient réelle"
  summary: "Le projet bac à sable de la page projets contient maintenant tout le produit — chaque écran, chaque parcours, chaque promesse, reliés à la valeur servie. Ouvre-la et balade-toi."
suggested:
  molecule: arkaik
  type: feature
  tags: [changelog]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
