### PR TITLE
Self-map content: the story (cycle 5, PR B)

### DIFF
--- a/app/project/[id]/changelog/page.tsx
+++ b/app/project/[id]/changelog/page.tsx
@@ -14,6 +14,7 @@ import {
 import { orderEvents } from "@arkaik/schema";
 import { PageShell } from "@/components/layout/PageShell";
 import { DecisionStatusBadge } from "@/components/layout/DecisionStatusBadge";
+import { useEdges } from "@/lib/hooks/useEdges";
 import { useNodes } from "@/lib/hooks/useNodes";
 import { useEffectiveProduct } from "@/lib/hooks/useProductScope";
 import { useProject } from "@/lib/hooks/useProject";
@@ -184,6 +185,7 @@ export default function ChangelogPage() {
 
   const { project: projectBundle, loading: projectLoading } = useProject(id);
   const { nodes: dataNodes, loading: nodesLoading } = useNodes(id);
+  const { edges: dataEdges } = useEdges(id);
   const { journal, loading: journalLoading } = useJournal(id);
   const { openNode } = useProjectPanels();
   // Display only — the changelog itself stays unscoped; this just fills the
@@ -241,6 +243,10 @@ export default function ChangelogPage() {
     <PageShell
       title="Changelog"
       meta={productScopeMetaLabel(scope)}
+      allNodes={dataNodes}
+      allEdges={dataEdges}
+      scope={scope}
+      journal={journal}
       headerExtra={
         projectBundle?.project.version ? (
           <div className="flex items-center gap-2 text-xs text-muted-foreground">

--- a/app/project/[id]/history/page.tsx
+++ b/app/project/[id]/history/page.tsx
@@ -49,7 +49,12 @@ export default function HistoryPage() {
   }
 
   return (
-    <PageShell title="History" meta={`${journal.length} event${journal.length === 1 ? "" : "s"}`}>
+    <PageShell
+      title="History"
+      meta={`${journal.length} event${journal.length === 1 ? "" : "s"}`}
+      allNodes={dataNodes}
+      journal={journal}
+    >
       <div className="h-full overflow-auto p-4 md:p-6">
         <div className="flex w-full flex-col gap-4">
           {journal.length === 0 ? (

--- a/components/panels/ProjectPanels.tsx
+++ b/components/panels/ProjectPanels.tsx
@@ -33,8 +33,8 @@ interface ProjectPanelsProps {
    * reason every surface takes one: a panel shows what the surface behind it
    * was showing, so when the deferred per-surface override lands the panel must
    * follow that surface and not the global. Optional because the shell is now
-   * mounted by pages that carry no nodes at all — Settings, Changelog, Maps —
-   * where the only panel is the raw bundle and there is nothing to scope.
+   * mounted by pages that carry no nodes at all — Settings, Maps — where the
+   * only panel is the raw bundle and there is nothing to scope.
    */
   scope?: ProductScope;
   journal?: JournalEvent[];

--- a/docs/superpowers/specs/2026-08-03-self-map-program.md
+++ b/docs/superpowers/specs/2026-08-03-self-map-program.md
@@ -1,6 +1,6 @@
 # The Self-Map Program — vision & cycle plan
 
-**Date:** 2026-08-03 · **Status:** cycles 1–3 shipped; cycle 4 in progress
+**Date:** 2026-08-03 · **Status:** all 5 cycles shipped (cycle 5 PRs in review)
 **Resume:** in a fresh session, say "continue the self-map program — start
 cycle N" and point the agent here. Each cycle gets its own
 brainstorm → spec → plan → subagent execution → PR, and updates this file's
@@ -67,23 +67,26 @@ Decisions from cycle 2. The granular event feed (`node.status_changed`,
 `edge.added`, …) moves to a **History page** (project switcher section, near
 settings). Depends on cycles 1–2.
 
-### 4. Public Arkaik project in /projects — in progress (spec: [2026-08-04-public-self-map-design.md](2026-08-04-public-self-map-design.md))
+### 4. Public Arkaik project in /projects — ✅ SHIPPED 2026-08-04 (PR #338)
 
-The self-map as a default, public, uneditable project for anonymous and
-logged-in users. Open questions: how it's referenced in `/projects`
-(`seed/arkaik-self-map.json` already ships as the beachhead; Publik
-infrastructure exists but renders previews, not graphs); play-without-persist
-(local display tweaks that don't write back); stretch goal — full local
-sandbox edits (create/rewire/remove, reset on hard refresh), possibly via
-import-a-copy semantics which already exist.
+The self-map as a default public **full sandbox** (reset on refresh, not
+read-only): an in-memory seed provider behind the provider seam, a fourth
+"Explore" section on `/projects` rendered for everyone, the stable
+client-rendered URL `/project/arkaik-self-map`, a persistent banner with
+Reset and Import-a-copy. Spec:
+[2026-08-04-public-self-map-design.md](2026-08-04-public-self-map-design.md).
 
-### 5. Content population (subagent horde) — interleaved with 4
+### 5. Content population (subagent horde) — ✅ SHIPPED 2026-08-04 (PR A #339, PR B #340)
 
-Fan out subagents over the repo's PRs and docs to build: a comprehensive
-product mapping; an intelligent acceptance mapping; acceptances wired to
-Value elements; a full changelog history and narrative (deliverables,
-releases, decisions). Runs against the cycle 1–3 model so nothing is
-retrofitted. The back-and-forth with cycle 4 is deliberate (see Vision).
+The corpus-first fan-out populated the seed with the whole product and its
+history: **220 nodes** (34 views, 36 flows, 26 data models, 22 API
+endpoints, 84 valued acceptances, 18 decisions), 411 edges, three products
+(`studio`/`platform`/`toolchain`), four curated maps, and a 791-event
+journal — 111 deliverables (Lab-Note-sourced, real merge timestamps)
+grouped into 10 thematic-era releases, decision trails, honest per-node
+status arcs, and 3 open ideas. PR A = the map; PR B (stacked) = the story.
+Spec:
+[2026-08-04-content-population-design.md](2026-08-04-content-population-design.md).
 
 ## Standing decisions (do not re-litigate)
 

--- a/seed/arkaik-self-map.json
+++ b/seed/arkaik-self-map.json
@@ -79,7 +79,8 @@
           ]
         }
       ]
-    }
+    },
+    "version": "the-self-map"
   },
   "nodes": [
     {
@@ -3861,6 +3862,231 @@
         ]
       },
       "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DEC-journal-jsonl-sidecar",
+      "species": "decision",
+      "title": "The journal is an append-only JSONL sidecar, merged by git union",
+      "description": "History lives in a journal.jsonl file next to the snapshot, one self-contained event per line, never inside the bundle. Appending is the only write verb.",
+      "status": "live",
+      "metadata": {
+        "decision_status": "enacted",
+        "context": "Status was a mutable field that forgets, and the product needed timelines, changelogs and release notes without bloating or endangering the snapshot. Agents are the primary writers, and whole-file JSON regeneration invites the corrupt-the-whole-file failure mode. JSONL is the one shape where git's union merge is sound: concurrent appends merge automatically and order is recoverable from the events themselves.",
+        "consequences": "`arkaik init` configures `merge=union` for the sidecar, so parallel branches never conflict on history. A malformed line invalidates exactly one event — the validator reports the line number — and can never damage existing history or the snapshot. Embedded `journal[]` exists only as a projection for transport (import, Publik, LLM output), not as a storage recommendation.",
+        "decided_at": "2026-07-11"
+      },
+      "platforms": [],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DEC-snapshot-authoritative",
+      "species": "decision",
+      "title": "Snapshot authoritative for state, journal for history — never event sourcing",
+      "description": "The snapshot is the source of truth for current state and the journal for how it got there; v1 makes no replay promises and consumers never re-project one from the other.",
+      "status": "live",
+      "metadata": {
+        "decision_status": "enacted",
+        "context": "With two records of the graph, one had to win. Event sourcing would make the journal primary and force replay guarantees, merge semantics and migration of every historical event shape — machinery the product does not need. Per-node timestamps do not exist and clocks lie, so any reconciliation had to work by value.",
+        "consequences": "Every writer dual-writes: patch the snapshot and append the matching event in the same change. The validator cross-checks the two by value — the last status_changed.to must equal the current status — and any mismatch is a named validation error. Divergence is repaired explicitly by appending corrective events (the snapshot wins); silently re-projecting would launder drift instead of surfacing it.",
+        "decided_at": "2026-07-11"
+      },
+      "platforms": [],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DEC-history-never-rewritten",
+      "species": "decision",
+      "title": "History is never rewritten; legacy ids are accepted forever",
+      "description": "Journal events, once written, are never edited or migrated. Historical events may carry retired vocabulary (like the pre-v3 status ids) and every validator must accept them indefinitely.",
+      "status": "live",
+      "metadata": {
+        "decision_status": "enacted",
+        "context": "An append-only log is only trustworthy if it is actually immutable — a history that gets rewritten on every vocabulary change is a cache, not a record. Rewriting archives would also break the union-merge model and invalidate compacted release archives. The alternative, migrating old events on read, quietly forges what actually happened.",
+        "consequences": "Vocabulary changes ship as permanent read-side aliases, not history rewrites: validators must accept `prioritized`/`blocked` in old `node.status_changed` events forever. Unknown event types and fields are preserved on rewrite and ignored on read, so the vocabulary grows without version bumps. This is a standing decision of the self-map program: do not re-litigate.",
+        "decided_at": "2026-07-11"
+      },
+      "platforms": [],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DEC-deterministic-ids",
+      "species": "decision",
+      "title": "IDs are deterministic and human-readable, derived from titles",
+      "description": "Node ids are a species prefix plus the kebab-cased title (F-onboarding, DM-bounce), with deterministic disambiguation on collision — never random UUIDs.",
+      "status": "live",
+      "metadata": {
+        "decision_status": "enacted",
+        "context": "Bundles live in git and are written by agents in separate sessions: random ids make every diff noisy and force a lookup table between the map and any conversation about it. A human or agent should be able to predict the id of \"Checkout view\" without opening the file. The app originally violated this with UUID suffixes, recorded as a defect until the app adopted the convention.",
+        "consequences": "Ids double as stable references in prose, PRs and journal events. Renaming a title does not change the id; changing an id means repointing every edge, playlist reference and root_node_id in the same change. Title collisions disambiguate deterministically with a semantic suffix or a counter, and a duplicate id is an import-rejecting error.",
+        "decided_at": "2026-07-11"
+      },
+      "platforms": [],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DEC-local-first-no-account-gate",
+      "species": "decision",
+      "title": "Local-first: the browser owns the data, and sign-in never gates it",
+      "description": "Projects live in the browser's IndexedDB store by default. Every editing feature works without an account, a server, or a network connection.",
+      "status": "live",
+      "metadata": {
+        "decision_status": "enacted",
+        "context": "The try-it path had to be zero-friction: a Try Lokal button, no sign-up, full editor. Making the server the system of record would have coupled the core product to accounts and infrastructure before either earned their place, and the vision's design rule is that every layer above the format is opt-in convenience.",
+        "consequences": "Lokal is not a tier — it is the default. The store graduated from localStorage to IndexedDB via Dexie (with a one-time legacy import) to hold per-project journals without inflating every write. Services degrade to absent when their env vars are unset: the app must boot and serve every local-first surface regardless. Sign-in adds capabilities; it never rearranges or gates local projects.",
+        "decided_at": "2026-03-19"
+      },
+      "platforms": [],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DEC-publik-strips-journal",
+      "species": "decision",
+      "title": "Publik publishes journal-stripped by default, enforced server-side",
+      "description": "Publishing a snapshot to Publik removes the journal unless the request explicitly opts in — and the strip happens on the server, never trusting the client to do it.",
+      "status": "live",
+      "metadata": {
+        "decision_status": "enacted",
+        "context": "A snapshot is what you chose to share; the journal is how you got there — actors, timestamps, abandoned ideas, internal back-and-forth. A privacy default that depends on client behavior alone fails the moment a CLI flag is forgotten, and history leaking through a forgotten flag is not an acceptable failure mode.",
+        "consequences": "POST /api/publik removes `journal[]` server-side unless `?include_journal=true` is passed explicitly. Synk backups are the deliberate opposite — they are the user's private data, so history rides along and restores round-trip intact. Publik snapshots stay immutable: no update endpoint, re-publishing mints a new id.",
+        "decided_at": "2026-07-12"
+      },
+      "platforms": [],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DEC-synk-one-way-backup",
+      "species": "decision",
+      "title": "Synk is one-way-up backup, deduped by content hash — not sync",
+      "description": "Synk uploads whole bundles on a debounced interval and never writes server state into the local store unprompted. Identical content, detected by canonical-form SHA-256, stores nothing.",
+      "status": "live",
+      "metadata": {
+        "decision_status": "enacted",
+        "context": "Real two-way sync means conflict resolution and journal-based merge — a hard problem the free tier had no business pretending to solve. The browser stays the source of truth for every tier, so the honest free offering is backup: the server stores what the client sent, verbatim, and is never the system of record. Canonical serialization makes \"did anything change?\" a byte comparison.",
+        "consequences": "The client hashes the canonical bundle and the server skips the write when it matches the latest stored hash. Restore is an explicit user action that imports a version as a new local project through the existing collision handling — it never overwrites. Retention prunes on write (no cron), always keeping the newest backup per project regardless of age.",
+        "decided_at": "2026-07-13"
+      },
+      "platforms": [],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DEC-agent-plane-mcp",
+      "species": "decision",
+      "title": "The agent plane is an MCP server with validator-gated dual-writes",
+      "description": "Agents reach the map through arkaik-mcp tools — the same projections humans see as pages — and every mutating tool validates the mutated bundle before writing anything.",
+      "status": "live",
+      "metadata": {
+        "decision_status": "enacted",
+        "context": "An agent asked \"what's blocked on iOS?\" should not parse a 4,000-line JSON file into context or shell out to a CLI with flags. The audience-symmetry principle demanded every human surface have an agent-consumable twin produced by the same schema functions. Free-form file edits by agents invite snapshot-without-history drift, so the write path had to enforce the dual-write doctrine structurally.",
+        "consequences": "Every mutation is applied in memory, its journal events derived by the shared derivation, and `validateBundle` run over the result — any error returns pathed findings and writes nothing. On success the events append to the sidecar (actor arkaik-mcp) and the snapshot rewrites canonically. Repo and hosted backends share one identical tool catalog, so agent behavior cannot drift between modes.",
+        "decided_at": "2026-07-14"
+      },
+      "platforms": [],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DEC-shared-mutation-core",
+      "species": "decision",
+      "title": "One shared mutation core for every writer",
+      "description": "The app, the CLI, the MCP server and the hosted API all apply graph mutations and derive their journal events through the same core in the schema package — with only the actor as a parameter.",
+      "status": "live",
+      "metadata": {
+        "decision_status": "enacted",
+        "context": "By the time hosted projects arrived there were four writers of the same graph, and each private implementation of apply-and-derive was a place for the dual-write doctrine to silently diverge. The event-derivation logic was already pure; keeping copies of it in the app, the MCP server and the server API meant the same edit could produce different histories depending on who made it.",
+        "consequences": "Mutation application and event derivation live once in the schema package; the app binds actor arkaik-app, the MCP server arkaik-mcp, the GitHub App github-app. A new writer gets the doctrine by construction rather than by discipline. The hosted mutations endpoint takes ops — intents — and replays them through this same core under a row lock.",
+        "decided_at": "2026-07-27"
+      },
+      "platforms": [],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DEC-hosted-server-of-record",
+      "species": "decision",
+      "title": "Hosted projects: the server is the system of record — boundary crossed on purpose",
+      "description": "For a project moved into an account, the server owns the graph and mutates it directly, deliberately breaking the \"browser is the source of truth\" rule that still holds everywhere else.",
+      "status": "live",
+      "metadata": {
+        "decision_status": "enacted",
+        "context": "The browser cannot be the system of record for a graph that a coding agent in any repository and a GitHub webhook both write to. Keeping it there would have required two-way sync, conflict resolution and merge — exactly the problem the services boundaries deferred — to deliver a feature whose whole point is that there is one copy. The crossing was recorded in the spec rather than quietly edited, because the boundary is load-bearing everywhere else.",
+        "consequences": "Every server mutation passes the same validateBundle in the same transaction and is refused whole on any error; every change lands as a journal event with a real actor, so history says what acted. Synk and Publik are unchanged. The cost, stated plainly: hosted projects do not work offline — local-first projects still do, and remain the default, with export always available.",
+        "decided_at": "2026-07-27"
+      },
+      "platforms": [],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DEC-promotion-copy-not-move",
+      "species": "decision",
+      "title": "Move to account is a copy, never a move",
+      "description": "Promoting a local project to a hosted one copies it: the hosted copy gets a new server-owned prj_ id and the local original stays exactly where it is.",
+      "status": "live",
+      "metadata": {
+        "decision_status": "enacted",
+        "context": "Promotion crosses a trust boundary — from data the browser owns to data a server owns — and a destructive move would make trying the hosted feature a one-way door. Hosted projects also do not work offline, so destroying the local original would trade capability for capability. Nothing should be lost if the user changes their mind.",
+        "consequences": "The local project keeps working untouched after promotion; the hosted copy lives under a fresh prj_ id with an In your account badge. The same posture repeats across the product — Synk restore imports as a new project, Publik recipients import copies — so no arkaik surface ever destructively relocates a user's graph.",
+        "decided_at": "2026-07-27"
+      },
+      "platforms": [],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DEC-products-one-graph",
+      "species": "decision",
+      "title": "Products are an axis on one graph, not separate projects",
+      "description": "A family of apps sharing one substrate is modeled as product definitions in project metadata, with membership stored on flows and views — never as one project per app.",
+      "status": "live",
+      "metadata": {
+        "decision_status": "enacted",
+        "context": "A project was implicitly one product on three hardcoded platforms, so a web-only admin app showed phantom iOS tabs and dragged down Android delivery numbers it was never part of. Splitting into one project per app was rejected: the shared substrate — data models and endpoints — is the norm, and the cross-product traversal is exactly what the graph exists to answer.",
+        "consequences": "Products live at project.metadata.products; flows, views and acceptances store membership while data models and endpoints derive it by reachability. node.platforms stays authoritative, every surface picks its shape from the scope's platform arity, and a bundle with no products key behaves exactly as before — no migration, no new concepts. All product validation findings are warnings, so a product decision can never fail CI.",
+        "decided_at": "2026-08-02"
+      },
+      "platforms": [],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DEC-acceptance-first-intake",
+      "species": "decision",
+      "title": "Anchorless acceptances are intake, not floating NFRs",
+      "description": "An acceptance with no covers edges is an idea filed before its flows and views exist — a triage state waiting to be attached or decomposed, not a cross-cutting requirement that applies everywhere.",
+      "status": "live",
+      "metadata": {
+        "decision_status": "enacted",
+        "context": "A PM filing \"therapist can export session notes\" knows which app it is for before knowing which screens it needs, so the model had to admit acceptances before anchors. Reading absent anchors as applies-everywhere would duplicate noise across every product scope; reading stored membership as out-voting the graph would let an acceptance claim a product none of its anchors belong to.",
+        "consequences": "Anchors win: a covered acceptance derives its products from what it covers, and stored membership is read only when it covers nothing. Unanchored acceptances surface under All products as an inbox, with a validator warning rather than an error. The workflow shipped as attach, detach, create and split operations, with context carried through each split.",
+        "decided_at": "2026-08-02"
+      },
+      "platforms": [],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DEC-idea-stays-a-status",
+      "species": "decision",
+      "title": "Idea stays a status",
+      "description": "An idea is the first stage of the delivery lifecycle, not a separate species or a journal-only artifact. Revisited during the decisions-species work and deliberately re-parked.",
+      "status": "live",
+      "metadata": {
+        "decision_status": "enacted",
+        "context": "When the decision species arrived, ideas were the obvious next candidate for extraction — the journal already has idea.proposed events. But a node at status idea is a real node with a place in the graph: it renders as a ghost, participates in maps, and commits into discovery and backlog. Extracting it would split \"things we might build\" across two mechanisms with no reader benefit.",
+        "consequences": "The 7-status lifecycle keeps idea as its entry point, and the changelog's Design panel reads commitments as idea to discovery to backlog transitions. journal idea.proposed events remain the pre-node intake channel and can link to a node once one exists. The question stays answerable later — this was a re-park, not a never.",
+        "decided_at": "2026-08-03"
+      },
+      "platforms": [],
+      "project_id": "arkaik-self-map"
+    },
+    {
+      "id": "DEC-self-map-sandbox-seed",
+      "species": "decision",
+      "title": "The self-map ships as an in-memory sandbox seed, reset on refresh",
+      "description": "Arkaik's own map is a default public project served by an in-memory seed provider behind the provider seam: every mutation succeeds in per-tab memory, and refresh restores the pristine seed.",
+      "status": "live",
+      "metadata": {
+        "decision_status": "enacted",
+        "context": "The public self-map had to feel like the real product — read-only or display-tweaks-only were rejected because a graph browser you cannot edit demonstrates nothing. But persisting visitor edits to a shared public project is nonsense, and a shadow IndexedDB copy or a server-hosted project would each drag in machinery the page does not need.",
+        "consequences": "A seed DataProvider deep-clones the build-time-imported seed bundle through the normal migrate path, serves reads from memory, and lets every mutator succeed in memory — so all existing hooks, editors and journal appends behave identically, and the History page demonstrates itself. Two tabs are two sandboxes; a banner states the rules and offers Reset and Import a copy; the reserved id can never be squatted by an import.",
+        "decided_at": "2026-08-04"
+      },
+      "platforms": [],
+      "project_id": "arkaik-self-map"
     }
   ],
   "edges": [
@@ -6348,9 +6574,432 @@
       "source_id": "AC-mcp-validated-dual-write",
       "target_id": "V-mcp-tool-catalog",
       "edge_type": "covers"
+    },
+    {
+      "id": "e-DEC-journal-jsonl-sidecar-DM-journal-event",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-journal-jsonl-sidecar",
+      "target_id": "DM-journal-event",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-journal-jsonl-sidecar-F-journal-release",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-journal-jsonl-sidecar",
+      "target_id": "F-journal-release",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-journal-jsonl-sidecar-V-history",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-journal-jsonl-sidecar",
+      "target_id": "V-history",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-journal-jsonl-sidecar-AC-bad-line-cannot-corrupt-history",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-journal-jsonl-sidecar",
+      "target_id": "AC-bad-line-cannot-corrupt-history",
+      "edge_type": "generates"
+    },
+    {
+      "id": "e-DEC-journal-jsonl-sidecar-AC-parallel-appends-merge-clean",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-journal-jsonl-sidecar",
+      "target_id": "AC-parallel-appends-merge-clean",
+      "edge_type": "generates"
+    },
+    {
+      "id": "e-DEC-snapshot-authoritative-DM-project-bundle",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-snapshot-authoritative",
+      "target_id": "DM-project-bundle",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-snapshot-authoritative-DM-journal-event",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-snapshot-authoritative",
+      "target_id": "DM-journal-event",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-snapshot-authoritative-F-validate-bundle",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-snapshot-authoritative",
+      "target_id": "F-validate-bundle",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-history-never-rewritten-DM-journal-event",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-history-never-rewritten",
+      "target_id": "DM-journal-event",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-history-never-rewritten-V-history",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-history-never-rewritten",
+      "target_id": "V-history",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-history-never-rewritten-AC-history-never-rewritten",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-history-never-rewritten",
+      "target_id": "AC-history-never-rewritten",
+      "edge_type": "generates"
+    },
+    {
+      "id": "e-DEC-deterministic-ids-DM-node",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-deterministic-ids",
+      "target_id": "DM-node",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-deterministic-ids-DM-edge",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-deterministic-ids",
+      "target_id": "DM-edge",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-deterministic-ids-F-edit-graph-on-canvas",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-deterministic-ids",
+      "target_id": "F-edit-graph-on-canvas",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-local-first-no-account-gate-DM-projects",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-local-first-no-account-gate",
+      "target_id": "DM-projects",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-local-first-no-account-gate-DM-journals",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-local-first-no-account-gate",
+      "target_id": "DM-journals",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-local-first-no-account-gate-V-projects",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-local-first-no-account-gate",
+      "target_id": "V-projects",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-local-first-no-account-gate-F-sign-in",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-local-first-no-account-gate",
+      "target_id": "F-sign-in",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-local-first-no-account-gate-AC-signin-never-gates-local",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-local-first-no-account-gate",
+      "target_id": "AC-signin-never-gates-local",
+      "edge_type": "generates"
+    },
+    {
+      "id": "e-DEC-publik-strips-journal-API-post-publik",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-publik-strips-journal",
+      "target_id": "API-post-publik",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-publik-strips-journal-F-publish-to-publik",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-publik-strips-journal",
+      "target_id": "F-publish-to-publik",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-publik-strips-journal-DM-publik-snapshots",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-publik-strips-journal",
+      "target_id": "DM-publik-snapshots",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-publik-strips-journal-AC-publish-never-leaks-journal",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-publik-strips-journal",
+      "target_id": "AC-publish-never-leaks-journal",
+      "edge_type": "generates"
+    },
+    {
+      "id": "e-DEC-synk-one-way-backup-API-synk-project",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-synk-one-way-backup",
+      "target_id": "API-synk-project",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-synk-one-way-backup-DM-synk-backups",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-synk-one-way-backup",
+      "target_id": "DM-synk-backups",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-synk-one-way-backup-F-synk-backup-restore",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-synk-one-way-backup",
+      "target_id": "F-synk-backup-restore",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-synk-one-way-backup-AC-backups-dedupe-by-content",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-synk-one-way-backup",
+      "target_id": "AC-backups-dedupe-by-content",
+      "edge_type": "generates"
+    },
+    {
+      "id": "e-DEC-synk-one-way-backup-AC-restore-never-overwrites",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-synk-one-way-backup",
+      "target_id": "AC-restore-never-overwrites",
+      "edge_type": "generates"
+    },
+    {
+      "id": "e-DEC-agent-plane-mcp-V-mcp-tool-catalog",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-agent-plane-mcp",
+      "target_id": "V-mcp-tool-catalog",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-agent-plane-mcp-F-mcp-agent-session",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-agent-plane-mcp",
+      "target_id": "F-mcp-agent-session",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-agent-plane-mcp-AC-mcp-validated-dual-write",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-agent-plane-mcp",
+      "target_id": "AC-mcp-validated-dual-write",
+      "edge_type": "generates"
+    },
+    {
+      "id": "e-DEC-shared-mutation-core-API-post-graph-project-mutations",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-shared-mutation-core",
+      "target_id": "API-post-graph-project-mutations",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-shared-mutation-core-F-edit-graph-on-canvas",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-shared-mutation-core",
+      "target_id": "F-edit-graph-on-canvas",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-shared-mutation-core-F-mcp-agent-session",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-shared-mutation-core",
+      "target_id": "F-mcp-agent-session",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-hosted-server-of-record-DM-graph-projects",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-hosted-server-of-record",
+      "target_id": "DM-graph-projects",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-hosted-server-of-record-DM-graph-events",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-hosted-server-of-record",
+      "target_id": "DM-graph-events",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-hosted-server-of-record-API-post-graph-project-mutations",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-hosted-server-of-record",
+      "target_id": "API-post-graph-project-mutations",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-hosted-server-of-record-API-post-github-webhook",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-hosted-server-of-record",
+      "target_id": "API-post-github-webhook",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-promotion-copy-not-move-F-move-to-account",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-promotion-copy-not-move",
+      "target_id": "F-move-to-account",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-promotion-copy-not-move-DM-graph-projects",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-promotion-copy-not-move",
+      "target_id": "DM-graph-projects",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-promotion-copy-not-move-AC-move-to-account-copies",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-promotion-copy-not-move",
+      "target_id": "AC-move-to-account-copies",
+      "edge_type": "generates"
+    },
+    {
+      "id": "e-DEC-promotion-copy-not-move-AC-move-keeps-local-copy",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-promotion-copy-not-move",
+      "target_id": "AC-move-keeps-local-copy",
+      "edge_type": "generates"
+    },
+    {
+      "id": "e-DEC-products-one-graph-DM-product",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-products-one-graph",
+      "target_id": "DM-product",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-products-one-graph-F-manage-products",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-products-one-graph",
+      "target_id": "F-manage-products",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-products-one-graph-V-project-settings",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-products-one-graph",
+      "target_id": "V-project-settings",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-products-one-graph-AC-products-named-in-settings",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-products-one-graph",
+      "target_id": "AC-products-named-in-settings",
+      "edge_type": "generates"
+    },
+    {
+      "id": "e-DEC-acceptance-first-intake-V-acceptances-matrix",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-acceptance-first-intake",
+      "target_id": "V-acceptances-matrix",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-acceptance-first-intake-F-edit-acceptance",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-acceptance-first-intake",
+      "target_id": "F-edit-acceptance",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-acceptance-first-intake-AC-split-carries-context",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-acceptance-first-intake",
+      "target_id": "AC-split-carries-context",
+      "edge_type": "generates"
+    },
+    {
+      "id": "e-DEC-idea-stays-a-status-V-changelog",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-idea-stays-a-status",
+      "target_id": "V-changelog",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-idea-stays-a-status-V-delivery-board",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-idea-stays-a-status",
+      "target_id": "V-delivery-board",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-self-map-sandbox-seed-F-explore-sandbox",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-self-map-sandbox-seed",
+      "target_id": "F-explore-sandbox",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-self-map-sandbox-seed-V-sandbox-notice",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-self-map-sandbox-seed",
+      "target_id": "V-sandbox-notice",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-self-map-sandbox-seed-V-projects",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-self-map-sandbox-seed",
+      "target_id": "V-projects",
+      "edge_type": "impacts"
+    },
+    {
+      "id": "e-DEC-self-map-sandbox-seed-AC-sandbox-resets-pristine",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-self-map-sandbox-seed",
+      "target_id": "AC-sandbox-resets-pristine",
+      "edge_type": "generates"
+    },
+    {
+      "id": "e-DEC-self-map-sandbox-seed-AC-sandbox-edits-are-real",
+      "project_id": "arkaik-self-map",
+      "source_id": "DEC-self-map-sandbox-seed",
+      "target_id": "AC-sandbox-edits-are-real",
+      "edge_type": "generates"
     }
   ],
   "journal": [
+    {
+      "id": "012603191800000000000129",
+      "actor": "alexis",
+      "ts": "2026-03-19T18:00:00Z",
+      "type": "decision.status_changed",
+      "node_id": "DEC-local-first-no-account-gate",
+      "from": "proposed",
+      "to": "approved"
+    },
+    {
+      "id": "012603191800000000000562",
+      "ts": "2026-03-19T18:00:00Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DEC-local-first-no-account-gate",
+      "species": "decision",
+      "title": "Local-first: the browser owns the data, and sign-in never gates it"
+    },
+    {
+      "id": "012603191945460000000010",
+      "actor": "claude-code",
+      "ts": "2026-03-19T19:45:46Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-7",
+      "title": "The canvas comes alive",
+      "summary": "Arkaik gets its very first canvas: a map you can pan and zoom, with a minimap to keep your bearings. One little node marks the spot where your product graph will grow.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/7",
+      "node_ids": [
+        "V-journey-map"
+      ]
+    },
     {
       "id": "012603191945460000000054",
       "ts": "2026-03-19T19:45:46Z",
@@ -6368,6 +7017,24 @@
       "node_id": "AC-scoped-journey-never-lies",
       "species": "acceptance",
       "title": "Scoped journey never lies"
+    },
+    {
+      "id": "012603192045460000000266",
+      "actor": "claude-code",
+      "ts": "2026-03-19T20:45:46.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-journey-map",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603192045460000000412",
+      "actor": "claude-code",
+      "ts": "2026-03-19T20:45:46.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-scoped-journey-never-lies",
+      "from": "idea",
+      "to": "development"
     },
     {
       "id": "012603192048160000000005",
@@ -6397,6 +7064,127 @@
       "title": "Edge"
     },
     {
+      "id": "012603192100010000000130",
+      "actor": "alexis",
+      "ts": "2026-03-19T21:00:01Z",
+      "type": "decision.status_changed",
+      "node_id": "DEC-local-first-no-account-gate",
+      "from": "approved",
+      "to": "enacted"
+    },
+    {
+      "id": "012603192129390000000011",
+      "actor": "claude-code",
+      "ts": "2026-03-19T21:29:39Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-63",
+      "title": "Your product takes center stage",
+      "summary": "The map's first real shape: your product appears as a bold circle at the heart of the canvas, wearing its lifecycle status for everyone to see.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/63",
+      "node_ids": [
+        "V-journey-map"
+      ]
+    },
+    {
+      "id": "012603192145460000000267",
+      "actor": "claude-code",
+      "ts": "2026-03-19T21:45:46.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-journey-map",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012603192148160000000168",
+      "actor": "claude-code",
+      "ts": "2026-03-19T21:48:16.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-project",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603192148160000000170",
+      "actor": "claude-code",
+      "ts": "2026-03-19T21:48:16.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-node",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603192148160000000172",
+      "actor": "claude-code",
+      "ts": "2026-03-19T21:48:16.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-edge",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603192239450000000012",
+      "actor": "claude-code",
+      "ts": "2026-03-19T22:39:45Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-68",
+      "title": "Data and APIs join the map",
+      "summary": "Your data models and API endpoints now show up as their own distinct shapes, so the map covers what's under the hood — not just the screens people see.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/68",
+      "node_ids": []
+    },
+    {
+      "id": "012603200831190000000013",
+      "actor": "claude-code",
+      "ts": "2026-03-20T08:31:19Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-71",
+      "title": "Click to unfold your product",
+      "summary": "Click your product and its scenarios fan out around it; click again and they tuck back in. The first taste of a map that reveals detail only when you ask for it.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/71",
+      "node_ids": [
+        "V-journey-map"
+      ]
+    },
+    {
+      "id": "012603200942010000000014",
+      "actor": "claude-code",
+      "ts": "2026-03-20T09:42:01Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-73",
+      "title": "Flows open into flowcharts",
+      "summary": "Click a flow and it unfolds into its steps and decision points right on the canvas. You can now zoom from the big picture down to a single screen without ever leaving the map.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/73",
+      "node_ids": [
+        "V-journey-map"
+      ]
+    },
+    {
+      "id": "012603201357370000000015",
+      "actor": "claude-code",
+      "ts": "2026-03-20T13:57:37Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-75",
+      "title": "Always know where you are",
+      "summary": "A breadcrumb trail follows you as you drill from product to scenario to flow. Click any crumb to hop straight back up the hierarchy.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/75",
+      "node_ids": [
+        "V-journey-map"
+      ]
+    },
+    {
+      "id": "012603201834580000000016",
+      "actor": "claude-code",
+      "ts": "2026-03-20T18:34:58Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-78",
+      "title": "Every node tells its story",
+      "summary": "Click any node and a panel slides in with its title, status, platforms, and description — the map is no longer just shapes, it's readable.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/78",
+      "node_ids": [
+        "V-node-detail-panel"
+      ]
+    },
+    {
       "id": "012603201834580000000065",
       "ts": "2026-03-20T18:34:58Z",
       "actor": "claude-code",
@@ -6404,6 +7192,20 @@
       "node_id": "V-node-detail-panel",
       "species": "view",
       "title": "Node Detail Panel"
+    },
+    {
+      "id": "012603201852510000000017",
+      "actor": "claude-code",
+      "ts": "2026-03-20T18:52:51Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-79",
+      "title": "Edit details right where you read them",
+      "summary": "The detail panel is no longer read-only: rename a node, change its status, toggle its platforms, or rewrite its description — everything saves as you go.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/79",
+      "node_ids": [
+        "V-node-detail-panel",
+        "F-edit-node-details"
+      ]
     },
     {
       "id": "012603201852510000000071",
@@ -6422,6 +7224,47 @@
       "node_id": "AC-details-autosave-on-pause",
       "species": "acceptance",
       "title": "Detail edits autosave"
+    },
+    {
+      "id": "012603201934580000000288",
+      "actor": "claude-code",
+      "ts": "2026-03-20T19:34:58.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-node-detail-panel",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603201952510000000300",
+      "actor": "claude-code",
+      "ts": "2026-03-20T19:52:51.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-edit-node-details",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603201952510000000436",
+      "actor": "claude-code",
+      "ts": "2026-03-20T19:52:51.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-details-autosave-on-pause",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603202011020000000018",
+      "actor": "claude-code",
+      "ts": "2026-03-20T20:11:02Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-84",
+      "title": "Grow the map yourself",
+      "summary": "A new-node button lives on the canvas: pick a name, a species, a status, and watch your creation appear on the map. Your graph is officially yours to build.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/84",
+      "node_ids": [
+        "F-edit-graph-on-canvas",
+        "V-journey-map"
+      ]
     },
     {
       "id": "012603202011020000000063",
@@ -6469,6 +7312,165 @@
       "title": "Insert between playlist steps"
     },
     {
+      "id": "012603202034580000000289",
+      "actor": "claude-code",
+      "ts": "2026-03-20T20:34:58.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-node-detail-panel",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012603202035500000000019",
+      "actor": "claude-code",
+      "ts": "2026-03-20T20:35:50Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-85",
+      "title": "Add a child with one hover",
+      "summary": "Hover any product, scenario, or flow and an add-child button appears — the form comes pre-filled with the right parent and the right kind of node, so growing the hierarchy takes seconds.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/85",
+      "node_ids": [
+        "F-edit-graph-on-canvas"
+      ]
+    },
+    {
+      "id": "012603202047410000000020",
+      "actor": "claude-code",
+      "ts": "2026-03-20T20:47:41Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-89",
+      "title": "Draw connections by hand",
+      "summary": "Drag from one node to another to link them, pick what kind of relationship it is, and the connection sticks. Your map's wiring is now yours to draw.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/89",
+      "node_ids": [
+        "F-edit-graph-on-canvas",
+        "AC-valid-edge-types-only"
+      ]
+    },
+    {
+      "id": "012603202052510000000301",
+      "actor": "claude-code",
+      "ts": "2026-03-20T20:52:51.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-edit-node-details",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012603202111020000000284",
+      "actor": "claude-code",
+      "ts": "2026-03-20T21:11:02.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-edit-graph-on-canvas",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603202111020000000416",
+      "actor": "claude-code",
+      "ts": "2026-03-20T21:11:02.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-no-cyclic-playlists",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603202111020000000418",
+      "actor": "claude-code",
+      "ts": "2026-03-20T21:11:02.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-valid-edge-types-only",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603202111020000000420",
+      "actor": "claude-code",
+      "ts": "2026-03-20T21:11:02.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-delete-asks-first",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603202111020000000422",
+      "actor": "claude-code",
+      "ts": "2026-03-20T21:11:02.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-insert-between-steps",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603202125070000000021",
+      "actor": "claude-code",
+      "ts": "2026-03-20T21:25:07Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-90",
+      "title": "Tidy up, safely",
+      "summary": "Nodes and connections can now be deleted from the map — always with a confirmation first, and a clear heads-up when child nodes would go along for the ride.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/90",
+      "node_ids": [
+        "F-edit-graph-on-canvas",
+        "AC-delete-asks-first"
+      ]
+    },
+    {
+      "id": "012603202125070000000421",
+      "actor": "claude-code",
+      "ts": "2026-03-20T21:25:07Z",
+      "type": "node.status_changed",
+      "node_id": "AC-delete-asks-first",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012603202211020000000285",
+      "actor": "claude-code",
+      "ts": "2026-03-20T22:11:02.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-edit-graph-on-canvas",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012603202211020000000419",
+      "actor": "claude-code",
+      "ts": "2026-03-20T22:11:02.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-valid-edge-types-only",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012603202224290000000022",
+      "actor": "claude-code",
+      "ts": "2026-03-20T22:24:29Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-92",
+      "title": "A warm welcome for first-timers",
+      "summary": "Arriving with an empty slate? The home page now greets you with an example project one click away — import it and land straight on a living map to explore.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/92",
+      "node_ids": [
+        "V-projects",
+        "F-import-example-projects",
+        "AC-example-projects-one-click"
+      ]
+    },
+    {
+      "id": "012603202248400000000023",
+      "actor": "claude-code",
+      "ts": "2026-03-20T22:48:40Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-93",
+      "title": "Arkaik gets its face",
+      "summary": "The home page now carries the Arkaik logo, a baseline that says what this is all about, and a clear path to your projects — plus the logo in the header wherever you roam.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/93",
+      "node_ids": [
+        "V-landing"
+      ]
+    },
+    {
       "id": "012603202248400000000114",
       "ts": "2026-03-20T22:48:40Z",
       "actor": "claude-code",
@@ -6503,6 +7505,42 @@
       "node_id": "AC-move-to-account-copies",
       "species": "acceptance",
       "title": "Move to account keeps the original"
+    },
+    {
+      "id": "012603202348400000000386",
+      "actor": "claude-code",
+      "ts": "2026-03-20T23:48:40.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-landing",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603202348400000000390",
+      "actor": "claude-code",
+      "ts": "2026-03-20T23:48:40.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-sections-mirror-project-homes",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603202348400000000402",
+      "actor": "claude-code",
+      "ts": "2026-03-20T23:48:40.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-sign-in-adds-never-rearranges",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603202348400000000404",
+      "actor": "claude-code",
+      "ts": "2026-03-20T23:48:40.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-move-to-account-copies",
+      "from": "idea",
+      "to": "development"
     },
     {
       "id": "01K0SELFMAPSEED00000000001",
@@ -6640,6 +7678,121 @@
       "title": "Status migrations: hard cutover + permanent aliases"
     },
     {
+      "id": "012603210015420000000000",
+      "actor": "alexis",
+      "ts": "2026-03-21T00:15:42.000Z",
+      "type": "release.tagged",
+      "version": "first-graph",
+      "notes": "Arkaik is born as a canvas: an atomic hierarchy of products, scenarios, flows and views, semantic zoom that unfolds a product down to its flowcharts, a detail panel, and the first editable graph."
+    },
+    {
+      "id": "012603210048400000000387",
+      "actor": "claude-code",
+      "ts": "2026-03-21T00:48:40.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-landing",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012603210100000000000154",
+      "actor": "claude-code",
+      "ts": "2026-03-21T01:00:00.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-projects",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603210100000000000156",
+      "actor": "claude-code",
+      "ts": "2026-03-21T01:00:00.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-projects-routing",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603210100000000000158",
+      "actor": "claude-code",
+      "ts": "2026-03-21T01:00:00.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-import-json",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603210100000000000160",
+      "actor": "claude-code",
+      "ts": "2026-03-21T01:00:00.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-create-project",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603210100000000000162",
+      "actor": "claude-code",
+      "ts": "2026-03-21T01:00:00.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-delete-project",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603210100000000000164",
+      "actor": "claude-code",
+      "ts": "2026-03-21T01:00:00.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-import-example-projects",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603210100000000000166",
+      "actor": "claude-code",
+      "ts": "2026-03-21T01:00:00.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-project-bundle",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603210200000000000155",
+      "actor": "claude-code",
+      "ts": "2026-03-21T02:00:00.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-projects",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012603210200000000000165",
+      "actor": "claude-code",
+      "ts": "2026-03-21T02:00:00.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-import-example-projects",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012603210900460000000024",
+      "actor": "claude-code",
+      "ts": "2026-03-21T09:00:46Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-101",
+      "title": "Create, import, and delete projects",
+      "summary": "The projects screen is now a real home base: start a fresh project, bring one in from a JSON file, or remove one you no longer need — with a confirmation before anything disappears.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/101",
+      "node_ids": [
+        "V-projects",
+        "V-create-project-dialog",
+        "F-create-project",
+        "F-import-json",
+        "F-delete-project"
+      ]
+    },
+    {
       "id": "012603210900460000000052",
       "ts": "2026-03-21T09:00:46Z",
       "actor": "claude-code",
@@ -6667,6 +7820,48 @@
       "title": "Create lands where you asked"
     },
     {
+      "id": "012603210900460000000159",
+      "actor": "claude-code",
+      "ts": "2026-03-21T09:00:46Z",
+      "type": "node.status_changed",
+      "node_id": "F-import-json",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012603210900460000000161",
+      "actor": "claude-code",
+      "ts": "2026-03-21T09:00:46Z",
+      "type": "node.status_changed",
+      "node_id": "F-create-project",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012603210900460000000163",
+      "actor": "claude-code",
+      "ts": "2026-03-21T09:00:46Z",
+      "type": "node.status_changed",
+      "node_id": "F-delete-project",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012603210913160000000025",
+      "actor": "claude-code",
+      "ts": "2026-03-21T09:13:16Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-102",
+      "title": "Take your project with you as JSON",
+      "summary": "An always-visible Export button downloads your whole project as a single JSON file, so your map is never locked in.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/102",
+      "node_ids": [
+        "F-export-bundle",
+        "DM-project-bundle",
+        "AC-export-full-bundle"
+      ]
+    },
+    {
       "id": "012603210913160000000098",
       "ts": "2026-03-21T09:13:16Z",
       "actor": "claude-code",
@@ -6674,6 +7869,15 @@
       "node_id": "F-export-bundle",
       "species": "flow",
       "title": "Export Project Bundle"
+    },
+    {
+      "id": "012603210913160000000167",
+      "actor": "claude-code",
+      "ts": "2026-03-21T09:13:16Z",
+      "type": "node.status_changed",
+      "node_id": "DM-project-bundle",
+      "from": "development",
+      "to": "live"
     },
     {
       "id": "012603210913160000000182",
@@ -6721,6 +7925,113 @@
       "title": "Exports Re-import Cleanly"
     },
     {
+      "id": "012603211000460000000262",
+      "actor": "claude-code",
+      "ts": "2026-03-21T10:00:46.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-create-project-dialog",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603211000460000000398",
+      "actor": "claude-code",
+      "ts": "2026-03-21T10:00:46.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-signed-in-skips-landing",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603211000460000000400",
+      "actor": "claude-code",
+      "ts": "2026-03-21T10:00:46.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-create-lands-in-chosen-home",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603211013160000000354",
+      "actor": "claude-code",
+      "ts": "2026-03-21T10:13:16.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-export-bundle",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603211013160000000522",
+      "actor": "claude-code",
+      "ts": "2026-03-21T10:13:16.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-export-full-bundle",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603211024360000000516",
+      "actor": "claude-code",
+      "ts": "2026-03-21T10:24:36.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-legacy-bundle-migrates",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603211024360000000518",
+      "actor": "claude-code",
+      "ts": "2026-03-21T10:24:36.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-broken-import-explains",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603211024360000000520",
+      "actor": "claude-code",
+      "ts": "2026-03-21T10:24:36.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-reserved-ids-stay-reserved",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603211024360000000524",
+      "actor": "claude-code",
+      "ts": "2026-03-21T10:24:36.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-export-reimports-cleanly",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603211030090000000026",
+      "actor": "claude-code",
+      "ts": "2026-03-21T10:30:09Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-105",
+      "title": "Richer statuses at a glance",
+      "summary": "Cards now speak a finer language of progress — eight statuses from idea to live, compact icons with tooltips, and platform icons that show exactly where each piece runs.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/105",
+      "node_ids": [
+        "V-journey-map"
+      ]
+    },
+    {
+      "id": "012603211043430000000027",
+      "actor": "claude-code",
+      "ts": "2026-03-21T10:43:43Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-107",
+      "title": "The keyboard joins in",
+      "summary": "Press Escape to close the panel, Delete to remove the selected node (it still asks first), and Cmd+E to export — and nothing fires while you're busy typing.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/107",
+      "node_ids": [
+        "F-navigate-by-keyboard"
+      ]
+    },
+    {
       "id": "012603211043430000000064",
       "ts": "2026-03-21T10:43:43Z",
       "actor": "claude-code",
@@ -6728,6 +8039,80 @@
       "node_id": "F-navigate-by-keyboard",
       "species": "flow",
       "title": "Navigate By Keyboard"
+    },
+    {
+      "id": "012603211100460000000263",
+      "actor": "claude-code",
+      "ts": "2026-03-21T11:00:46.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-create-project-dialog",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012603211113160000000355",
+      "actor": "claude-code",
+      "ts": "2026-03-21T11:13:16.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-export-bundle",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012603211113160000000523",
+      "actor": "claude-code",
+      "ts": "2026-03-21T11:13:16.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-export-full-bundle",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012603211143430000000286",
+      "actor": "claude-code",
+      "ts": "2026-03-21T11:43:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-navigate-by-keyboard",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603211201160000000028",
+      "actor": "claude-code",
+      "ts": "2026-03-21T12:01:16Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-108",
+      "title": "See progress per platform",
+      "summary": "Each screen now tracks its own status per platform, and flows roll it all up into little gauges — so you can tell how far along Web or iOS really is at a glance.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/108",
+      "node_ids": [
+        "V-journey-map",
+        "V-node-detail-panel"
+      ]
+    },
+    {
+      "id": "012603211243430000000287",
+      "actor": "claude-code",
+      "ts": "2026-03-21T12:43:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-navigate-by-keyboard",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012603211759410000000029",
+      "actor": "claude-code",
+      "ts": "2026-03-21T17:59:41Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-139",
+      "title": "Edit a flow's playlist from the panel",
+      "summary": "Flows now carry an editable playlist: reorder steps, branch on conditions and junctions, and search for — or create — the screen you need without leaving the detail panel.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/139",
+      "node_ids": [
+        "F-edit-flow-playlist",
+        "V-node-detail-panel",
+        "AC-playlist-branching-entries"
+      ]
     },
     {
       "id": "012603211759410000000072",
@@ -6757,6 +8142,69 @@
       "title": "Playlists branch inline"
     },
     {
+      "id": "012603211829160000000030",
+      "actor": "claude-code",
+      "ts": "2026-03-21T18:29:16Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-141",
+      "title": "One plus button to insert anything",
+      "summary": "The plus button between two steps now opens a single dialog: pick a view, flow, condition, or junction, then search for an existing one or create it on the spot.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/141",
+      "node_ids": [
+        "F-edit-graph-on-canvas",
+        "AC-insert-between-steps"
+      ]
+    },
+    {
+      "id": "012603211829160000000423",
+      "actor": "claude-code",
+      "ts": "2026-03-21T18:29:16Z",
+      "type": "node.status_changed",
+      "node_id": "AC-insert-between-steps",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012603211859410000000302",
+      "actor": "claude-code",
+      "ts": "2026-03-21T18:59:41.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-edit-flow-playlist",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603211859410000000438",
+      "actor": "claude-code",
+      "ts": "2026-03-21T18:59:41.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-playlist-cycle-blocked",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603211859410000000440",
+      "actor": "claude-code",
+      "ts": "2026-03-21T18:59:41.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-playlist-branching-entries",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603211938480000000031",
+      "actor": "claude-code",
+      "ts": "2026-03-21T19:38:48Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-144",
+      "title": "Read your project raw",
+      "summary": "A new Raw panel shows your whole project as JSON or YAML, with tabs to switch formats and one-click copy — handy when you want to see exactly what's under the map.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/144",
+      "node_ids": [
+        "V-raw-bundle-panel"
+      ]
+    },
+    {
       "id": "012603211938480000000066",
       "ts": "2026-03-21T19:38:48Z",
       "actor": "claude-code",
@@ -6775,6 +8223,24 @@
       "title": "Format switch preserves draft"
     },
     {
+      "id": "012603211959410000000303",
+      "actor": "claude-code",
+      "ts": "2026-03-21T19:59:41.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-edit-flow-playlist",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012603211959410000000441",
+      "actor": "claude-code",
+      "ts": "2026-03-21T19:59:41.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-playlist-branching-entries",
+      "from": "development",
+      "to": "live"
+    },
+    {
       "id": "012603212021030000000119",
       "ts": "2026-03-21T20:21:03Z",
       "actor": "claude-code",
@@ -6782,6 +8248,91 @@
       "node_id": "AC-example-projects-one-click",
       "species": "acceptance",
       "title": "Examples are one click away"
+    },
+    {
+      "id": "012603212038480000000290",
+      "actor": "claude-code",
+      "ts": "2026-03-21T20:38:48.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-raw-bundle-panel",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603212038480000000444",
+      "actor": "claude-code",
+      "ts": "2026-03-21T20:38:48.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-raw-format-switch-roundtrips",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603212121030000000396",
+      "actor": "claude-code",
+      "ts": "2026-03-21T21:21:03.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-example-projects-one-click",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603212138480000000291",
+      "actor": "claude-code",
+      "ts": "2026-03-21T21:38:48.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-raw-bundle-panel",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012603212221030000000397",
+      "actor": "claude-code",
+      "ts": "2026-03-21T22:21:03.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-example-projects-one-click",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012603212230570000000032",
+      "actor": "claude-code",
+      "ts": "2026-03-21T22:30:57Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-149",
+      "title": "The map lays itself out",
+      "summary": "The canvas now arranges itself with a proper layout engine, so the graph stays tidy on its own however deep you drill.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/149",
+      "node_ids": [
+        "V-journey-map"
+      ]
+    },
+    {
+      "id": "012603212342020000000033",
+      "actor": "claude-code",
+      "ts": "2026-03-21T23:42:02Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-150",
+      "title": "View cards, take two",
+      "summary": "View cards got a redesign: a large variant with cover and details, a compact one for dense maps, popovers showing what each screen calls, and a switch in the top bar to pick your style.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/150",
+      "node_ids": [
+        "V-journey-map"
+      ]
+    },
+    {
+      "id": "012603220019020000000034",
+      "actor": "claude-code",
+      "ts": "2026-03-22T00:19:02Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-153",
+      "title": "Meet the Library",
+      "summary": "Every node in your project, browsable outside the canvas: filter by species, search by title or description, and flip between a gallery and a sortable directory.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/153",
+      "node_ids": [
+        "V-library",
+        "F-browse-library"
+      ]
     },
     {
       "id": "012603220019020000000067",
@@ -6811,6 +8362,65 @@
       "title": "Bulk selection stays honest"
     },
     {
+      "id": "012603220119020000000292",
+      "actor": "claude-code",
+      "ts": "2026-03-22T01:19:02.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-library",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603220119020000000306",
+      "actor": "claude-code",
+      "ts": "2026-03-22T01:19:02.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-browse-library",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603220119020000000460",
+      "actor": "claude-code",
+      "ts": "2026-03-22T01:19:02.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-library-bulk-move-honest",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603220219020000000293",
+      "actor": "claude-code",
+      "ts": "2026-03-22T02:19:02.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-library",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012603220219020000000307",
+      "actor": "claude-code",
+      "ts": "2026-03-22T02:19:02.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-browse-library",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012603220655160000000035",
+      "actor": "claude-code",
+      "ts": "2026-03-22T06:55:16Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-154",
+      "title": "A sidebar to move around",
+      "summary": "Projects now have a proper sidebar: switch projects, hop between Canvas and Library, and enjoy one clean header per page instead of stacked toolbars.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/154",
+      "node_ids": [
+        "V-library",
+        "V-journey-map"
+      ]
+    },
+    {
       "id": "012603221054470000000101",
       "ts": "2026-03-22T10:54:47Z",
       "actor": "claude-code",
@@ -6836,6 +8446,111 @@
       "node_id": "AC-docs-live-in-app",
       "species": "acceptance",
       "title": "Docs Live In App"
+    },
+    {
+      "id": "012603221154470000000360",
+      "actor": "claude-code",
+      "ts": "2026-03-22T11:54:47.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-browse-docs",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603221154470000000362",
+      "actor": "claude-code",
+      "ts": "2026-03-22T11:54:47.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-docs-site",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603221154470000000532",
+      "actor": "claude-code",
+      "ts": "2026-03-22T11:54:47.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-docs-live-in-app",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603221852510000000437",
+      "actor": "claude-code",
+      "ts": "2026-03-22T18:52:51.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-details-autosave-on-pause",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012603222248400000000403",
+      "actor": "claude-code",
+      "ts": "2026-03-22T22:48:40.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-sign-in-adds-never-rearranges",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012603230000000000000157",
+      "actor": "claude-code",
+      "ts": "2026-03-23T00:00:00.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-projects-routing",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012603230900460000000401",
+      "actor": "claude-code",
+      "ts": "2026-03-23T09:00:46.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-create-lands-in-chosen-home",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012603230924360000000521",
+      "actor": "claude-code",
+      "ts": "2026-03-23T09:24:36.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-reserved-ids-stay-reserved",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012603231759410000000439",
+      "actor": "claude-code",
+      "ts": "2026-03-23T17:59:41.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-playlist-cycle-blocked",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012603231938480000000445",
+      "actor": "claude-code",
+      "ts": "2026-03-23T19:38:48.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-raw-format-switch-roundtrips",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012603240544220000000036",
+      "actor": "claude-code",
+      "ts": "2026-03-24T05:44:22Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-167",
+      "title": "Generate a map with any AI",
+      "summary": "A new Generate page assembles a ready-to-paste prompt for your favorite AI, so it can draft a map of your product for you — copy it or download it in one click.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/167",
+      "node_ids": [
+        "V-generate-prompt",
+        "F-generate-with-ai",
+        "AC-prompt-for-any-llm"
+      ]
     },
     {
       "id": "012603240544220000000092",
@@ -6865,6 +8580,245 @@
       "title": "One prompt, any LLM"
     },
     {
+      "id": "012603240644220000000342",
+      "actor": "claude-code",
+      "ts": "2026-03-24T06:44:22.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-generate-prompt",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603240644220000000352",
+      "actor": "claude-code",
+      "ts": "2026-03-24T06:44:22.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-generate-with-ai",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603240644220000000514",
+      "actor": "claude-code",
+      "ts": "2026-03-24T06:44:22.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-prompt-for-any-llm",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012603240744220000000343",
+      "actor": "claude-code",
+      "ts": "2026-03-24T07:44:22.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-generate-prompt",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012603240744220000000353",
+      "actor": "claude-code",
+      "ts": "2026-03-24T07:44:22.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-generate-with-ai",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012603240744220000000515",
+      "actor": "claude-code",
+      "ts": "2026-03-24T07:44:22.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-prompt-for-any-llm",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012603241054470000000533",
+      "actor": "claude-code",
+      "ts": "2026-03-24T10:54:47.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-docs-live-in-app",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012603270625410000000037",
+      "actor": "claude-code",
+      "ts": "2026-03-27T06:25:41Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-170",
+      "title": "Attach screenshots to your screens",
+      "summary": "Drag and drop a screenshot onto any platform variant in the detail panel — each platform keeps its own image, stored right inside your project.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/170",
+      "node_ids": [
+        "V-node-detail-panel",
+        "F-edit-node-details"
+      ]
+    },
+    {
+      "id": "012603270747390000000038",
+      "actor": "claude-code",
+      "ts": "2026-03-27T07:47:39Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-172",
+      "title": "Screenshots show up on the map",
+      "summary": "View cards now display your real screenshots instead of a placeholder, so the canvas starts to look like your actual product.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/172",
+      "node_ids": [
+        "V-journey-map"
+      ]
+    },
+    {
+      "id": "012603272037530000000039",
+      "actor": "claude-code",
+      "ts": "2026-03-27T20:37:53Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-174",
+      "title": "Zoom into any screenshot",
+      "summary": "Click a screenshot to open a full-screen preview — flip between platforms with arrow keys or tabs, with each platform's status and notes alongside.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/174",
+      "node_ids": [
+        "V-node-detail-panel",
+        "V-journey-map"
+      ]
+    },
+    {
+      "id": "012603272107530000000001",
+      "actor": "alexis",
+      "ts": "2026-03-27T21:07:53.000Z",
+      "type": "release.tagged",
+      "version": "playlists-and-library",
+      "notes": "Flows learn to tell their story as playlists, projects gain import/export, a library, keyboard shortcuts, and screenshots — the graph becomes something you actually work in."
+    },
+    {
+      "id": "012607100900000000000121",
+      "actor": "alexis",
+      "ts": "2026-07-10T09:00:00Z",
+      "type": "decision.status_changed",
+      "node_id": "DEC-journal-jsonl-sidecar",
+      "from": "proposed",
+      "to": "approved"
+    },
+    {
+      "id": "012607100900000000000558",
+      "ts": "2026-07-10T09:00:00Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DEC-journal-jsonl-sidecar",
+      "species": "decision",
+      "title": "The journal is an append-only JSONL sidecar, merged by git union"
+    },
+    {
+      "id": "012607100905000000000123",
+      "actor": "alexis",
+      "ts": "2026-07-10T09:05:00Z",
+      "type": "decision.status_changed",
+      "node_id": "DEC-snapshot-authoritative",
+      "from": "proposed",
+      "to": "approved"
+    },
+    {
+      "id": "012607100905000000000559",
+      "ts": "2026-07-10T09:05:00Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DEC-snapshot-authoritative",
+      "species": "decision",
+      "title": "Snapshot authoritative for state, journal for history — never event sourcing"
+    },
+    {
+      "id": "012607100910000000000125",
+      "actor": "alexis",
+      "ts": "2026-07-10T09:10:00Z",
+      "type": "decision.status_changed",
+      "node_id": "DEC-history-never-rewritten",
+      "from": "proposed",
+      "to": "approved"
+    },
+    {
+      "id": "012607100910000000000560",
+      "ts": "2026-07-10T09:10:00Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DEC-history-never-rewritten",
+      "species": "decision",
+      "title": "History is never rewritten; legacy ids are accepted forever"
+    },
+    {
+      "id": "012607111000000000000127",
+      "actor": "alexis",
+      "ts": "2026-07-11T10:00:00Z",
+      "type": "decision.status_changed",
+      "node_id": "DEC-deterministic-ids",
+      "from": "proposed",
+      "to": "approved"
+    },
+    {
+      "id": "012607111000000000000561",
+      "ts": "2026-07-11T10:00:00Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DEC-deterministic-ids",
+      "species": "decision",
+      "title": "IDs are deterministic and human-readable, derived from titles"
+    },
+    {
+      "id": "012607111200000000000122",
+      "actor": "alexis",
+      "ts": "2026-07-11T12:00:00Z",
+      "type": "decision.status_changed",
+      "node_id": "DEC-journal-jsonl-sidecar",
+      "from": "approved",
+      "to": "enacted"
+    },
+    {
+      "id": "012607111205000000000124",
+      "actor": "alexis",
+      "ts": "2026-07-11T12:05:00Z",
+      "type": "decision.status_changed",
+      "node_id": "DEC-snapshot-authoritative",
+      "from": "approved",
+      "to": "enacted"
+    },
+    {
+      "id": "012607111210000000000126",
+      "actor": "alexis",
+      "ts": "2026-07-11T12:10:00Z",
+      "type": "decision.status_changed",
+      "node_id": "DEC-history-never-rewritten",
+      "from": "approved",
+      "to": "enacted"
+    },
+    {
+      "id": "012607111250180000000040",
+      "actor": "claude-code",
+      "ts": "2026-07-11T12:50:18Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-175",
+      "title": "A complete example product to explore",
+      "summary": "Pebbles, a fully mapped sample product, now ships with the app. Open it to see what a real product graph looks like — flows, views, data models and all — before mapping your own.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/175",
+      "node_ids": [
+        "F-import-example-projects",
+        "AC-example-projects-one-click",
+        "DM-project-bundle"
+      ]
+    },
+    {
+      "id": "012607111417360000000041",
+      "actor": "claude-code",
+      "ts": "2026-07-11T14:17:36Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-176",
+      "title": "The example project opens without a hitch",
+      "summary": "Two lookalike ids were tripping up the Pebbles sample and cascading into errors across the whole map. Every node and connection now lands exactly where it should.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/176",
+      "node_ids": [
+        "F-import-example-projects"
+      ]
+    },
+    {
       "id": "012607111417360000000104",
       "ts": "2026-07-11T14:17:36Z",
       "actor": "claude-code",
@@ -6874,6 +8828,146 @@
       "title": "Arkaik Agent Skill"
     },
     {
+      "id": "012607111517360000000366",
+      "actor": "claude-code",
+      "ts": "2026-07-11T15:17:36.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-arkaik-skill",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607111754490000000042",
+      "actor": "claude-code",
+      "ts": "2026-07-11T17:54:49Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-196",
+      "title": "One shared definition of what a bundle is",
+      "summary": "Projects, nodes, edges and playlists now have a single published schema that the app and any outside tool can lean on — so everyone agrees on what a valid bundle looks like.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/196",
+      "node_ids": [
+        "DM-project-bundle",
+        "DM-project",
+        "DM-node",
+        "DM-edge"
+      ]
+    },
+    {
+      "id": "012607111754490000000169",
+      "actor": "claude-code",
+      "ts": "2026-07-11T17:54:49Z",
+      "type": "node.status_changed",
+      "node_id": "DM-project",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607111754490000000171",
+      "actor": "claude-code",
+      "ts": "2026-07-11T17:54:49Z",
+      "type": "node.status_changed",
+      "node_id": "DM-node",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607111754490000000173",
+      "actor": "claude-code",
+      "ts": "2026-07-11T17:54:49Z",
+      "type": "node.status_changed",
+      "node_id": "DM-edge",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607111808080000000043",
+      "actor": "claude-code",
+      "ts": "2026-07-11T18:08:08Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-197",
+      "title": "Broken bundles get caught — with reasons",
+      "summary": "Validation now understands the graph itself: duplicate ids, edges pointing nowhere, circular playlists, mismatched connections. Each finding tells you exactly where the problem lives and how serious it is.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/197",
+      "node_ids": [
+        "F-validate-bundle",
+        "AC-validator-blocks-broken-bundle",
+        "AC-no-cyclic-playlists",
+        "DM-project-bundle"
+      ]
+    },
+    {
+      "id": "012607111808080000000417",
+      "actor": "claude-code",
+      "ts": "2026-07-11T18:08:08Z",
+      "type": "node.status_changed",
+      "node_id": "AC-no-cyclic-playlists",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607111913190000000044",
+      "actor": "claude-code",
+      "ts": "2026-07-11T19:13:19Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-199",
+      "title": "Imports that fail explain themselves",
+      "summary": "When a bundle can't be imported, the app now points at the exact field that's wrong — like a missing id on the third node — instead of failing with a shrug.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/199",
+      "node_ids": [
+        "F-import-json",
+        "AC-broken-import-explains",
+        "F-validate-bundle"
+      ]
+    },
+    {
+      "id": "012607111913190000000519",
+      "actor": "claude-code",
+      "ts": "2026-07-11T19:13:19Z",
+      "type": "node.status_changed",
+      "node_id": "AC-broken-import-explains",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607112233470000000045",
+      "actor": "claude-code",
+      "ts": "2026-07-11T22:33:47Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-208",
+      "title": "Old bundles still open",
+      "summary": "Bundles saved in earlier formats are quietly upgraded when you load or import them, and anything the app doesn't recognize is carried along untouched. Nothing you exported before gets left behind.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/208",
+      "node_ids": [
+        "AC-legacy-bundle-migrates",
+        "F-import-json",
+        "DM-project-bundle"
+      ]
+    },
+    {
+      "id": "012607112233470000000517",
+      "actor": "claude-code",
+      "ts": "2026-07-11T22:33:47Z",
+      "type": "node.status_changed",
+      "node_id": "AC-legacy-bundle-migrates",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607112252330000000046",
+      "actor": "claude-code",
+      "ts": "2026-07-11T22:52:33Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-209",
+      "title": "Link your map to the outside world",
+      "summary": "Nodes can now carry typed links to the places work actually happens — Figma files, GitHub issues, pull requests and more — and projects can wear a version label. Everything survives a round trip intact.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/209",
+      "node_ids": [
+        "F-sync-refs",
+        "DM-node",
+        "DM-project-bundle"
+      ]
+    },
+    {
       "id": "012607112307110000000008",
       "ts": "2026-07-11T23:07:11Z",
       "actor": "claude-code",
@@ -6881,6 +8975,75 @@
       "node_id": "DM-journal-event",
       "species": "data-model",
       "title": "JournalEvent"
+    },
+    {
+      "id": "012607112307110000000047",
+      "actor": "claude-code",
+      "ts": "2026-07-11T23:07:11Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-210",
+      "title": "Your map can now remember its history",
+      "summary": "A bundle can carry an append-only log of everything that happened — status changes, releases, ideas, requests — and validation keeps the log and the current map in agreement. One bad line never corrupts the rest.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/210",
+      "node_ids": [
+        "DM-journal-event",
+        "AC-bad-line-cannot-corrupt-history",
+        "F-validate-bundle"
+      ]
+    },
+    {
+      "id": "012607112325450000000048",
+      "actor": "claude-code",
+      "ts": "2026-07-11T23:25:45Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-211",
+      "title": "See external links right on your nodes",
+      "summary": "References now show up in the detail panel as recognizable links — a Figma icon, a pull request with its live status mirrored beside it. The mirrored status is display only; your own status is never touched.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/211",
+      "node_ids": [
+        "V-node-detail-panel",
+        "F-sync-refs"
+      ]
+    },
+    {
+      "id": "012607112354000000000049",
+      "actor": "claude-code",
+      "ts": "2026-07-11T23:54:00Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-213",
+      "title": "Your agent keeps the history for you",
+      "summary": "The agent skill now records a journal event alongside every change it makes to the map, and the validator refuses to let the two drift apart. It also adapts itself to your project's own names and file paths.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/213",
+      "node_ids": [
+        "V-arkaik-skill",
+        "F-journal-release",
+        "F-validate-bundle"
+      ]
+    },
+    {
+      "id": "012607112354000000000367",
+      "actor": "claude-code",
+      "ts": "2026-07-11T23:54:00Z",
+      "type": "node.status_changed",
+      "node_id": "V-arkaik-skill",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607112355590000000050",
+      "actor": "claude-code",
+      "ts": "2026-07-11T23:55:59Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-214",
+      "title": "Browse your project's story",
+      "summary": "Every node now shows a History timeline in its panel, and a new Changelog view groups what shipped by release, with open ideas waiting below. Projects without a journal stay calm and empty — never an error.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/214",
+      "node_ids": [
+        "V-changelog",
+        "V-node-detail-panel",
+        "F-review-changelog",
+        "AC-empty-journal-calm"
+      ]
     },
     {
       "id": "012607112355590000000077",
@@ -6919,6 +9082,126 @@
       "title": "Deliverables Anchor When Shipped"
     },
     {
+      "id": "012607120007110000000174",
+      "actor": "claude-code",
+      "ts": "2026-07-12T00:07:11.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-journal-event",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607120025590000000002",
+      "actor": "alexis",
+      "ts": "2026-07-12T00:25:59.000Z",
+      "type": "release.tagged",
+      "version": "the-format",
+      "notes": "The bundle grows a written contract: a shared schema package, validation in CI, external refs, and the journal — history as append-only events with its first changelog view."
+    },
+    {
+      "id": "012607120055590000000312",
+      "actor": "claude-code",
+      "ts": "2026-07-12T00:55:59.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-changelog",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607120055590000000322",
+      "actor": "claude-code",
+      "ts": "2026-07-12T00:55:59.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-review-changelog",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607120055590000000468",
+      "actor": "claude-code",
+      "ts": "2026-07-12T00:55:59.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-changelog-design-delivery-split",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607120055590000000470",
+      "actor": "claude-code",
+      "ts": "2026-07-12T00:55:59.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-deliverable-anchored-first-ship",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607120107110000000175",
+      "actor": "claude-code",
+      "ts": "2026-07-12T01:07:11.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-journal-event",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607120155590000000313",
+      "actor": "claude-code",
+      "ts": "2026-07-12T01:55:59.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-changelog",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607120155590000000323",
+      "actor": "claude-code",
+      "ts": "2026-07-12T01:55:59.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-review-changelog",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607120811420000000051",
+      "actor": "claude-code",
+      "ts": "2026-07-12T08:11:42Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-226",
+      "title": "Exports that diff cleanly in git",
+      "summary": "Exported bundles now always come out in one canonical shape — same key order, same sorting, same formatting every time. Commit your map to a repo and the diffs show what actually changed, nothing else.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/226",
+      "node_ids": [
+        "F-export-bundle",
+        "V-raw-bundle-panel",
+        "DM-project-bundle",
+        "AC-export-reimports-cleanly"
+      ]
+    },
+    {
+      "id": "012607120811420000000525",
+      "actor": "claude-code",
+      "ts": "2026-07-12T08:11:42Z",
+      "type": "node.status_changed",
+      "node_id": "AC-export-reimports-cleanly",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607120822310000000052",
+      "actor": "claude-code",
+      "ts": "2026-07-12T08:22:31Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-227",
+      "title": "Meet the arkaik CLI: validate your bundle from the terminal",
+      "summary": "A new command-line companion checks any bundle right where it lives, pointing at exactly what's wrong — and --fix-format tidies the file into canonical shape for you.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/227",
+      "node_ids": [
+        "V-cli-terminal",
+        "F-validate-bundle",
+        "AC-validator-blocks-broken-bundle"
+      ]
+    },
+    {
       "id": "012607120822310000000103",
       "ts": "2026-07-12T08:22:31Z",
       "actor": "claude-code",
@@ -6944,6 +9227,23 @@
       "node_id": "AC-validator-blocks-broken-bundle",
       "species": "acceptance",
       "title": "Validator Blocks Broken Bundles"
+    },
+    {
+      "id": "012607120835260000000053",
+      "actor": "claude-code",
+      "ts": "2026-07-12T08:35:26Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-228",
+      "title": "One command to map a repo",
+      "summary": "arkaik init sets up everything a repo needs — a starter bundle, a journal, and the agent skill tuned to your product. Re-run it anytime: it never clobbers your work, and --update refreshes just the skill.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/228",
+      "node_ids": [
+        "V-cli-terminal",
+        "F-init-repo",
+        "V-arkaik-skill",
+        "AC-one-command-repo-setup",
+        "AC-init-rerun-never-clobbers"
+      ]
     },
     {
       "id": "012607120835260000000106",
@@ -6982,6 +9282,22 @@
       "title": "One Skill Doctrine Everywhere"
     },
     {
+      "id": "012607120855430000000054",
+      "actor": "claude-code",
+      "ts": "2026-07-12T08:55:43Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-229",
+      "title": "Your project's history, readable and releasable",
+      "summary": "arkaik log tells the story of your map — the whole changelog or a single node's timeline. And arkaik release tags a version and drafts the release notes for you from everything that shipped since the last one.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/229",
+      "node_ids": [
+        "V-cli-terminal",
+        "F-journal-release",
+        "DM-journal-event",
+        "AC-release-notes-draft-themselves"
+      ]
+    },
+    {
       "id": "012607120855430000000108",
       "ts": "2026-07-12T08:55:43Z",
       "actor": "claude-code",
@@ -7018,6 +9334,21 @@
       "title": "Release Notes Draft Themselves"
     },
     {
+      "id": "012607120913150000000055",
+      "actor": "claude-code",
+      "ts": "2026-07-12T09:13:15Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-230",
+      "title": "Linked issues stay in sync, without taking over",
+      "summary": "arkaik sync checks the GitHub issues and PRs your nodes point to and mirrors their latest state into your map, journaling every change. It only reflects — your own statuses are never overwritten.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/230",
+      "node_ids": [
+        "V-cli-terminal",
+        "F-sync-refs",
+        "AC-sync-mirrors-not-authority"
+      ]
+    },
+    {
       "id": "012607120913150000000109",
       "ts": "2026-07-12T09:13:15Z",
       "actor": "claude-code",
@@ -7036,6 +9367,48 @@
       "title": "Sync Mirrors, Never Overrides"
     },
     {
+      "id": "012607120922310000000364",
+      "actor": "claude-code",
+      "ts": "2026-07-12T09:22:31.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-cli-terminal",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607120922310000000372",
+      "actor": "claude-code",
+      "ts": "2026-07-12T09:22:31.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-validate-bundle",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607120922310000000540",
+      "actor": "claude-code",
+      "ts": "2026-07-12T09:22:31.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-validator-blocks-broken-bundle",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607120930290000000056",
+      "actor": "claude-code",
+      "ts": "2026-07-12T09:30:29Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-231",
+      "title": "Pack your map into one file — and open it in the app",
+      "summary": "arkaik pack rolls a repo's bundle and journal into a single shareable file, with the option to leave history out or tuck screenshots inside. arkaik open checks it's valid, then hands it straight to the app.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/231",
+      "node_ids": [
+        "V-cli-terminal",
+        "F-share-map",
+        "AC-share-validated-history-private"
+      ]
+    },
+    {
       "id": "012607120930290000000110",
       "ts": "2026-07-12T09:30:29Z",
       "actor": "claude-code",
@@ -7052,6 +9425,254 @@
       "node_id": "AC-share-validated-history-private",
       "species": "acceptance",
       "title": "Share Validated, History Private"
+    },
+    {
+      "id": "012607120935260000000370",
+      "actor": "claude-code",
+      "ts": "2026-07-12T09:35:26.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-init-repo",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607120935260000000534",
+      "actor": "claude-code",
+      "ts": "2026-07-12T09:35:26.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-one-command-repo-setup",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607120935260000000536",
+      "actor": "claude-code",
+      "ts": "2026-07-12T09:35:26.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-init-rerun-never-clobbers",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607120935260000000538",
+      "actor": "claude-code",
+      "ts": "2026-07-12T09:35:26.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-one-skill-doctrine-everywhere",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607120945190000000057",
+      "actor": "claude-code",
+      "ts": "2026-07-12T09:45:19Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-232",
+      "title": "Install the Arkaik skill as a Claude Code plugin",
+      "summary": "Prefer plugins over the CLI? The same agent skill is now one marketplace install away, and it always matches the canonical version — same doctrine, whichever way you get it.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/232",
+      "node_ids": [
+        "V-arkaik-skill",
+        "AC-one-skill-doctrine-everywhere"
+      ]
+    },
+    {
+      "id": "012607120945190000000539",
+      "actor": "claude-code",
+      "ts": "2026-07-12T09:45:19Z",
+      "type": "node.status_changed",
+      "node_id": "AC-one-skill-doctrine-everywhere",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607120955430000000374",
+      "actor": "claude-code",
+      "ts": "2026-07-12T09:55:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-journal-release",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607120955430000000542",
+      "actor": "claude-code",
+      "ts": "2026-07-12T09:55:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-bad-line-cannot-corrupt-history",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607120955430000000544",
+      "actor": "claude-code",
+      "ts": "2026-07-12T09:55:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-parallel-appends-merge-clean",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607120955430000000546",
+      "actor": "claude-code",
+      "ts": "2026-07-12T09:55:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-release-notes-draft-themselves",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607121013150000000376",
+      "actor": "claude-code",
+      "ts": "2026-07-12T10:13:15.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-sync-refs",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607121013150000000550",
+      "actor": "claude-code",
+      "ts": "2026-07-12T10:13:15.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-sync-mirrors-not-authority",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607121022310000000365",
+      "actor": "claude-code",
+      "ts": "2026-07-12T10:22:31.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-cli-terminal",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607121022310000000373",
+      "actor": "claude-code",
+      "ts": "2026-07-12T10:22:31.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-validate-bundle",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607121022310000000541",
+      "actor": "claude-code",
+      "ts": "2026-07-12T10:22:31.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-validator-blocks-broken-bundle",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607121030290000000378",
+      "actor": "claude-code",
+      "ts": "2026-07-12T10:30:29.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-share-map",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607121030290000000552",
+      "actor": "claude-code",
+      "ts": "2026-07-12T10:30:29.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-share-validated-history-private",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607121035260000000371",
+      "actor": "claude-code",
+      "ts": "2026-07-12T10:35:26.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-init-repo",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607121035260000000535",
+      "actor": "claude-code",
+      "ts": "2026-07-12T10:35:26.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-one-command-repo-setup",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607121035260000000537",
+      "actor": "claude-code",
+      "ts": "2026-07-12T10:35:26.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-init-rerun-never-clobbers",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607121055430000000375",
+      "actor": "claude-code",
+      "ts": "2026-07-12T10:55:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-journal-release",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607121055430000000543",
+      "actor": "claude-code",
+      "ts": "2026-07-12T10:55:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-bad-line-cannot-corrupt-history",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607121055430000000547",
+      "actor": "claude-code",
+      "ts": "2026-07-12T10:55:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-release-notes-draft-themselves",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607121113150000000377",
+      "actor": "claude-code",
+      "ts": "2026-07-12T11:13:15.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-sync-refs",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607121113150000000551",
+      "actor": "claude-code",
+      "ts": "2026-07-12T11:13:15.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-sync-mirrors-not-authority",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607121130290000000379",
+      "actor": "claude-code",
+      "ts": "2026-07-12T11:30:29.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-share-map",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607121130290000000553",
+      "actor": "claude-code",
+      "ts": "2026-07-12T11:30:29.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-share-validated-history-private",
+      "from": "development",
+      "to": "live"
     },
     {
       "id": "012607121237290000000012",
@@ -7081,6 +9702,159 @@
       "title": "meta"
     },
     {
+      "id": "012607121237290000000058",
+      "actor": "claude-code",
+      "ts": "2026-07-12T12:37:29Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-235",
+      "title": "Sturdier local storage under your projects",
+      "summary": "Your projects now live in the browser's proper database instead of one big blob — saves touch only the project you're editing, and everything you had migrates over automatically on first load.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/235",
+      "node_ids": [
+        "DM-projects",
+        "DM-journals",
+        "DM-meta",
+        "DM-project-bundle"
+      ]
+    },
+    {
+      "id": "012607121237470000000059",
+      "actor": "claude-code",
+      "ts": "2026-07-12T12:37:47Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-236",
+      "title": "The app now keeps a journal of every edit",
+      "summary": "Every change you make on the canvas — creating a node, moving a status, linking a ref — is now recorded in your project's history, the same way the CLI and the agent skill do it. Export a bundle and its story travels with it.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/236",
+      "node_ids": [
+        "DM-journal-event",
+        "DM-journals",
+        "F-edit-graph-on-canvas"
+      ]
+    },
+    {
+      "id": "012607121244060000000060",
+      "actor": "claude-code",
+      "ts": "2026-07-12T12:44:06Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-234",
+      "title": "IDs you can actually read",
+      "summary": "New nodes and edges get names derived from their titles — V-home instead of V-a1b2c3d4 — so bundles are legible at a glance. Existing projects are upgraded automatically, links and playlists included.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/234",
+      "node_ids": [
+        "DM-node",
+        "DM-edge",
+        "AC-legacy-bundle-migrates"
+      ]
+    },
+    {
+      "id": "012607121307470000000003",
+      "actor": "alexis",
+      "ts": "2026-07-12T13:07:47.000Z",
+      "type": "release.tagged",
+      "version": "the-toolchain",
+      "notes": "A real CLI (init, log, release, pack), the skill shipped as a plugin, deterministic IDs, and IndexedDB storage — Arkaik works where the work happens."
+    },
+    {
+      "id": "012607121336000000000128",
+      "actor": "alexis",
+      "ts": "2026-07-12T13:36:00Z",
+      "type": "decision.status_changed",
+      "node_id": "DEC-deterministic-ids",
+      "from": "approved",
+      "to": "enacted"
+    },
+    {
+      "id": "012607121337290000000182",
+      "actor": "claude-code",
+      "ts": "2026-07-12T13:37:29.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-projects",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607121337290000000184",
+      "actor": "claude-code",
+      "ts": "2026-07-12T13:37:29.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-journals",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607121337290000000186",
+      "actor": "claude-code",
+      "ts": "2026-07-12T13:37:29.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-meta",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607121437290000000183",
+      "actor": "claude-code",
+      "ts": "2026-07-12T14:37:29.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-projects",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607121437290000000185",
+      "actor": "claude-code",
+      "ts": "2026-07-12T14:37:29.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-journals",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607121437290000000187",
+      "actor": "claude-code",
+      "ts": "2026-07-12T14:37:29.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-meta",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607121800000000000131",
+      "actor": "alexis",
+      "ts": "2026-07-12T18:00:00Z",
+      "type": "decision.status_changed",
+      "node_id": "DEC-publik-strips-journal",
+      "from": "proposed",
+      "to": "approved"
+    },
+    {
+      "id": "012607121800000000000563",
+      "ts": "2026-07-12T18:00:00Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DEC-publik-strips-journal",
+      "species": "decision",
+      "title": "Publik publishes journal-stripped by default, enforced server-side"
+    },
+    {
+      "id": "012607121805000000000133",
+      "actor": "alexis",
+      "ts": "2026-07-12T18:05:00Z",
+      "type": "decision.status_changed",
+      "node_id": "DEC-synk-one-way-backup",
+      "from": "proposed",
+      "to": "approved"
+    },
+    {
+      "id": "012607121805000000000564",
+      "ts": "2026-07-12T18:05:00Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DEC-synk-one-way-backup",
+      "species": "decision",
+      "title": "Synk is one-way-up backup, deduped by content hash — not sync"
+    },
+    {
       "id": "012607122247470000000015",
       "ts": "2026-07-12T22:47:47Z",
       "actor": "claude-code",
@@ -7088,6 +9862,19 @@
       "node_id": "DM-publik-snapshots",
       "species": "data-model",
       "title": "publik_snapshots"
+    },
+    {
+      "id": "012607122247470000000061",
+      "actor": "claude-code",
+      "ts": "2026-07-12T22:47:47Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-246",
+      "title": "Groundwork for sharing and backups",
+      "summary": "Arkaik quietly grew its first server-side home — the foundation that makes sharing maps and backing them up possible. The app itself keeps working fully offline, no account required.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/246",
+      "node_ids": [
+        "DM-publik-snapshots"
+      ]
     },
     {
       "id": "012607122308470000000016",
@@ -7124,6 +9911,23 @@
       "node_id": "API-post-publik-report",
       "species": "api-endpoint",
       "title": "POST /api/publik/{id}/report"
+    },
+    {
+      "id": "012607122308470000000062",
+      "actor": "claude-code",
+      "ts": "2026-07-12T23:08:47Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-248",
+      "title": "Share a snapshot of your map with a link",
+      "summary": "Publish a snapshot of your map and get a link anyone can open — plus a private key, shown once, that lets only you take it down. Your project history stays out of the snapshot unless you choose otherwise.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/248",
+      "node_ids": [
+        "API-post-publik",
+        "API-publik-snapshot",
+        "API-post-publik-report",
+        "DM-publik-snapshots",
+        "DM-publik-rate-limits"
+      ]
     },
     {
       "id": "012607122323040000000017",
@@ -7198,6 +10002,23 @@
       "title": "GET /api/synk/ping"
     },
     {
+      "id": "012607122323040000000063",
+      "actor": "claude-code",
+      "ts": "2026-07-12T23:23:04Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-249",
+      "title": "Sign in with GitHub",
+      "summary": "You can now sign in with your GitHub account — the doorway to backing up your maps. Nothing local is ever gated behind it: every existing feature keeps working without an account.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/249",
+      "node_ids": [
+        "F-sign-in",
+        "API-auth-nextauth",
+        "API-get-auth-status",
+        "DM-users",
+        "AC-signin-never-gates-local"
+      ]
+    },
+    {
       "id": "012607122323040000000090",
       "ts": "2026-07-12T23:23:04Z",
       "actor": "claude-code",
@@ -7223,6 +10044,264 @@
       "node_id": "AC-signin-never-gates-local",
       "species": "acceptance",
       "title": "Sign-in never gates local"
+    },
+    {
+      "id": "012607122330000000000132",
+      "actor": "alexis",
+      "ts": "2026-07-12T23:30:00Z",
+      "type": "decision.status_changed",
+      "node_id": "DEC-publik-strips-journal",
+      "from": "approved",
+      "to": "enacted"
+    },
+    {
+      "id": "012607122347470000000188",
+      "actor": "claude-code",
+      "ts": "2026-07-12T23:47:47.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-publik-snapshots",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130008470000000190",
+      "actor": "claude-code",
+      "ts": "2026-07-13T00:08:47.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-publik-rate-limits",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130008470000000242",
+      "actor": "claude-code",
+      "ts": "2026-07-13T00:08:47.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-post-publik",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130008470000000244",
+      "actor": "claude-code",
+      "ts": "2026-07-13T00:08:47.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-publik-snapshot",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130008470000000246",
+      "actor": "claude-code",
+      "ts": "2026-07-13T00:08:47.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-post-publik-report",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130023040000000192",
+      "actor": "claude-code",
+      "ts": "2026-07-13T00:23:04.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-users",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130023040000000194",
+      "actor": "claude-code",
+      "ts": "2026-07-13T00:23:04.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-accounts",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130023040000000196",
+      "actor": "claude-code",
+      "ts": "2026-07-13T00:23:04.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-sessions",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130023040000000198",
+      "actor": "claude-code",
+      "ts": "2026-07-13T00:23:04.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-verification-token",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130023040000000218",
+      "actor": "claude-code",
+      "ts": "2026-07-13T00:23:04.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-auth-nextauth",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130023040000000220",
+      "actor": "claude-code",
+      "ts": "2026-07-13T00:23:04.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-get-auth-status",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130023040000000224",
+      "actor": "claude-code",
+      "ts": "2026-07-13T00:23:04.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-github",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130023040000000256",
+      "actor": "claude-code",
+      "ts": "2026-07-13T00:23:04.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-get-synk-ping",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130023040000000338",
+      "actor": "claude-code",
+      "ts": "2026-07-13T00:23:04.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-account-menu",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130023040000000346",
+      "actor": "claude-code",
+      "ts": "2026-07-13T00:23:04.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-sign-in",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130023040000000512",
+      "actor": "claude-code",
+      "ts": "2026-07-13T00:23:04.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-signin-never-gates-local",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130047470000000189",
+      "actor": "claude-code",
+      "ts": "2026-07-13T00:47:47.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-publik-snapshots",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607130108470000000191",
+      "actor": "claude-code",
+      "ts": "2026-07-13T01:08:47.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-publik-rate-limits",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607130108470000000243",
+      "actor": "claude-code",
+      "ts": "2026-07-13T01:08:47.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-post-publik",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607130108470000000245",
+      "actor": "claude-code",
+      "ts": "2026-07-13T01:08:47.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-publik-snapshot",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607130108470000000247",
+      "actor": "claude-code",
+      "ts": "2026-07-13T01:08:47.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-post-publik-report",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607130123040000000193",
+      "actor": "claude-code",
+      "ts": "2026-07-13T01:23:04.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-users",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607130123040000000219",
+      "actor": "claude-code",
+      "ts": "2026-07-13T01:23:04.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-auth-nextauth",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607130123040000000221",
+      "actor": "claude-code",
+      "ts": "2026-07-13T01:23:04.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-get-auth-status",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607130123040000000347",
+      "actor": "claude-code",
+      "ts": "2026-07-13T01:23:04.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-sign-in",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607130123040000000513",
+      "actor": "claude-code",
+      "ts": "2026-07-13T01:23:04.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-signin-never-gates-local",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607130821030000000064",
+      "actor": "claude-code",
+      "ts": "2026-07-13T08:21:03Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-250",
+      "title": "Publish straight from your terminal",
+      "summary": "One command — arkaik push — validates your map, publishes it, and hands back a shareable link with your one-time owner key. Your history stays on your machine unless you explicitly include it.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/250",
+      "node_ids": [
+        "V-cli-terminal",
+        "F-share-map",
+        "API-post-publik"
+      ]
     },
     {
       "id": "012607130821140000000021",
@@ -7277,6 +10356,40 @@
       "node_id": "API-get-synk-backup",
       "species": "api-endpoint",
       "title": "GET /api/synk/backups/{id}"
+    },
+    {
+      "id": "012607130821140000000065",
+      "actor": "claude-code",
+      "ts": "2026-07-13T08:21:14Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-251",
+      "title": "Your account can now keep safe copies of your maps",
+      "summary": "The backup service arrived: signed-in projects can be stored under your account, with identical versions skipped automatically and older ones tidied away — so a week of history is always within reach.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/251",
+      "node_ids": [
+        "API-synk-project",
+        "API-get-synk-projects",
+        "API-get-synk-backup",
+        "DM-synk-projects",
+        "DM-synk-backups"
+      ]
+    },
+    {
+      "id": "012607130824430000000066",
+      "actor": "claude-code",
+      "ts": "2026-07-13T08:24:43Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-252",
+      "title": "A Publish button in the app, and a page for every shared map",
+      "summary": "Publishing now lives right in the app: a dialog tells you exactly what becomes public before you share. Every shared map gets its own preview page, and anyone with the link can import their own copy in one click.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/252",
+      "node_ids": [
+        "V-publik-publish-dialog",
+        "V-publik-snapshot",
+        "F-publish-to-publik",
+        "AC-owner-key-shown-once",
+        "AC-snapshot-imports-as-copy"
+      ]
     },
     {
       "id": "012607130824430000000086",
@@ -7351,6 +10464,23 @@
       "title": "Anyone imports a copy"
     },
     {
+      "id": "012607130859240000000067",
+      "actor": "claude-code",
+      "ts": "2026-07-13T08:59:24Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-253",
+      "title": "Backups that run themselves",
+      "summary": "Once you're signed in, your maps back up quietly about a minute after you stop editing — with per-project status on your project cards, a one-click offer for maps not yet covered, and a restore that always imports a copy, never overwrites your work.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/253",
+      "node_ids": [
+        "F-synk-backup-restore",
+        "V-synk-onboarding-banner",
+        "V-synk-restore-dialog",
+        "AC-backups-run-themselves",
+        "AC-restore-never-overwrites"
+      ]
+    },
+    {
       "id": "012607130859240000000088",
       "ts": "2026-07-13T08:59:24Z",
       "actor": "claude-code",
@@ -7423,6 +10553,389 @@
       "title": "One-click backup offer"
     },
     {
+      "id": "012607130900000000000135",
+      "actor": "alexis",
+      "ts": "2026-07-13T09:00:00Z",
+      "type": "decision.status_changed",
+      "node_id": "DEC-agent-plane-mcp",
+      "from": "proposed",
+      "to": "approved"
+    },
+    {
+      "id": "012607130900000000000565",
+      "ts": "2026-07-13T09:00:00Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DEC-agent-plane-mcp",
+      "species": "decision",
+      "title": "The agent plane is an MCP server with validator-gated dual-writes"
+    },
+    {
+      "id": "012607130921140000000200",
+      "actor": "claude-code",
+      "ts": "2026-07-13T09:21:14.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-synk-projects",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130921140000000202",
+      "actor": "claude-code",
+      "ts": "2026-07-13T09:21:14.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-synk-backups",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130921140000000248",
+      "actor": "claude-code",
+      "ts": "2026-07-13T09:21:14.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-get-synk-projects",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130921140000000250",
+      "actor": "claude-code",
+      "ts": "2026-07-13T09:21:14.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-synk-project",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130921140000000252",
+      "actor": "claude-code",
+      "ts": "2026-07-13T09:21:14.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-get-synk-project-backups",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130921140000000254",
+      "actor": "claude-code",
+      "ts": "2026-07-13T09:21:14.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-get-synk-backup",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130924430000000330",
+      "actor": "claude-code",
+      "ts": "2026-07-13T09:24:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-publik-snapshot",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130924430000000332",
+      "actor": "claude-code",
+      "ts": "2026-07-13T09:24:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-publik-publish-dialog",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130924430000000344",
+      "actor": "claude-code",
+      "ts": "2026-07-13T09:24:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-publish-to-publik",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130924430000000488",
+      "actor": "claude-code",
+      "ts": "2026-07-13T09:24:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-publish-never-leaks-journal",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130924430000000490",
+      "actor": "claude-code",
+      "ts": "2026-07-13T09:24:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-owner-key-shown-once",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130924430000000492",
+      "actor": "claude-code",
+      "ts": "2026-07-13T09:24:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-snapshot-delete-needs-key",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130924430000000494",
+      "actor": "claude-code",
+      "ts": "2026-07-13T09:24:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-publish-without-account",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130924430000000496",
+      "actor": "claude-code",
+      "ts": "2026-07-13T09:24:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-snapshot-imports-as-copy",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130929240000000004",
+      "actor": "alexis",
+      "ts": "2026-07-13T09:29:24.000Z",
+      "type": "release.tagged",
+      "version": "publik-and-synk",
+      "notes": "Sign in with GitHub, publish a snapshot to the world with Publik, and keep deduped backups flowing with Synk."
+    },
+    {
+      "id": "012607130959240000000334",
+      "actor": "claude-code",
+      "ts": "2026-07-13T09:59:24.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-synk-onboarding-banner",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130959240000000336",
+      "actor": "claude-code",
+      "ts": "2026-07-13T09:59:24.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-synk-restore-dialog",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130959240000000348",
+      "actor": "claude-code",
+      "ts": "2026-07-13T09:59:24.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-synk-backup-restore",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130959240000000498",
+      "actor": "claude-code",
+      "ts": "2026-07-13T09:59:24.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-backups-run-themselves",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130959240000000500",
+      "actor": "claude-code",
+      "ts": "2026-07-13T09:59:24.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-backups-dedupe-by-content",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130959240000000502",
+      "actor": "claude-code",
+      "ts": "2026-07-13T09:59:24.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-backup-failure-loses-nothing",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130959240000000504",
+      "actor": "claude-code",
+      "ts": "2026-07-13T09:59:24.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-restore-never-overwrites",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607130959240000000506",
+      "actor": "claude-code",
+      "ts": "2026-07-13T09:59:24.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-one-click-backup-offer",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607131021140000000201",
+      "actor": "claude-code",
+      "ts": "2026-07-13T10:21:14.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-synk-projects",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607131021140000000203",
+      "actor": "claude-code",
+      "ts": "2026-07-13T10:21:14.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-synk-backups",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607131021140000000249",
+      "actor": "claude-code",
+      "ts": "2026-07-13T10:21:14.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-get-synk-projects",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607131021140000000251",
+      "actor": "claude-code",
+      "ts": "2026-07-13T10:21:14.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-synk-project",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607131021140000000255",
+      "actor": "claude-code",
+      "ts": "2026-07-13T10:21:14.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-get-synk-backup",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607131024430000000331",
+      "actor": "claude-code",
+      "ts": "2026-07-13T10:24:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-publik-snapshot",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607131024430000000333",
+      "actor": "claude-code",
+      "ts": "2026-07-13T10:24:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-publik-publish-dialog",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607131024430000000345",
+      "actor": "claude-code",
+      "ts": "2026-07-13T10:24:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-publish-to-publik",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607131024430000000491",
+      "actor": "claude-code",
+      "ts": "2026-07-13T10:24:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-owner-key-shown-once",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607131024430000000497",
+      "actor": "claude-code",
+      "ts": "2026-07-13T10:24:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-snapshot-imports-as-copy",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607131059240000000335",
+      "actor": "claude-code",
+      "ts": "2026-07-13T10:59:24.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-synk-onboarding-banner",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607131059240000000337",
+      "actor": "claude-code",
+      "ts": "2026-07-13T10:59:24.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-synk-restore-dialog",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607131059240000000349",
+      "actor": "claude-code",
+      "ts": "2026-07-13T10:59:24.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-synk-backup-restore",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607131059240000000499",
+      "actor": "claude-code",
+      "ts": "2026-07-13T10:59:24.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-backups-run-themselves",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607131059240000000505",
+      "actor": "claude-code",
+      "ts": "2026-07-13T10:59:24.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-restore-never-overwrites",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607131200000000000134",
+      "actor": "alexis",
+      "ts": "2026-07-13T12:00:00Z",
+      "type": "decision.status_changed",
+      "node_id": "DEC-synk-one-way-backup",
+      "from": "approved",
+      "to": "enacted"
+    },
+    {
+      "id": "012607132235140000000068",
+      "actor": "claude-code",
+      "ts": "2026-07-13T22:35:14Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-254",
+      "title": "One graph, many maps — and a tidier sidebar",
+      "summary": "The groundwork for maps: your product graph can now project into different views instead of one big canvas. Species filtering moved into the sidebar with shareable deep links, so the library stays focused on search and browsing.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/254",
+      "node_ids": [
+        "V-library",
+        "F-browse-library",
+        "DM-map-definition"
+      ]
+    },
+    {
       "id": "012607132304430000000009",
       "ts": "2026-07-13T23:04:43Z",
       "actor": "claude-code",
@@ -7430,6 +10943,23 @@
       "node_id": "DM-map-definition",
       "species": "data-model",
       "title": "MapDefinition"
+    },
+    {
+      "id": "012607132304430000000069",
+      "actor": "claude-code",
+      "ts": "2026-07-13T23:04:43Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-255",
+      "title": "The Delivery board: where every platform stands",
+      "summary": "A new board answers \"what's shipped where?\" at a glance — one card per view per platform, grouped by status, so a screen that's live on iOS but still in progress on Android shows up honestly in both columns. Clicking a card opens the detail panel already on that platform's tab.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/255",
+      "node_ids": [
+        "V-delivery-board",
+        "F-track-delivery",
+        "AC-board-item-per-platform",
+        "AC-board-mirrors-lifecycle",
+        "DM-map-definition"
+      ]
     },
     {
       "id": "012607132304430000000081",
@@ -7477,6 +11007,114 @@
       "title": "One Card per Platform"
     },
     {
+      "id": "012607132355590000000471",
+      "actor": "claude-code",
+      "ts": "2026-07-13T23:55:59.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-deliverable-anchored-first-ship",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607140004430000000176",
+      "actor": "claude-code",
+      "ts": "2026-07-14T00:04:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-map-definition",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607140004430000000320",
+      "actor": "claude-code",
+      "ts": "2026-07-14T00:04:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-delivery-board",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607140004430000000328",
+      "actor": "claude-code",
+      "ts": "2026-07-14T00:04:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-track-delivery",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607140004430000000472",
+      "actor": "claude-code",
+      "ts": "2026-07-14T00:04:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-unreleased-work-visible",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607140004430000000482",
+      "actor": "claude-code",
+      "ts": "2026-07-14T00:04:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-board-mirrors-lifecycle",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607140004430000000484",
+      "actor": "claude-code",
+      "ts": "2026-07-14T00:04:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-board-item-per-platform",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607140104430000000177",
+      "actor": "claude-code",
+      "ts": "2026-07-14T01:04:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-map-definition",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607140104430000000321",
+      "actor": "claude-code",
+      "ts": "2026-07-14T01:04:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-delivery-board",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607140104430000000329",
+      "actor": "claude-code",
+      "ts": "2026-07-14T01:04:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-track-delivery",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607140104430000000483",
+      "actor": "claude-code",
+      "ts": "2026-07-14T01:04:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-board-mirrors-lifecycle",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607140104430000000485",
+      "actor": "claude-code",
+      "ts": "2026-07-14T01:04:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-board-item-per-platform",
+      "from": "development",
+      "to": "live"
+    },
+    {
       "id": "012607140850090000000053",
       "ts": "2026-07-14T08:50:09Z",
       "actor": "claude-code",
@@ -7520,6 +11158,23 @@
       "node_id": "F-create-custom-map",
       "species": "flow",
       "title": "Create Custom Map"
+    },
+    {
+      "id": "012607140850090000000070",
+      "actor": "claude-code",
+      "ts": "2026-07-14T08:50:09Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-256",
+      "title": "Maps become places you can visit",
+      "summary": "A new Maps index gathers the built-in Journey and System maps alongside your own custom maps — create one in a dialog and it's saved as plain data in your bundle. The System map is brand new: all your views, endpoints, and data models on one canvas, with every cross-layer connection drawn.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/256",
+      "node_ids": [
+        "V-maps-index",
+        "V-system-map",
+        "V-journey-map",
+        "F-browse-maps",
+        "F-create-custom-map"
+      ]
     },
     {
       "id": "012607140850090000000076",
@@ -7603,6 +11258,177 @@
       "title": "Unsaved raw edits guarded"
     },
     {
+      "id": "012607140855430000000545",
+      "actor": "claude-code",
+      "ts": "2026-07-14T08:55:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-parallel-appends-merge-clean",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607140950090000000264",
+      "actor": "claude-code",
+      "ts": "2026-07-14T09:50:09.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-maps-index",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607140950090000000268",
+      "actor": "claude-code",
+      "ts": "2026-07-14T09:50:09.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-system-map",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607140950090000000270",
+      "actor": "claude-code",
+      "ts": "2026-07-14T09:50:09.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-map-editor-dialog",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607140950090000000278",
+      "actor": "claude-code",
+      "ts": "2026-07-14T09:50:09.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-browse-maps",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607140950090000000280",
+      "actor": "claude-code",
+      "ts": "2026-07-14T09:50:09.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-create-custom-map",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607140950090000000310",
+      "actor": "claude-code",
+      "ts": "2026-07-14T09:50:09.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-edit-raw-bundle",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607140950090000000408",
+      "actor": "claude-code",
+      "ts": "2026-07-14T09:50:09.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-honest-map-counts",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607140950090000000410",
+      "actor": "claude-code",
+      "ts": "2026-07-14T09:50:09.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-drill-down-in-place",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607140950090000000424",
+      "actor": "claude-code",
+      "ts": "2026-07-14T09:50:09.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-custom-map-as-data",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607140950090000000430",
+      "actor": "claude-code",
+      "ts": "2026-07-14T09:50:09.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-viewport-stays-put",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607140950090000000432",
+      "actor": "claude-code",
+      "ts": "2026-07-14T09:50:09.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-spotlight-neighborhood",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607140950090000000434",
+      "actor": "claude-code",
+      "ts": "2026-07-14T09:50:09.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-system-two-renditions",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607140950090000000442",
+      "actor": "claude-code",
+      "ts": "2026-07-14T09:50:09.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-raw-edits-validated",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607140950090000000446",
+      "actor": "claude-code",
+      "ts": "2026-07-14T09:50:09.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-raw-close-guard",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607141050090000000265",
+      "actor": "claude-code",
+      "ts": "2026-07-14T10:50:09.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-maps-index",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607141050090000000269",
+      "actor": "claude-code",
+      "ts": "2026-07-14T10:50:09.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-system-map",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607141050090000000279",
+      "actor": "claude-code",
+      "ts": "2026-07-14T10:50:09.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-browse-maps",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607141050090000000281",
+      "actor": "claude-code",
+      "ts": "2026-07-14T10:50:09.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-create-custom-map",
+      "from": "development",
+      "to": "live"
+    },
+    {
       "id": "012607141106120000000068",
       "ts": "2026-07-14T11:06:12Z",
       "actor": "claude-code",
@@ -7612,6 +11438,20 @@
       "title": "Overview"
     },
     {
+      "id": "012607141106120000000071",
+      "actor": "claude-code",
+      "ts": "2026-07-14T11:06:12Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-257",
+      "title": "Projects now open on an Overview dashboard",
+      "summary": "Opening a project lands you on the big picture: platform delivery gauges, release pulse, backlog, inventory, health checks, and live map counts — each card one click from the surface that owns the detail. \"Where does this product stand?\" now has a home page.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/257",
+      "node_ids": [
+        "V-overview",
+        "AC-overview-health-indicators"
+      ]
+    },
+    {
       "id": "012607141106120000000152",
       "ts": "2026-07-14T11:06:12Z",
       "actor": "claude-code",
@@ -7619,6 +11459,66 @@
       "node_id": "AC-overview-health-indicators",
       "species": "acceptance",
       "title": "Doc health always visible"
+    },
+    {
+      "id": "012607141206120000000294",
+      "actor": "claude-code",
+      "ts": "2026-07-14T12:06:12.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-overview",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607141206120000000462",
+      "actor": "claude-code",
+      "ts": "2026-07-14T12:06:12.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-overview-health-indicators",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607141306120000000295",
+      "actor": "claude-code",
+      "ts": "2026-07-14T13:06:12.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-overview",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607141306120000000463",
+      "actor": "claude-code",
+      "ts": "2026-07-14T13:06:12.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-overview-health-indicators",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607141800000000000136",
+      "actor": "alexis",
+      "ts": "2026-07-14T18:00:00Z",
+      "type": "decision.status_changed",
+      "node_id": "DEC-agent-plane-mcp",
+      "from": "approved",
+      "to": "enacted"
+    },
+    {
+      "id": "012607141807170000000072",
+      "actor": "claude-code",
+      "ts": "2026-07-14T18:07:17Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-258",
+      "title": "arkaik-mcp: your map, open to agents",
+      "summary": "A new MCP server gives AI agents the same product graph you browse — 14 tools to read nodes, maps, changelog, and backlog, and to make edits that are validation-gated and journaled just like yours. One command sets it up, and broken writes are refused before they touch a file.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/258",
+      "node_ids": [
+        "V-mcp-tool-catalog",
+        "F-mcp-agent-session",
+        "AC-mcp-validated-dual-write"
+      ]
     },
     {
       "id": "012607141807170000000105",
@@ -7648,6 +11548,308 @@
       "title": "Agents Write Validator-Gated"
     },
     {
+      "id": "012607141907170000000368",
+      "actor": "claude-code",
+      "ts": "2026-07-14T19:07:17.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-mcp-tool-catalog",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607141907170000000382",
+      "actor": "claude-code",
+      "ts": "2026-07-14T19:07:17.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-mcp-agent-session",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607141907170000000556",
+      "actor": "claude-code",
+      "ts": "2026-07-14T19:07:17.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-mcp-validated-dual-write",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607142007170000000369",
+      "actor": "claude-code",
+      "ts": "2026-07-14T20:07:17.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-mcp-tool-catalog",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607142007170000000383",
+      "actor": "claude-code",
+      "ts": "2026-07-14T20:07:17.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-mcp-agent-session",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607142007170000000557",
+      "actor": "claude-code",
+      "ts": "2026-07-14T20:07:17.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-mcp-validated-dual-write",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607142323040000000195",
+      "actor": "claude-code",
+      "ts": "2026-07-14T23:23:04.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-accounts",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607142323040000000197",
+      "actor": "claude-code",
+      "ts": "2026-07-14T23:23:04.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-sessions",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607142323040000000199",
+      "actor": "claude-code",
+      "ts": "2026-07-14T23:23:04.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-verification-token",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607142323040000000257",
+      "actor": "claude-code",
+      "ts": "2026-07-14T23:23:04.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-get-synk-ping",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607150821140000000253",
+      "actor": "claude-code",
+      "ts": "2026-07-15T08:21:14.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-get-synk-project-backups",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607150824430000000489",
+      "actor": "claude-code",
+      "ts": "2026-07-15T08:24:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-publish-never-leaks-journal",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607150824430000000493",
+      "actor": "claude-code",
+      "ts": "2026-07-15T08:24:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-snapshot-delete-needs-key",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607150824430000000495",
+      "actor": "claude-code",
+      "ts": "2026-07-15T08:24:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-publish-without-account",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607150859240000000501",
+      "actor": "claude-code",
+      "ts": "2026-07-15T08:59:24.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-backups-dedupe-by-content",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607150859240000000503",
+      "actor": "claude-code",
+      "ts": "2026-07-15T08:59:24.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-backup-failure-loses-nothing",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607150859240000000507",
+      "actor": "claude-code",
+      "ts": "2026-07-15T08:59:24.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-one-click-backup-offer",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607152304430000000473",
+      "actor": "claude-code",
+      "ts": "2026-07-15T23:04:43.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-unreleased-work-visible",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607160850090000000271",
+      "actor": "claude-code",
+      "ts": "2026-07-16T08:50:09.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-map-editor-dialog",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607160850090000000409",
+      "actor": "claude-code",
+      "ts": "2026-07-16T08:50:09.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-honest-map-counts",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607160850090000000425",
+      "actor": "claude-code",
+      "ts": "2026-07-16T08:50:09.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-custom-map-as-data",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607160850090000000431",
+      "actor": "claude-code",
+      "ts": "2026-07-16T08:50:09.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-viewport-stays-put",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607160850090000000433",
+      "actor": "claude-code",
+      "ts": "2026-07-16T08:50:09.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-spotlight-neighborhood",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607160850090000000435",
+      "actor": "claude-code",
+      "ts": "2026-07-16T08:50:09.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-system-two-renditions",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607160850090000000443",
+      "actor": "claude-code",
+      "ts": "2026-07-16T08:50:09.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-raw-edits-validated",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607161327500000000073",
+      "actor": "claude-code",
+      "ts": "2026-07-16T13:27:50Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-261",
+      "title": "arkaik-mcp installs cleanly from npm",
+      "summary": "The agent server is now truly one command away: the 0.1.2 release fixes the earlier broken publishes, so `npx -y arkaik-mcp` downloads a working, dependency-free server every time.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/261",
+      "node_ids": [
+        "V-mcp-tool-catalog",
+        "F-mcp-agent-session"
+      ]
+    },
+    {
+      "id": "012607161357500000000005",
+      "actor": "alexis",
+      "ts": "2026-07-16T13:57:50.000Z",
+      "type": "release.tagged",
+      "version": "maps-and-the-agent-plane",
+      "notes": "Curated maps and a system view join the canvas, an overview dashboard lands, and arkaik-mcp gives agents a first-class way in."
+    },
+    {
+      "id": "012607172309310000000074",
+      "actor": "claude-code",
+      "ts": "2026-07-17T23:09:31Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-266",
+      "title": "Build a flow and its playlist in one go",
+      "summary": "Agents can now create or update a flow with a full playlist in a single step — the connecting edges are synthesized automatically, so a flow never gets stuck half-made behind a validation deadlock.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/266",
+      "node_ids": [
+        "F-mcp-agent-session",
+        "V-mcp-tool-catalog",
+        "F-edit-flow-playlist"
+      ]
+    },
+    {
+      "id": "012607172316370000000075",
+      "actor": "claude-code",
+      "ts": "2026-07-17T23:16:37Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-265",
+      "title": "Map endpoints that call other endpoints",
+      "summary": "An API endpoint can now call other endpoints on your map — just right for a backend route that fans out to several internal or external APIs, drawn on the System map.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/265",
+      "node_ids": [
+        "V-system-map",
+        "AC-valid-edge-types-only",
+        "F-edit-graph-on-canvas"
+      ]
+    },
+    {
+      "id": "012607191109420000000076",
+      "actor": "claude-code",
+      "ts": "2026-07-19T11:09:42Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-272",
+      "title": "Icons wobble like they're hand-drawn",
+      "summary": "Every icon in Arkaik now carries a subtle hand-drawn distortion, and gently boils to life while you hover or focus its row, card, or menu item. Calm at rest, and it stays still if you prefer reduced motion.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/272",
+      "node_ids": []
+    },
+    {
+      "id": "012607191116450000000077",
+      "actor": "claude-code",
+      "ts": "2026-07-19T11:16:45Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-270",
+      "title": "Acceptances arrive: promises you can test",
+      "summary": "Arkaik gains a fifth species — the acceptance, a small testable promise with a Given/When/Then for the how, value tags for the why, and a status per platform. Views, flows, and the product become honest aggregates of what's actually promised.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/270",
+      "node_ids": [
+        "DM-node",
+        "DM-project-bundle"
+      ]
+    },
+    {
       "id": "012607191312540000000070",
       "ts": "2026-07-19T13:12:54Z",
       "actor": "claude-code",
@@ -7664,6 +11866,23 @@
       "node_id": "F-edit-acceptance",
       "species": "flow",
       "title": "Edit Acceptance"
+    },
+    {
+      "id": "012607191312540000000078",
+      "actor": "claude-code",
+      "ts": "2026-07-19T13:12:54Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-273",
+      "title": "See which platform is late on which promise",
+      "summary": "The new Acceptances page lays every promise out in a parity matrix — one status column per platform, an amber marker wherever one platform lags. Filter by platform, status, value, or gaps (the URL is shareable), and edit an acceptance right in its panel.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/273",
+      "node_ids": [
+        "V-acceptances-matrix",
+        "F-edit-acceptance",
+        "V-node-detail-panel",
+        "AC-parity-gap-at-a-glance",
+        "AC-matrix-groups-by-anchor"
+      ]
     },
     {
       "id": "012607191312540000000145",
@@ -7702,6 +11921,107 @@
       "title": "Matrix groups by anchor"
     },
     {
+      "id": "012607191412540000000298",
+      "actor": "claude-code",
+      "ts": "2026-07-19T14:12:54.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-acceptances-matrix",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607191412540000000304",
+      "actor": "claude-code",
+      "ts": "2026-07-19T14:12:54.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-edit-acceptance",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607191412540000000448",
+      "actor": "claude-code",
+      "ts": "2026-07-19T14:12:54.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-acceptance-how-why-inline",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607191412540000000450",
+      "actor": "claude-code",
+      "ts": "2026-07-19T14:12:54.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-split-carries-context",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607191412540000000452",
+      "actor": "claude-code",
+      "ts": "2026-07-19T14:12:54.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-parity-gap-at-a-glance",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607191412540000000454",
+      "actor": "claude-code",
+      "ts": "2026-07-19T14:12:54.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-matrix-groups-by-anchor",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607191439360000000079",
+      "actor": "claude-code",
+      "ts": "2026-07-19T14:39:36Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-276",
+      "title": "Arkaik gets a proper app icon",
+      "summary": "A fresh favicon plus Apple touch and app icons, so Arkaik looks the part in your tabs, bookmarks, and on your home screen.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/276",
+      "node_ids": []
+    },
+    {
+      "id": "012607191512540000000299",
+      "actor": "claude-code",
+      "ts": "2026-07-19T15:12:54.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-acceptances-matrix",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607191512540000000305",
+      "actor": "claude-code",
+      "ts": "2026-07-19T15:12:54.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-edit-acceptance",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607191512540000000453",
+      "actor": "claude-code",
+      "ts": "2026-07-19T15:12:54.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-parity-gap-at-a-glance",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607191512540000000455",
+      "actor": "claude-code",
+      "ts": "2026-07-19T15:12:54.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-matrix-groups-by-anchor",
+      "from": "development",
+      "to": "live"
+    },
+    {
       "id": "012607191641580000000069",
       "ts": "2026-07-19T16:41:58Z",
       "actor": "claude-code",
@@ -7720,6 +12040,23 @@
       "title": "Audit Value Coverage"
     },
     {
+      "id": "012607191641580000000080",
+      "actor": "claude-code",
+      "ts": "2026-07-19T16:41:58Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-277",
+      "title": "The Value Pyramid — and gauges that tell the truth",
+      "summary": "A new Pyramid page shows how well each of the 30 value elements is delivered, per platform and grouped by tier — click one to see the acceptances behind it. And every view, flow, and product gauge now reflects its covering acceptances, with new Parity and Pyramid cards on the Overview.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/277",
+      "node_ids": [
+        "V-pyramid",
+        "F-audit-value-coverage",
+        "V-overview",
+        "AC-pyramid-coverage-glance",
+        "V-delivery-board"
+      ]
+    },
+    {
       "id": "012607191641580000000149",
       "ts": "2026-07-19T16:41:58Z",
       "actor": "claude-code",
@@ -7736,6 +12073,233 @@
       "node_id": "AC-pyramid-gap-filter",
       "species": "acceptance",
       "title": "Unserved values filterable"
+    },
+    {
+      "id": "012607191719150000000081",
+      "actor": "claude-code",
+      "ts": "2026-07-19T17:19:15Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-278",
+      "title": "The Arkaik logo comes alive",
+      "summary": "On the home page, the wordmark now shimmers with a gentle hand-drawn boil — its edges quiver like wet ink. It freezes politely if you prefer reduced motion.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/278",
+      "node_ids": [
+        "V-landing"
+      ]
+    },
+    {
+      "id": "012607191741580000000296",
+      "actor": "claude-code",
+      "ts": "2026-07-19T17:41:58.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-pyramid",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607191741580000000308",
+      "actor": "claude-code",
+      "ts": "2026-07-19T17:41:58.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-audit-value-coverage",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607191741580000000456",
+      "actor": "claude-code",
+      "ts": "2026-07-19T17:41:58.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-pyramid-coverage-glance",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607191741580000000458",
+      "actor": "claude-code",
+      "ts": "2026-07-19T17:41:58.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-pyramid-gap-filter",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607191756400000000082",
+      "actor": "claude-code",
+      "ts": "2026-07-19T17:56:40Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-281",
+      "title": "Faster paths to help, sign-in, and the details",
+      "summary": "Jump to the docs straight from the sidebar or the home page, sign in from the project switcher without leaving your work, and the library now opens as a tidy list by default. Long node details finally scroll instead of getting clipped.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/281",
+      "node_ids": [
+        "F-browse-docs",
+        "V-library",
+        "V-node-detail-panel",
+        "F-sign-in"
+      ]
+    },
+    {
+      "id": "012607191756400000000361",
+      "actor": "claude-code",
+      "ts": "2026-07-19T17:56:40Z",
+      "type": "node.status_changed",
+      "node_id": "F-browse-docs",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607191807310000000083",
+      "actor": "claude-code",
+      "ts": "2026-07-19T18:07:31Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-282",
+      "title": "A living backdrop on the home page",
+      "summary": "Drifting ASCII mountains now animate quietly behind the hero — adapting to light and dark mode, and holding perfectly still if you prefer reduced motion.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/282",
+      "node_ids": [
+        "V-landing"
+      ]
+    },
+    {
+      "id": "012607191841580000000297",
+      "actor": "claude-code",
+      "ts": "2026-07-19T18:41:58.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-pyramid",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607191841580000000309",
+      "actor": "claude-code",
+      "ts": "2026-07-19T18:41:58.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-audit-value-coverage",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607191841580000000457",
+      "actor": "claude-code",
+      "ts": "2026-07-19T18:41:58.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-pyramid-coverage-glance",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607211146210000000084",
+      "actor": "claude-code",
+      "ts": "2026-07-21T11:46:21Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-283",
+      "title": "Know what each value actually means",
+      "summary": "All 30 value elements now come with a short plain-language definition — visible right on the Pyramid page, and as a tooltip wherever you pick or read a value on an acceptance.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/283",
+      "node_ids": [
+        "V-pyramid",
+        "V-acceptances-matrix",
+        "F-edit-acceptance"
+      ]
+    },
+    {
+      "id": "012607211312540000000449",
+      "actor": "claude-code",
+      "ts": "2026-07-21T13:12:54.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-acceptance-how-why-inline",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607252236030000000085",
+      "actor": "claude-code",
+      "ts": "2026-07-25T22:36:03Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-284",
+      "title": "Delivery board icons show their true colors",
+      "summary": "The status icon on each Delivery column heading now wears its status color instead of rendering plain black.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/284",
+      "node_ids": [
+        "V-delivery-board",
+        "F-track-delivery"
+      ]
+    },
+    {
+      "id": "012607252247570000000086",
+      "actor": "claude-code",
+      "ts": "2026-07-25T22:47:57Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-285",
+      "title": "Filters you can scan at a glance",
+      "summary": "The status, value, and platform filters on the Acceptances page now show each option's icon — and the status's color — so you can spot the right one without reading every label.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/285",
+      "node_ids": [
+        "V-acceptances-matrix"
+      ]
+    },
+    {
+      "id": "012607252317570000000006",
+      "actor": "alexis",
+      "ts": "2026-07-25T23:17:57.000Z",
+      "type": "release.tagged",
+      "version": "acceptance-and-value",
+      "notes": "Acceptances become first-class: Given/When/Then promises anchored to surfaces and wired to the value they serve, crowned by the Pyramid."
+    },
+    {
+      "id": "012607260900000000000137",
+      "actor": "alexis",
+      "ts": "2026-07-26T09:00:00Z",
+      "type": "decision.status_changed",
+      "node_id": "DEC-shared-mutation-core",
+      "from": "proposed",
+      "to": "approved"
+    },
+    {
+      "id": "012607260900000000000566",
+      "ts": "2026-07-26T09:00:00Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DEC-shared-mutation-core",
+      "species": "decision",
+      "title": "One shared mutation core for every writer"
+    },
+    {
+      "id": "012607260905000000000139",
+      "actor": "alexis",
+      "ts": "2026-07-26T09:05:00Z",
+      "type": "decision.status_changed",
+      "node_id": "DEC-hosted-server-of-record",
+      "from": "proposed",
+      "to": "approved"
+    },
+    {
+      "id": "012607260905000000000567",
+      "ts": "2026-07-26T09:05:00Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DEC-hosted-server-of-record",
+      "species": "decision",
+      "title": "Hosted projects: the server is the system of record — boundary crossed on purpose"
+    },
+    {
+      "id": "012607260910000000000141",
+      "actor": "alexis",
+      "ts": "2026-07-26T09:10:00Z",
+      "type": "decision.status_changed",
+      "node_id": "DEC-promotion-copy-not-move",
+      "from": "proposed",
+      "to": "approved"
+    },
+    {
+      "id": "012607260910000000000568",
+      "ts": "2026-07-26T09:10:00Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DEC-promotion-copy-not-move",
+      "species": "decision",
+      "title": "Move to account is a copy, never a move"
     },
     {
       "id": "012607270651570000000023",
@@ -7783,6 +12347,23 @@
       "title": "DELETE /api/tokens/{id}"
     },
     {
+      "id": "012607270651570000000087",
+      "actor": "claude-code",
+      "ts": "2026-07-27T06:51:57Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-286",
+      "title": "Create tokens for your terminal and your agents",
+      "summary": "A new settings page lets you mint access tokens — the key your coding agent or CI uses to reach your projects. Copy it once, revoke it whenever you like.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/286",
+      "node_ids": [
+        "V-agent-tokens",
+        "API-tokens",
+        "API-delete-token",
+        "DM-api-tokens",
+        "AC-agent-token-shown-once"
+      ]
+    },
+    {
       "id": "012607270651570000000091",
       "ts": "2026-07-27T06:51:57Z",
       "actor": "claude-code",
@@ -7799,6 +12380,132 @@
       "node_id": "AC-agent-token-shown-once",
       "species": "acceptance",
       "title": "Token secret shown once"
+    },
+    {
+      "id": "012607270751570000000204",
+      "actor": "claude-code",
+      "ts": "2026-07-27T07:51:57.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-owners",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607270751570000000206",
+      "actor": "claude-code",
+      "ts": "2026-07-27T07:51:57.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-owner-members",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607270751570000000208",
+      "actor": "claude-code",
+      "ts": "2026-07-27T07:51:57.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-api-tokens",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607270751570000000258",
+      "actor": "claude-code",
+      "ts": "2026-07-27T07:51:57.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-tokens",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607270751570000000260",
+      "actor": "claude-code",
+      "ts": "2026-07-27T07:51:57.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-delete-token",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607270751570000000340",
+      "actor": "claude-code",
+      "ts": "2026-07-27T07:51:57.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-agent-tokens",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607270751570000000510",
+      "actor": "claude-code",
+      "ts": "2026-07-27T07:51:57.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-agent-token-shown-once",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607270851570000000209",
+      "actor": "claude-code",
+      "ts": "2026-07-27T08:51:57.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-api-tokens",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607270851570000000259",
+      "actor": "claude-code",
+      "ts": "2026-07-27T08:51:57.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-tokens",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607270851570000000261",
+      "actor": "claude-code",
+      "ts": "2026-07-27T08:51:57.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-delete-token",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607270851570000000341",
+      "actor": "claude-code",
+      "ts": "2026-07-27T08:51:57.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-agent-tokens",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607270851570000000511",
+      "actor": "claude-code",
+      "ts": "2026-07-27T08:51:57.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-agent-token-shown-once",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607270900000000000138",
+      "actor": "alexis",
+      "ts": "2026-07-27T09:00:00Z",
+      "type": "decision.status_changed",
+      "node_id": "DEC-shared-mutation-core",
+      "from": "approved",
+      "to": "enacted"
+    },
+    {
+      "id": "012607271200000000000140",
+      "actor": "alexis",
+      "ts": "2026-07-27T12:00:00Z",
+      "type": "decision.status_changed",
+      "node_id": "DEC-hosted-server-of-record",
+      "from": "approved",
+      "to": "enacted"
     },
     {
       "id": "012607271318310000000026",
@@ -7882,6 +12589,65 @@
       "title": "POST /api/graph/projects/{id}/mutations"
     },
     {
+      "id": "012607271318310000000088",
+      "actor": "claude-code",
+      "ts": "2026-07-27T13:18:31Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-288",
+      "title": "Your projects can now live in your account",
+      "summary": "Create a project that lives with your account instead of only in this browser — the same map is there on another machine, and your coding agent can reach it too.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/288",
+      "node_ids": [
+        "API-graph-projects",
+        "API-graph-project",
+        "API-post-graph-project-mutations",
+        "DM-graph-projects",
+        "DM-graph-events"
+      ]
+    },
+    {
+      "id": "012607271324510000000089",
+      "actor": "claude-code",
+      "ts": "2026-07-27T13:24:51Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-289",
+      "title": "Edit your account's projects right in the app",
+      "summary": "Projects that live in your account open and edit just like local ones, side by side in your list. And when you're ready, you can move a browser project into your account — the local original stays put.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/289",
+      "node_ids": [
+        "V-projects",
+        "F-move-to-account",
+        "AC-move-keeps-local-copy",
+        "AC-move-to-account-copies"
+      ]
+    },
+    {
+      "id": "012607271324510000000405",
+      "actor": "claude-code",
+      "ts": "2026-07-27T13:24:51Z",
+      "type": "node.status_changed",
+      "node_id": "AC-move-to-account-copies",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607271328490000000090",
+      "actor": "claude-code",
+      "ts": "2026-07-27T13:28:49Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-290",
+      "title": "Point your coding agent at your Arkaik project",
+      "summary": "Run one command in any repo and your coding agent can read and update that project's map while it works — no copying files around, no export/import dance.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/290",
+      "node_ids": [
+        "F-link-hosted",
+        "F-mcp-agent-session",
+        "V-mcp-tool-catalog",
+        "AC-hosted-token-never-on-disk",
+        "AC-linked-repo-fails-loud"
+      ]
+    },
+    {
       "id": "012607271328490000000111",
       "ts": "2026-07-27T13:28:49Z",
       "actor": "claude-code",
@@ -7945,6 +12711,429 @@
       "title": "GET/POST/DELETE /api/graph/projects/{id}/repos"
     },
     {
+      "id": "012607271333010000000091",
+      "actor": "claude-code",
+      "ts": "2026-07-27T13:33:01Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-291",
+      "title": "Your acceptances tick themselves off as you ship",
+      "summary": "Mention an acceptance in a pull request and it moves to in-progress on its own — then to shipped when the PR merges, on the platform that repository builds for.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/291",
+      "node_ids": [
+        "API-post-github-webhook",
+        "API-graph-project-repos",
+        "DM-project-repos",
+        "DM-github-deliveries",
+        "F-sync-refs"
+      ]
+    },
+    {
+      "id": "012607271400000000000142",
+      "actor": "alexis",
+      "ts": "2026-07-27T14:00:00Z",
+      "type": "decision.status_changed",
+      "node_id": "DEC-promotion-copy-not-move",
+      "from": "approved",
+      "to": "enacted"
+    },
+    {
+      "id": "012607271418310000000210",
+      "actor": "claude-code",
+      "ts": "2026-07-27T14:18:31.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-graph-projects",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607271418310000000212",
+      "actor": "claude-code",
+      "ts": "2026-07-27T14:18:31.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-graph-events",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607271418310000000226",
+      "actor": "claude-code",
+      "ts": "2026-07-27T14:18:31.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-graph-projects",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607271418310000000228",
+      "actor": "claude-code",
+      "ts": "2026-07-27T14:18:31.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-graph-project",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607271418310000000230",
+      "actor": "claude-code",
+      "ts": "2026-07-27T14:18:31.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-get-graph-project-nodes",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607271418310000000232",
+      "actor": "claude-code",
+      "ts": "2026-07-27T14:18:31.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-get-graph-project-edges",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607271418310000000234",
+      "actor": "claude-code",
+      "ts": "2026-07-27T14:18:31.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-get-graph-project-journal",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607271418310000000236",
+      "actor": "claude-code",
+      "ts": "2026-07-27T14:18:31.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-get-graph-project-export",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607271418310000000238",
+      "actor": "claude-code",
+      "ts": "2026-07-27T14:18:31.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-post-graph-project-mutations",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607271428490000000380",
+      "actor": "claude-code",
+      "ts": "2026-07-27T14:28:49.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-link-hosted",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607271428490000000548",
+      "actor": "claude-code",
+      "ts": "2026-07-27T14:28:49.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-linked-repo-fails-loud",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607271428490000000554",
+      "actor": "claude-code",
+      "ts": "2026-07-27T14:28:49.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-hosted-token-never-on-disk",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607271433010000000214",
+      "actor": "claude-code",
+      "ts": "2026-07-27T14:33:01.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-project-repos",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607271433010000000216",
+      "actor": "claude-code",
+      "ts": "2026-07-27T14:33:01.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-github-deliveries",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607271433010000000222",
+      "actor": "claude-code",
+      "ts": "2026-07-27T14:33:01.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-post-github-webhook",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607271433010000000240",
+      "actor": "claude-code",
+      "ts": "2026-07-27T14:33:01.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-graph-project-repos",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012607271518310000000211",
+      "actor": "claude-code",
+      "ts": "2026-07-27T15:18:31.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-graph-projects",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607271518310000000213",
+      "actor": "claude-code",
+      "ts": "2026-07-27T15:18:31.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-graph-events",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607271518310000000227",
+      "actor": "claude-code",
+      "ts": "2026-07-27T15:18:31.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-graph-projects",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607271518310000000229",
+      "actor": "claude-code",
+      "ts": "2026-07-27T15:18:31.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-graph-project",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607271518310000000239",
+      "actor": "claude-code",
+      "ts": "2026-07-27T15:18:31.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-post-graph-project-mutations",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607271528490000000381",
+      "actor": "claude-code",
+      "ts": "2026-07-27T15:28:49.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-link-hosted",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607271528490000000549",
+      "actor": "claude-code",
+      "ts": "2026-07-27T15:28:49.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-linked-repo-fails-loud",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607271528490000000555",
+      "actor": "claude-code",
+      "ts": "2026-07-27T15:28:49.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-hosted-token-never-on-disk",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607271533010000000215",
+      "actor": "claude-code",
+      "ts": "2026-07-27T15:33:01.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-project-repos",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607271533010000000217",
+      "actor": "claude-code",
+      "ts": "2026-07-27T15:33:01.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-github-deliveries",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607271533010000000223",
+      "actor": "claude-code",
+      "ts": "2026-07-27T15:33:01.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-post-github-webhook",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607271533010000000241",
+      "actor": "claude-code",
+      "ts": "2026-07-27T15:33:01.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-graph-project-repos",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607280206310000000092",
+      "actor": "claude-code",
+      "ts": "2026-07-28T02:06:31Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-293",
+      "title": "Tell a pull request which platform it shipped",
+      "summary": "Write AC-guest-checkout@ios in a pull request and only iOS moves — handy when one repository builds several apps. When arkaik can't tell which platform you meant, it says so instead of guessing and marking everything shipped.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/293",
+      "node_ids": [
+        "API-post-github-webhook",
+        "F-sync-refs",
+        "AC-parity-gap-at-a-glance"
+      ]
+    },
+    {
+      "id": "012607280552300000000093",
+      "actor": "claude-code",
+      "ts": "2026-07-28T05:52:30Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-294",
+      "title": "One repository, several apps, no extra typing",
+      "summary": "Link a monorepo once per app folder and arkaik works out which app a pull request touched from the files it changed. Your acceptances move on the right platform without anyone remembering to say so.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/294",
+      "node_ids": [
+        "DM-project-repos",
+        "API-graph-project-repos",
+        "API-post-github-webhook",
+        "API-github"
+      ]
+    },
+    {
+      "id": "012607280552300000000225",
+      "actor": "claude-code",
+      "ts": "2026-07-28T05:52:30Z",
+      "type": "node.status_changed",
+      "node_id": "API-github",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607280642560000000094",
+      "actor": "claude-code",
+      "ts": "2026-07-28T06:42:56Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-295",
+      "title": "The arkaik CLI is installable now",
+      "summary": "The command-line tool could not be installed at all, and the published MCP server was an old build that quietly ignored account projects. Both are fixed, so linking a repository to arkaik works the way the docs say it does.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/295",
+      "node_ids": [
+        "V-cli-terminal",
+        "F-link-hosted",
+        "F-mcp-agent-session"
+      ]
+    },
+    {
+      "id": "012607280716300000000095",
+      "actor": "claude-code",
+      "ts": "2026-07-28T07:16:30Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-297",
+      "title": "The tools now tell you their real version",
+      "summary": "The MCP server was announcing an old version number — exactly the wrong clue when checking whether your install can reach account projects. It now reports its true version, and the CLI answers --version too.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/297",
+      "node_ids": [
+        "V-cli-terminal",
+        "V-mcp-tool-catalog"
+      ]
+    },
+    {
+      "id": "012607280746300000000007",
+      "actor": "alexis",
+      "ts": "2026-07-28T07:46:30.000Z",
+      "type": "release.tagged",
+      "version": "hosted-projects",
+      "notes": "Hosted graph projects with agent tokens, the app and MCP speaking to the same store, and PRs that move acceptances on their own."
+    },
+    {
+      "id": "012607290651570000000205",
+      "actor": "claude-code",
+      "ts": "2026-07-29T06:51:57.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-owners",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607290651570000000207",
+      "actor": "claude-code",
+      "ts": "2026-07-29T06:51:57.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-owner-members",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607291318310000000231",
+      "actor": "claude-code",
+      "ts": "2026-07-29T13:18:31.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-get-graph-project-nodes",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607291318310000000233",
+      "actor": "claude-code",
+      "ts": "2026-07-29T13:18:31.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-get-graph-project-edges",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607291318310000000235",
+      "actor": "claude-code",
+      "ts": "2026-07-29T13:18:31.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-get-graph-project-journal",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012607291318310000000237",
+      "actor": "claude-code",
+      "ts": "2026-07-29T13:18:31.000Z",
+      "type": "node.status_changed",
+      "node_id": "API-get-graph-project-export",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608011106510000000096",
+      "actor": "claude-code",
+      "ts": "2026-08-01T11:06:51Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-298",
+      "title": "All your projects, right where you left them",
+      "summary": "The projects list now waits a beat for your account before it draws, so the projects you moved there show up alongside the ones on this device — no more wondering where half of them went.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/298",
+      "node_ids": [
+        "V-projects",
+        "API-get-auth-status"
+      ]
+    },
+    {
       "id": "012608011241070000000096",
       "ts": "2026-08-01T12:41:07Z",
       "actor": "claude-code",
@@ -7954,6 +13143,23 @@
       "title": "Move Project to Account"
     },
     {
+      "id": "012608011241070000000097",
+      "actor": "claude-code",
+      "ts": "2026-08-01T12:41:07Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-300",
+      "title": "Your projects, sorted by where they live",
+      "summary": "The projects page now groups everything into Hosted, Synked and Lokal, each with its own way to add a project — so what you create lands exactly where you meant it to. The backup nudge only appears when there is actually something local to back up.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/300",
+      "node_ids": [
+        "V-projects",
+        "F-create-project",
+        "F-import-json",
+        "F-synk-backup-restore",
+        "AC-sections-mirror-project-homes"
+      ]
+    },
+    {
       "id": "012608011241070000000175",
       "ts": "2026-08-01T12:41:07Z",
       "actor": "claude-code",
@@ -7961,6 +13167,89 @@
       "node_id": "AC-move-keeps-local-copy",
       "species": "acceptance",
       "title": "Moving keeps local copy"
+    },
+    {
+      "id": "012608011241070000000391",
+      "actor": "claude-code",
+      "ts": "2026-08-01T12:41:07Z",
+      "type": "node.status_changed",
+      "node_id": "AC-sections-mirror-project-homes",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608011341070000000350",
+      "actor": "claude-code",
+      "ts": "2026-08-01T13:41:07.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-move-to-account",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012608011341070000000508",
+      "actor": "claude-code",
+      "ts": "2026-08-01T13:41:07.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-move-keeps-local-copy",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012608011441070000000351",
+      "actor": "claude-code",
+      "ts": "2026-08-01T14:41:07.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-move-to-account",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608011441070000000509",
+      "actor": "claude-code",
+      "ts": "2026-08-01T14:41:07.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-move-keeps-local-copy",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608011516270000000098",
+      "actor": "claude-code",
+      "ts": "2026-08-01T15:16:27Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-301",
+      "title": "Your agent tokens now have a front door",
+      "summary": "Agent tokens live with your account, and you can finally reach them straight from the account menu — no more hunting for the URL.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/301",
+      "node_ids": [
+        "V-account-menu",
+        "V-agent-tokens"
+      ]
+    },
+    {
+      "id": "012608011516270000000339",
+      "actor": "claude-code",
+      "ts": "2026-08-01T15:16:27Z",
+      "type": "node.status_changed",
+      "node_id": "V-account-menu",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608011626040000000099",
+      "actor": "claude-code",
+      "ts": "2026-08-01T16:26:04Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-302",
+      "title": "A settings page for every project",
+      "summary": "Repository links and project deletion moved off the projects list into a dedicated Settings page inside each project. The project card is now simply the way in — no delete button lurking next to it.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/302",
+      "node_ids": [
+        "V-project-settings",
+        "F-delete-project",
+        "AC-delete-behind-confirmation"
+      ]
     },
     {
       "id": "012608011626040000000113",
@@ -7990,6 +13279,51 @@
       "title": "Public map cannot be deleted"
     },
     {
+      "id": "012608011726040000000384",
+      "actor": "claude-code",
+      "ts": "2026-08-01T17:26:04.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-project-settings",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012608011726040000000392",
+      "actor": "claude-code",
+      "ts": "2026-08-01T17:26:04.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-delete-behind-confirmation",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012608011726040000000394",
+      "actor": "claude-code",
+      "ts": "2026-08-01T17:26:04.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-public-map-undeletable",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012608011826040000000385",
+      "actor": "claude-code",
+      "ts": "2026-08-01T18:26:04.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-project-settings",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608011826040000000393",
+      "actor": "claude-code",
+      "ts": "2026-08-01T18:26:04.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-delete-behind-confirmation",
+      "from": "development",
+      "to": "live"
+    },
+    {
       "id": "012608020601400000000058",
       "ts": "2026-08-02T06:01:40Z",
       "actor": "claude-code",
@@ -7999,6 +13333,21 @@
       "title": "Command Palette"
     },
     {
+      "id": "012608020601400000000100",
+      "actor": "claude-code",
+      "ts": "2026-08-02T06:01:40Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-307",
+      "title": "Jump anywhere in your project with ⌘K",
+      "summary": "Hit ⌘K from any page and type where you want to go — a map, a library, the delivery board, your settings. Tab completes what you started, Enter takes you there.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/307",
+      "node_ids": [
+        "V-command-palette",
+        "F-navigate-by-keyboard",
+        "AC-palette-jump-anywhere"
+      ]
+    },
+    {
       "id": "012608020601400000000134",
       "ts": "2026-08-02T06:01:40Z",
       "actor": "claude-code",
@@ -8006,6 +13355,115 @@
       "node_id": "AC-palette-jump-anywhere",
       "species": "acceptance",
       "title": "Jump anywhere from keyboard"
+    },
+    {
+      "id": "012608020604360000000101",
+      "actor": "claude-code",
+      "ts": "2026-08-02T06:04:36Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-309",
+      "title": "Your value pyramid, readable at a glance",
+      "summary": "Each value element now shows four progress rings — one overall, one per platform — instead of a stack of status bars. Hover a ring for the full breakdown, switch between cards and a compact list, and filter down to what's covered or what's still missing.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/309",
+      "node_ids": [
+        "V-pyramid",
+        "V-overview",
+        "F-audit-value-coverage",
+        "AC-pyramid-coverage-glance",
+        "AC-pyramid-gap-filter"
+      ]
+    },
+    {
+      "id": "012608020604360000000459",
+      "actor": "claude-code",
+      "ts": "2026-08-02T06:04:36Z",
+      "type": "node.status_changed",
+      "node_id": "AC-pyramid-gap-filter",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608020625190000000102",
+      "actor": "claude-code",
+      "ts": "2026-08-02T06:25:19Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-305",
+      "title": "Open a node without losing your map",
+      "summary": "Node details now open in a column beside your map instead of covering it. Follow a reference to go deeper, press Esc to step back one level, and share the link — it remembers where you were.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/305",
+      "node_ids": [
+        "V-node-detail-panel",
+        "V-journey-map",
+        "V-system-map",
+        "AC-drill-down-in-place"
+      ]
+    },
+    {
+      "id": "012608020625190000000411",
+      "actor": "claude-code",
+      "ts": "2026-08-02T06:25:19Z",
+      "type": "node.status_changed",
+      "node_id": "AC-drill-down-in-place",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608020636060000000103",
+      "actor": "claude-code",
+      "ts": "2026-08-02T06:36:06Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-310",
+      "title": "Project navigation now comes first in the sidebar",
+      "summary": "Overview, Pyramid, Delivery and Changelog are now the first things you see when you open a project, so the main views are always one glance away.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/310",
+      "node_ids": [
+        "V-overview",
+        "V-pyramid",
+        "V-delivery-board",
+        "V-changelog"
+      ]
+    },
+    {
+      "id": "012608020643100000000104",
+      "actor": "claude-code",
+      "ts": "2026-08-02T06:43:10Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-311",
+      "title": "Skip the pitch when you're already building",
+      "summary": "Signed-in visitors now land straight on their projects instead of seeing the landing page again.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/311",
+      "node_ids": [
+        "V-landing",
+        "V-projects",
+        "AC-signed-in-skips-landing"
+      ]
+    },
+    {
+      "id": "012608020643100000000399",
+      "actor": "claude-code",
+      "ts": "2026-08-02T06:43:10Z",
+      "type": "node.status_changed",
+      "node_id": "AC-signed-in-skips-landing",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608020701400000000274",
+      "actor": "claude-code",
+      "ts": "2026-08-02T07:01:40.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-command-palette",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012608020701400000000426",
+      "actor": "claude-code",
+      "ts": "2026-08-02T07:01:40.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-palette-jump-anywhere",
+      "from": "idea",
+      "to": "development"
     },
     {
       "id": "012608020730270000000057",
@@ -8026,6 +13484,23 @@
       "title": "Adjust Map Display"
     },
     {
+      "id": "012608020730270000000105",
+      "actor": "claude-code",
+      "ts": "2026-08-02T07:30:27Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-312",
+      "title": "Every map can look the way it needs to",
+      "summary": "Maps now open on the ring charts you know from the Pyramid, and each map remembers its own look — screenshots on or off, platforms as rings or bars, chips or rows. Your walkthrough map and your delivery map are finally allowed to disagree.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/312",
+      "node_ids": [
+        "V-map-display-popover",
+        "F-adjust-map-display",
+        "AC-display-persists-per-map",
+        "DM-map-definition",
+        "V-journey-map"
+      ]
+    },
+    {
       "id": "012608020730270000000128",
       "ts": "2026-08-02T07:30:27Z",
       "actor": "claude-code",
@@ -8035,6 +13510,181 @@
       "title": "Display choices stick per map"
     },
     {
+      "id": "012608020801400000000275",
+      "actor": "claude-code",
+      "ts": "2026-08-02T08:01:40.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-command-palette",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608020801400000000427",
+      "actor": "claude-code",
+      "ts": "2026-08-02T08:01:40.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-palette-jump-anywhere",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608020830270000000272",
+      "actor": "claude-code",
+      "ts": "2026-08-02T08:30:27.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-map-display-popover",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012608020830270000000282",
+      "actor": "claude-code",
+      "ts": "2026-08-02T08:30:27.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-adjust-map-display",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012608020830270000000414",
+      "actor": "claude-code",
+      "ts": "2026-08-02T08:30:27.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-display-persists-per-map",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012608020900000000000143",
+      "actor": "alexis",
+      "ts": "2026-08-02T09:00:00Z",
+      "type": "decision.status_changed",
+      "node_id": "DEC-products-one-graph",
+      "from": "proposed",
+      "to": "approved"
+    },
+    {
+      "id": "012608020900000000000569",
+      "ts": "2026-08-02T09:00:00Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DEC-products-one-graph",
+      "species": "decision",
+      "title": "Products are an axis on one graph, not separate projects"
+    },
+    {
+      "id": "012608020905000000000145",
+      "actor": "alexis",
+      "ts": "2026-08-02T09:05:00Z",
+      "type": "decision.status_changed",
+      "node_id": "DEC-acceptance-first-intake",
+      "from": "proposed",
+      "to": "approved"
+    },
+    {
+      "id": "012608020905000000000570",
+      "ts": "2026-08-02T09:05:00Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DEC-acceptance-first-intake",
+      "species": "decision",
+      "title": "Anchorless acceptances are intake, not floating NFRs"
+    },
+    {
+      "id": "012608020919430000000106",
+      "actor": "claude-code",
+      "ts": "2026-08-02T09:19:43Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-313",
+      "title": "Search the docs with ⌘K",
+      "summary": "The documentation now has the same command palette as the project view. Type to find any page by its title or filename, press Enter to jump there.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/313",
+      "node_ids": [
+        "V-docs-site",
+        "V-command-palette",
+        "F-browse-docs"
+      ]
+    },
+    {
+      "id": "012608020919430000000363",
+      "actor": "claude-code",
+      "ts": "2026-08-02T09:19:43Z",
+      "type": "node.status_changed",
+      "node_id": "V-docs-site",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608020930270000000273",
+      "actor": "claude-code",
+      "ts": "2026-08-02T09:30:27.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-map-display-popover",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608020930270000000283",
+      "actor": "claude-code",
+      "ts": "2026-08-02T09:30:27.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-adjust-map-display",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608020930270000000415",
+      "actor": "claude-code",
+      "ts": "2026-08-02T09:30:27.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-display-persists-per-map",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608022000000000000144",
+      "actor": "alexis",
+      "ts": "2026-08-02T20:00:00Z",
+      "type": "decision.status_changed",
+      "node_id": "DEC-products-one-graph",
+      "from": "approved",
+      "to": "enacted"
+    },
+    {
+      "id": "012608022101360000000107",
+      "actor": "claude-code",
+      "ts": "2026-08-02T21:01:36Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-320",
+      "title": "A steadier place to work",
+      "summary": "Opening a panel no longer nudges the page around, every screen names where you are instead of repeating the project name, and everything you can do to a project now sits in one menu. The raw bundle opens as a side panel from any page, too.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/320",
+      "node_ids": [
+        "V-raw-bundle-panel",
+        "F-edit-raw-bundle",
+        "F-export-bundle",
+        "AC-raw-close-guard"
+      ]
+    },
+    {
+      "id": "012608022101360000000311",
+      "actor": "claude-code",
+      "ts": "2026-08-02T21:01:36Z",
+      "type": "node.status_changed",
+      "node_id": "F-edit-raw-bundle",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608022101360000000447",
+      "actor": "claude-code",
+      "ts": "2026-08-02T21:01:36Z",
+      "type": "node.status_changed",
+      "node_id": "AC-raw-close-guard",
+      "from": "development",
+      "to": "live"
+    },
+    {
       "id": "012608022136340000000010",
       "ts": "2026-08-02T21:36:34Z",
       "actor": "claude-code",
@@ -8042,6 +13692,23 @@
       "node_id": "DM-product",
       "species": "data-model",
       "title": "Product"
+    },
+    {
+      "id": "012608022136340000000108",
+      "actor": "claude-code",
+      "ts": "2026-08-02T21:36:34Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-308",
+      "title": "One project, several apps — each with its own platforms",
+      "summary": "Your admin dashboard stops pretending it's missing on iOS. Tell Arkaik which apps live in your project and which platforms each one ships on, and every ring, board and tab reports on the app you're actually looking at.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/308",
+      "node_ids": [
+        "DM-product",
+        "V-pyramid",
+        "V-delivery-board",
+        "V-library",
+        "AC-scoped-journey-never-lies"
+      ]
     },
     {
       "id": "012608022136340000000115",
@@ -8062,6 +13729,137 @@
       "title": "Products are named in Settings"
     },
     {
+      "id": "012608022136340000000413",
+      "actor": "claude-code",
+      "ts": "2026-08-02T21:36:34Z",
+      "type": "node.status_changed",
+      "node_id": "AC-scoped-journey-never-lies",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608022224140000000109",
+      "actor": "claude-code",
+      "ts": "2026-08-02T22:24:14Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-321",
+      "title": "Screens can now show what the server pushes them",
+      "summary": "A screen that receives live updates — a webhook, a stream, a push — can finally be drawn that way and still import cleanly. And when you link two things on a map, Arkaik only offers the relationships that actually make sense between them.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/321",
+      "node_ids": [
+        "F-edit-graph-on-canvas",
+        "AC-valid-edge-types-only",
+        "F-validate-bundle"
+      ]
+    },
+    {
+      "id": "012608022236340000000178",
+      "actor": "claude-code",
+      "ts": "2026-08-02T22:36:34.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-product",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012608022236340000000388",
+      "actor": "claude-code",
+      "ts": "2026-08-02T22:36:34.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-manage-products",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012608022236340000000406",
+      "actor": "claude-code",
+      "ts": "2026-08-02T22:36:34.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-products-named-in-settings",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012608022336340000000179",
+      "actor": "claude-code",
+      "ts": "2026-08-02T23:36:34.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-product",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608030501220000000110",
+      "actor": "claude-code",
+      "ts": "2026-08-03T05:01:22Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-322",
+      "title": "Your project can hold several apps — and now you can say so",
+      "summary": "Name the apps your project covers — the main app, an admin dashboard, a public API — right from settings. Assign screens and flows as you create them, or move a whole shelf at once from the Library.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/322",
+      "node_ids": [
+        "F-manage-products",
+        "V-project-settings",
+        "AC-products-named-in-settings",
+        "V-library",
+        "AC-library-bulk-move-honest"
+      ]
+    },
+    {
+      "id": "012608030501220000000389",
+      "actor": "claude-code",
+      "ts": "2026-08-03T05:01:22Z",
+      "type": "node.status_changed",
+      "node_id": "F-manage-products",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608030501220000000407",
+      "actor": "claude-code",
+      "ts": "2026-08-03T05:01:22Z",
+      "type": "node.status_changed",
+      "node_id": "AC-products-named-in-settings",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608030501220000000461",
+      "actor": "claude-code",
+      "ts": "2026-08-03T05:01:22Z",
+      "type": "node.status_changed",
+      "node_id": "AC-library-bulk-move-honest",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608030517450000000111",
+      "actor": "claude-code",
+      "ts": "2026-08-03T05:17:45Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-323",
+      "title": "Scrolling stays put",
+      "summary": "Swiping across breadcrumbs, tables and boards no longer bounces the page or sends you back a screen, and scrolling past the end of a panel stops there instead of dragging the whole page along. Buttons also stopped highlighting themselves like text when you click them.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/323",
+      "node_ids": []
+    },
+    {
+      "id": "012608030536390000000112",
+      "actor": "claude-code",
+      "ts": "2026-08-03T05:36:39Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-325",
+      "title": "The page header always says which app you're looking at",
+      "summary": "When you switch products, every page header updates to name the one you're viewing — 'All products' or a specific app — so you stay oriented as you move around.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/325",
+      "node_ids": [
+        "V-overview",
+        "V-delivery-board",
+        "V-pyramid",
+        "V-changelog"
+      ]
+    },
+    {
       "id": "012608030536510000000059",
       "ts": "2026-08-03T05:36:51Z",
       "actor": "claude-code",
@@ -8069,6 +13867,22 @@
       "node_id": "V-keyboard-shortcuts-dialog",
       "species": "view",
       "title": "Keyboard Shortcuts Dialog"
+    },
+    {
+      "id": "012608030536510000000113",
+      "actor": "claude-code",
+      "ts": "2026-08-03T05:36:51Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-324",
+      "title": "A keyboard shortcuts cheat sheet, one keystroke away",
+      "summary": "Press ⌘? (or Ctrl+? on Windows and Linux) anywhere to see every shortcut the app responds to, grouped by where it works — and the sheet stays in sync with what the app actually does.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/324",
+      "node_ids": [
+        "V-keyboard-shortcuts-dialog",
+        "F-navigate-by-keyboard",
+        "AC-shortcuts-no-dead-keys",
+        "V-command-palette"
+      ]
     },
     {
       "id": "012608030536510000000135",
@@ -8080,29 +13894,167 @@
       "title": "Shortcut list tells no lies"
     },
     {
-      "id": "01K0SELFMAPSEED00000000900",
-      "ts": "2026-08-03T12:00:00.000Z",
+      "id": "012608030537180000000114",
       "actor": "claude-code",
+      "ts": "2026-08-03T05:37:18Z",
       "type": "deliverable.shipped",
-      "deliverable_id": "pr-331",
-      "title": "Status lifecycle overhaul",
-      "summary": "Seven statuses, blocked as a flag, permanent legacy aliases.",
-      "url": "https://github.com/alexisbohns/arkaik/pull/331"
+      "deliverable_id": "pr-326",
+      "title": "The minimap works — and now it steers",
+      "summary": "The little map in the corner was showing nothing at all. It now draws your whole product, dims everything outside your current view, and lets you drag it to fly across the map — with node colours by status or by kind, saved per map.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/326",
+      "node_ids": [
+        "V-journey-map",
+        "V-system-map",
+        "V-map-display-popover",
+        "F-adjust-map-display"
+      ]
     },
     {
-      "id": "01K0SELFMAPSEED00000000901",
-      "ts": "2026-08-03T16:00:00.000Z",
+      "id": "012608030636510000000276",
       "actor": "claude-code",
+      "ts": "2026-08-03T06:36:51.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-keyboard-shortcuts-dialog",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012608030636510000000428",
+      "actor": "claude-code",
+      "ts": "2026-08-03T06:36:51.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-shortcuts-no-dead-keys",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012608030707540000000115",
+      "actor": "claude-code",
+      "ts": "2026-08-03T07:07:54Z",
       "type": "deliverable.shipped",
-      "deliverable_id": "pr-335",
-      "title": "Decisions species",
-      "summary": "ADR records as first-class graph nodes, with supersedes/generates/impacts edges.",
-      "url": "https://github.com/alexisbohns/arkaik/pull/335",
+      "deliverable_id": "pr-327",
+      "title": "Zoom in on one app, one page at a time",
+      "summary": "Delivery, Pyramid, Acceptances and Library each get their own product picker. Narrow one page to a single app without changing what you see everywhere else — and the link you share carries the setting with it.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/327",
+      "node_ids": [
+        "V-delivery-board",
+        "V-pyramid",
+        "V-acceptances-matrix",
+        "V-library"
+      ]
+    },
+    {
+      "id": "012608030736510000000277",
+      "actor": "claude-code",
+      "ts": "2026-08-03T07:36:51.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-keyboard-shortcuts-dialog",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608030736510000000429",
+      "actor": "claude-code",
+      "ts": "2026-08-03T07:36:51.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-shortcuts-no-dead-keys",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608030753290000000008",
+      "actor": "alexis",
+      "ts": "2026-08-03T07:53:29.000Z",
+      "type": "release.tagged",
+      "version": "going-multi-product",
+      "notes": "Products get declared, filtered, and shown everywhere; the studio gets its polish — command palette, column panels, a minimap you can steer."
+    },
+    {
+      "id": "012608031035380000000116",
+      "actor": "claude-code",
+      "ts": "2026-08-03T10:35:38Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-330",
+      "title": "File ideas before you build them",
+      "summary": "Acceptances can now start life as intake ideas — write them down first, then attach them to views and flows as those get built, or split one idea into several. The product stays with the idea through every step.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/330",
+      "node_ids": [
+        "V-acceptances-matrix",
+        "F-edit-acceptance",
+        "AC-split-carries-context",
+        "AC-matrix-groups-by-anchor"
+      ]
+    },
+    {
+      "id": "012608031035380000000146",
+      "actor": "alexis",
+      "ts": "2026-08-03T10:35:38Z",
+      "type": "decision.status_changed",
+      "node_id": "DEC-acceptance-first-intake",
+      "from": "approved",
+      "to": "enacted"
+    },
+    {
+      "id": "012608031035380000000451",
+      "actor": "claude-code",
+      "ts": "2026-08-03T10:35:38Z",
+      "type": "node.status_changed",
+      "node_id": "AC-split-carries-context",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608031100000000000147",
+      "actor": "alexis",
+      "ts": "2026-08-03T11:00:00Z",
+      "type": "decision.status_changed",
+      "node_id": "DEC-idea-stays-a-status",
+      "from": "proposed",
+      "to": "approved"
+    },
+    {
+      "id": "012608031100000000000571",
+      "ts": "2026-08-03T11:00:00Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DEC-idea-stays-a-status",
+      "species": "decision",
+      "title": "Idea stays a status"
+    },
+    {
+      "id": "012608031209320000000117",
+      "actor": "claude-code",
+      "ts": "2026-08-03T12:09:32Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-331",
+      "title": "Statuses that tell the real story",
+      "summary": "The lifecycle gets clearer: a new Discovery stage for things being shaped, Backlog now means genuinely ready to start, and blocked items keep their place — marked with a small red flag instead of losing their spot in the journey.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/331",
       "node_ids": [
         "DEC-two-axes-stay",
         "DEC-blocked-is-a-flag",
-        "DEC-migration-hard-cutover"
+        "DEC-migration-hard-cutover",
+        "V-library",
+        "AC-legacy-bundle-migrates"
       ]
+    },
+    {
+      "id": "012608031400000000000148",
+      "actor": "alexis",
+      "ts": "2026-08-03T14:00:00Z",
+      "type": "decision.status_changed",
+      "node_id": "DEC-idea-stays-a-status",
+      "from": "approved",
+      "to": "enacted"
+    },
+    {
+      "id": "012608031626040000000395",
+      "actor": "claude-code",
+      "ts": "2026-08-03T16:26:04.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-public-map-undeletable",
+      "from": "development",
+      "to": "live"
     },
     {
       "id": "01K0SELFMAPSEED00000000910",
@@ -8159,6 +14111,23 @@
       "title": "Log a Decision"
     },
     {
+      "id": "012608031845570000000118",
+      "actor": "claude-code",
+      "ts": "2026-08-03T18:45:57Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-335",
+      "title": "Your product's decisions, on the map",
+      "summary": "Arkaik now records decisions — the why, the what, and the consequences — right next to the screens and flows they shaped. Browse them in the new Decision Log, and see at a glance when one decision replaced another.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/335",
+      "node_ids": [
+        "V-decision-log",
+        "V-decision-editor",
+        "F-log-decision",
+        "AC-decision-keeps-why-how",
+        "AC-superseded-chain-traceable"
+      ]
+    },
+    {
       "id": "012608031845570000000158",
       "ts": "2026-08-03T18:45:57Z",
       "actor": "claude-code",
@@ -8195,6 +14164,122 @@
       "title": "Filter Decisions by Status"
     },
     {
+      "id": "012608031900000000000151",
+      "actor": "alexis",
+      "ts": "2026-08-03T19:00:00.000Z",
+      "type": "idea.proposed",
+      "title": "Milestones between deliverables and releases",
+      "description": "A middle grouping — named milestones that collect deliverables before a release tags them. Parked during the decisions-species cycle; the changelog's era grouping may already cover most of it."
+    },
+    {
+      "id": "012608031945570000000316",
+      "actor": "claude-code",
+      "ts": "2026-08-03T19:45:57.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-decision-log",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012608031945570000000318",
+      "actor": "claude-code",
+      "ts": "2026-08-03T19:45:57.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-decision-editor",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012608031945570000000326",
+      "actor": "claude-code",
+      "ts": "2026-08-03T19:45:57.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-log-decision",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012608031945570000000474",
+      "actor": "claude-code",
+      "ts": "2026-08-03T19:45:57.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-decision-keeps-why-how",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012608031945570000000476",
+      "actor": "claude-code",
+      "ts": "2026-08-03T19:45:57.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-decision-edits-autosave",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012608031945570000000478",
+      "actor": "claude-code",
+      "ts": "2026-08-03T19:45:57.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-superseded-chain-traceable",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012608031945570000000480",
+      "actor": "claude-code",
+      "ts": "2026-08-03T19:45:57.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-decision-status-filter",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012608032045570000000317",
+      "actor": "claude-code",
+      "ts": "2026-08-03T20:45:57.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-decision-log",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608032045570000000319",
+      "actor": "claude-code",
+      "ts": "2026-08-03T20:45:57.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-decision-editor",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608032045570000000327",
+      "actor": "claude-code",
+      "ts": "2026-08-03T20:45:57.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-log-decision",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608032045570000000475",
+      "actor": "claude-code",
+      "ts": "2026-08-03T20:45:57.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-decision-keeps-why-how",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608032045570000000479",
+      "actor": "claude-code",
+      "ts": "2026-08-03T20:45:57.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-superseded-chain-traceable",
+      "from": "development",
+      "to": "live"
+    },
+    {
       "id": "012608032243550000000011",
       "ts": "2026-08-03T22:43:55Z",
       "actor": "claude-code",
@@ -8220,6 +14305,23 @@
       "node_id": "F-audit-history",
       "species": "flow",
       "title": "Audit Project History"
+    },
+    {
+      "id": "012608032243550000000119",
+      "actor": "claude-code",
+      "ts": "2026-08-03T22:43:55Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-337",
+      "title": "Your changelog now tells two stories: what you decided, and what you shipped",
+      "summary": "The changelog splits into a Design side (open ideas, commitments, decisions) and a Delivery side (releases with the actual deliverables inside them). The play-by-play event feed gets its own History page, and anything blocked now wears a little amber dot.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/337",
+      "node_ids": [
+        "V-changelog",
+        "V-history",
+        "DM-deliverable",
+        "F-audit-history",
+        "AC-changelog-design-delivery-split"
+      ]
     },
     {
       "id": "012608032243550000000153",
@@ -8249,6 +14351,114 @@
       "title": "Empty History Is Calm"
     },
     {
+      "id": "012608032243550000000469",
+      "actor": "claude-code",
+      "ts": "2026-08-03T22:43:55Z",
+      "type": "node.status_changed",
+      "node_id": "AC-changelog-design-delivery-split",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608032343550000000180",
+      "actor": "claude-code",
+      "ts": "2026-08-03T23:43:55.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-deliverable",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012608032343550000000314",
+      "actor": "claude-code",
+      "ts": "2026-08-03T23:43:55.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-history",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012608032343550000000324",
+      "actor": "claude-code",
+      "ts": "2026-08-03T23:43:55.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-audit-history",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012608032343550000000464",
+      "actor": "claude-code",
+      "ts": "2026-08-03T23:43:55.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-history-never-rewritten",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012608032343550000000466",
+      "actor": "claude-code",
+      "ts": "2026-08-03T23:43:55.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-history-family-filter",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012608032343550000000486",
+      "actor": "claude-code",
+      "ts": "2026-08-03T23:43:55.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-empty-journal-calm",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012608040030000000000149",
+      "actor": "alexis",
+      "ts": "2026-08-04T00:30:00.000Z",
+      "type": "decision.status_changed",
+      "node_id": "DEC-self-map-sandbox-seed",
+      "from": "proposed",
+      "to": "approved"
+    },
+    {
+      "id": "012608040043550000000181",
+      "actor": "claude-code",
+      "ts": "2026-08-04T00:43:55.000Z",
+      "type": "node.status_changed",
+      "node_id": "DM-deliverable",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608040043550000000315",
+      "actor": "claude-code",
+      "ts": "2026-08-04T00:43:55.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-history",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608040043550000000325",
+      "actor": "claude-code",
+      "ts": "2026-08-04T00:43:55.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-audit-history",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608040043550000000487",
+      "actor": "claude-code",
+      "ts": "2026-08-04T00:43:55.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-empty-journal-calm",
+      "from": "development",
+      "to": "live"
+    },
+    {
       "id": "012608040657050000000099",
       "ts": "2026-08-04T06:57:05Z",
       "actor": "claude-code",
@@ -8265,6 +14475,32 @@
       "node_id": "V-sandbox-notice",
       "species": "view",
       "title": "Sandbox Notice"
+    },
+    {
+      "id": "012608040657050000000120",
+      "actor": "claude-code",
+      "ts": "2026-08-04T06:57:05Z",
+      "type": "deliverable.shipped",
+      "deliverable_id": "pr-338",
+      "title": "Take Arkaik's own map for a spin — no account needed",
+      "summary": "A new Explore section on the projects page opens the live map we use to build Arkaik. Poke around, move things, edit freely — it's a sandbox, and a refresh puts everything back. Like what you made? Import a copy and keep it.",
+      "url": "https://github.com/alexisbohns/arkaik/pull/338",
+      "node_ids": [
+        "V-projects",
+        "F-explore-sandbox",
+        "V-sandbox-notice",
+        "AC-sandbox-resets-pristine",
+        "AC-sandbox-edits-are-real"
+      ]
+    },
+    {
+      "id": "012608040657050000000150",
+      "actor": "alexis",
+      "ts": "2026-08-04T06:57:05Z",
+      "type": "decision.status_changed",
+      "node_id": "DEC-self-map-sandbox-seed",
+      "from": "approved",
+      "to": "enacted"
     },
     {
       "id": "012608040657050000000184",
@@ -8292,6 +14528,165 @@
       "node_id": "AC-sandbox-rules-stated-plainly",
       "species": "acceptance",
       "title": "Sandbox Rules Stated Plainly"
+    },
+    {
+      "id": "012608040720000000000465",
+      "actor": "claude-code",
+      "ts": "2026-08-04T07:20:00.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-history-never-rewritten",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608040720000000000467",
+      "actor": "claude-code",
+      "ts": "2026-08-04T07:20:00.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-history-family-filter",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608040720000000000477",
+      "actor": "claude-code",
+      "ts": "2026-08-04T07:20:00.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-decision-edits-autosave",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608040720000000000481",
+      "actor": "claude-code",
+      "ts": "2026-08-04T07:20:00.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-decision-status-filter",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608040727050000000009",
+      "actor": "alexis",
+      "ts": "2026-08-04T07:27:05.000Z",
+      "type": "release.tagged",
+      "version": "the-self-map",
+      "notes": "The self-map program: a modern status lifecycle, decision records, a changelog split into Design and Delivery, and Arkaik's own map as a public sandbox."
+    },
+    {
+      "id": "012608040757050000000356",
+      "actor": "claude-code",
+      "ts": "2026-08-04T07:57:05.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-explore-sandbox",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012608040757050000000358",
+      "actor": "claude-code",
+      "ts": "2026-08-04T07:57:05.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-sandbox-notice",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012608040757050000000526",
+      "actor": "claude-code",
+      "ts": "2026-08-04T07:57:05.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-sandbox-resets-pristine",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012608040757050000000528",
+      "actor": "claude-code",
+      "ts": "2026-08-04T07:57:05.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-sandbox-edits-are-real",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012608040757050000000530",
+      "actor": "claude-code",
+      "ts": "2026-08-04T07:57:05.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-sandbox-rules-stated-plainly",
+      "from": "idea",
+      "to": "development"
+    },
+    {
+      "id": "012608040800000000000152",
+      "actor": "alexis",
+      "ts": "2026-08-04T08:00:00.000Z",
+      "type": "idea.proposed",
+      "title": "Give Pebbles its own real history",
+      "description": "Retro-populate the Pebbles example bundle with deliverables, releases, and decisions the way the self-map now has them, so both examples demonstrate the full changelog."
+    },
+    {
+      "id": "012608040805000000000153",
+      "actor": "claude-code",
+      "ts": "2026-08-04T08:05:00.000Z",
+      "type": "idea.proposed",
+      "title": "A platform id for non-web surfaces",
+      "description": "Toolchain surfaces (CLI, MCP, skill) currently claim web because the platform enum has no terminal or agent value; a dedicated platform id would let the map say what they really are."
+    },
+    {
+      "id": "012608040857050000000357",
+      "actor": "claude-code",
+      "ts": "2026-08-04T08:57:05.000Z",
+      "type": "node.status_changed",
+      "node_id": "F-explore-sandbox",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608040857050000000359",
+      "actor": "claude-code",
+      "ts": "2026-08-04T08:57:05.000Z",
+      "type": "node.status_changed",
+      "node_id": "V-sandbox-notice",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608040857050000000527",
+      "actor": "claude-code",
+      "ts": "2026-08-04T08:57:05.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-sandbox-resets-pristine",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608040857050000000529",
+      "actor": "claude-code",
+      "ts": "2026-08-04T08:57:05.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-sandbox-edits-are-real",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608040857050000000531",
+      "actor": "claude-code",
+      "ts": "2026-08-04T08:57:05.000Z",
+      "type": "node.status_changed",
+      "node_id": "AC-sandbox-rules-stated-plainly",
+      "from": "development",
+      "to": "live"
+    },
+    {
+      "id": "012608040900000000000572",
+      "ts": "2026-08-04T09:00:00Z",
+      "actor": "claude-code",
+      "type": "node.created",
+      "node_id": "DEC-self-map-sandbox-seed",
+      "species": "decision",
+      "title": "The self-map ships as an in-memory sandbox seed, reset on refresh"
     },
     {
       "id": "012608041100000000000000",


### PR DESCRIPTION
Cycle 5, PR B of two — stacked on #339 (the map). This PR adds **the story**: the journal now tells how Arkaik was actually built. Spec: [content-population design](docs/superpowers/specs/2026-08-04-content-population-design.md).

## What the journal now holds (791 events, seed at 486KB)

- **111 deliverables** (`deliverable.shipped`) — every user-visible merged PR, chores skipped. Titles and summaries adapted from the PRs' own Lab Notes where they exist (benefit-first voice), each with its real merge timestamp, PR link, and the map nodes it touched.
- **10 thematic-era releases** (`release.tagged`), `first-graph` (2026-03-19) → `the-self-map` (2026-08-04), each with a narrative note; `project.version` ends at `the-self-map`. Deliverables group into eras by journal position — the changelog's own grouping rule, demonstrated.
- **15 new decisions** (18 total `DEC-` nodes) mined from the spec docs — JSONL sidecar journal, snapshot-vs-journal authority, deterministic ids, local-first, Publik strips the journal, copy-not-move promotion, products-on-one-graph, the sandbox seed itself, … — each with real context/consequences/`decided_at`, `impacts`/`generates` edges, and a `proposed → approved → enacted` event trail.
- **404 status arcs** (`node.status_changed`) so every node has an honest lifecycle history and per-node timelines render.
- **3 open ideas** (`idea.proposed`) so the backlog projection isn't empty — all verified genuinely open.

An adversarial story review ran before this PR: it caught two jargon stub duplicates, four future-dated arc events, one anachronistic release note ("five species" at birth), one already-shipped idea, and a handful of anachronistic `node_ids` — all fixed. Deliverable timestamps were spot-verified to equal the real `mergedAt` to the second; decision records were checked against the docs nearly verbatim. `validate-bundle.js` passes warning-clean; every deliverable falls inside an era; no event is future-dated.

Also updates the self-map program doc: cycles 4 and 5 marked shipped.

## Visual pass checklist (Alexis)

- [ ] Changelog page: Delivery panel groups 111 deliverables under 10 era releases; notes read as a story
- [ ] Changelog Design panel: commitments + decision activity render
- [ ] History page: 791 events paginate/filter acceptably; the feed reads as a real timeline
- [ ] Decision Log: 18 decisions ordered by decided_at; context/consequences read well; status filters work
- [ ] A node detail panel timeline (e.g. the journey canvas view): created → development → live at plausible dates
- [ ] Sandbox still snappy at 486KB seed

## Rider fix: changelog deep-links resolve again

Found during the visual pass: clicking a decision in the changelog's Design panel opened a `?node=` panel that always said "no node with that id" — the page mounts the panel shell without passing the nodes it already loads (`allNodes`), unlike the Decisions page. Fixed by passing `allNodes`/`allEdges`/`scope`/`journal` on the Changelog `PageShell` (panels there stay read-only — no `onUpdate`), and `allNodes`/`journal` on History so a panel trail carried across navigation still resolves. Stale shell comment updated. Pre-existing bug on main; cycle 5's content made it visible.

- [ ] Visual pass addition: click a decision in the changelog's Design panel — the panel now shows the decision

## Lab Note

```yaml
en:
  title: "Arkaik's map now remembers its own story"
  summary: "Open the sandbox project's changelog: every chapter of how Arkaik was built is there — what shipped, what was decided, and why. A product that keeps its own diary."
fr:
  title: "La carte d'Arkaik raconte maintenant son histoire"
  summary: "Ouvre le changelog du projet bac à sable : chaque chapitre de la construction d'Arkaik y est — ce qui a été livré, ce qui a été décidé, et pourquoi. Un produit qui tient son propre journal."
suggested:
  molecule: arkaik
  type: feature
  tags: [changelog]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

