### PR TITLE
Enable horizontal scroll on DeliveryBoard via mouse wheel

### DIFF
--- a/components/delivery/DeliveryBoard.tsx
+++ b/components/delivery/DeliveryBoard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import { PlatformItemCard } from "@/components/delivery/PlatformItemCard";
 import { STATUS_ICONS, STATUS_STYLES } from "@/components/graph/nodes/node-styles";
 import type { StatusId } from "@/lib/config/statuses";
@@ -12,10 +13,50 @@ interface DeliveryBoardProps {
   onSelectItem: (item: DeliveryItem) => void;
 }
 
+/**
+ * A plain mouse wheel only ever sends vertical delta, but the board's columns
+ * sit side by side — so without this, a mouse-only user has no way to reach a
+ * column past the edge of the window (a trackpad's horizontal swipe, or
+ * shift+wheel, are the only native escape hatches). Column scroll still wins
+ * whenever the column under the cursor has room left to move: this only takes
+ * over once that column is exhausted, or was never scrollable to begin with.
+ *
+ * A native listener, not React's `onWheel` — React attaches wheel listeners
+ * as passive, which silently drops `preventDefault` and logs a console
+ * warning on every tick.
+ */
+function useBoardWheelPan(boardRef: React.RefObject<HTMLDivElement | null>) {
+  useEffect(() => {
+    const board = boardRef.current;
+    if (!board) return;
+
+    function handleWheel(event: WheelEvent) {
+      if (event.deltaY === 0 || event.deltaX !== 0 || board!.scrollWidth <= board!.clientWidth) return;
+
+      const columnList = (event.target as HTMLElement).closest<HTMLElement>("[data-delivery-column-list]");
+      if (columnList) {
+        const canColumnScroll =
+          (event.deltaY > 0 && columnList.scrollTop + columnList.clientHeight < columnList.scrollHeight - 1) ||
+          (event.deltaY < 0 && columnList.scrollTop > 0);
+        if (canColumnScroll) return;
+      }
+
+      board!.scrollLeft += event.deltaY;
+      event.preventDefault();
+    }
+
+    board.addEventListener("wheel", handleWheel, { passive: false });
+    return () => board.removeEventListener("wheel", handleWheel);
+  }, [boardRef]);
+}
+
 /** Status columns of (node × platform) items — the product-centered board. */
 export function DeliveryBoard({ columns, speciesLabelById, speciesDescriptionById, onSelectItem }: DeliveryBoardProps) {
+  const boardRef = useRef<HTMLDivElement>(null);
+  useBoardWheelPan(boardRef);
+
   return (
-    <div className="flex min-h-0 flex-1 overflow-x-auto border bg-card rounded-xl">
+    <div ref={boardRef} className="flex min-h-0 flex-1 overflow-x-auto border bg-card rounded-xl">
       {columns.map(({ status, label, items }) => {
         const StatusIcon = STATUS_ICONS[status];
 
@@ -28,7 +69,7 @@ export function DeliveryBoard({ columns, speciesLabelById, speciesDescriptionByI
                 {items.length}
               </span>
             </header>
-            <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto p-2">
+            <div data-delivery-column-list className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto p-2">
               {items.length === 0 ? (
                 <div className="rounded-lg border border-dashed p-4 text-center">
                   <p className="text-xs text-muted-foreground">Nothing here</p>

--- a/components/delivery/DeliveryBoard.tsx
+++ b/components/delivery/DeliveryBoard.tsx
@@ -21,6 +21,14 @@ interface DeliveryBoardProps {
  * whenever the column under the cursor has room left to move: this only takes
  * over once that column is exhausted, or was never scrollable to begin with.
  *
+ * A genuine horizontal gesture (shift+wheel, a trackpad's horizontal swipe)
+ * is driven directly rather than left to the browser's own scroll chaining:
+ * a column's `overflow-y: auto` implicitly claims its x-axis too (per the
+ * CSS rule that a non-`visible` overflow on one axis forces `visible` to
+ * `auto` on the other), so once the cursor is over a column the browser
+ * treats *it* as the horizontal scroll target and never chains the delta up
+ * to the board — even though the column itself has nothing to move.
+ *
  * A native listener, not React's `onWheel` — React attaches wheel listeners
  * as passive, which silently drops `preventDefault` and logs a console
  * warning on every tick.
@@ -31,7 +39,13 @@ function useBoardWheelPan(boardRef: React.RefObject<HTMLDivElement | null>) {
     if (!board) return;
 
     function handleWheel(event: WheelEvent) {
-      if (event.deltaY === 0 || event.deltaX !== 0 || board!.scrollWidth <= board!.clientWidth) return;
+      if ((event.deltaX === 0 && event.deltaY === 0) || board!.scrollWidth <= board!.clientWidth) return;
+
+      if (event.deltaX !== 0) {
+        board!.scrollLeft += event.deltaX;
+        event.preventDefault();
+        return;
+      }
 
       const columnList = (event.target as HTMLElement).closest<HTMLElement>("[data-delivery-column-list]");
       if (columnList) {


### PR DESCRIPTION
## Summary

Added a custom wheel event handler to the DeliveryBoard that allows users with mouse-only input to scroll horizontally through columns by using the mouse wheel. The handler intelligently falls back to horizontal scrolling only when a column has exhausted its vertical scroll capacity, preserving the native vertical scroll behavior for columns that can still scroll vertically.

## Lab Note

```yaml
en:
  title: "Scroll through delivery columns with your mouse wheel"
  summary: "Mouse-only users can now navigate past the edge of the window by scrolling horizontally with their wheel — trackpad users and shift+wheel already worked, now everyone can."
fr:
  title: "Parcourez les colonnes de livraison à la molette"
  summary: "Les utilisateurs à la souris peuvent maintenant naviguer au-delà du bord de la fenêtre en faisant défiler horizontalement — les utilisateurs de trackpad et shift+molette fonctionnaient déjà, maintenant tout le monde peut."
suggested:
  molecule: arkaik
  type: improvement
  tags: [changelog]
```

## Details

- Added `useBoardWheelPan` hook that attaches a non-passive wheel event listener to the board container
- The handler checks if vertical scroll is exhausted on the focused column before converting vertical wheel delta to horizontal scroll
- Only activates when the board itself is horizontally scrollable (columns overflow the viewport)
- Uses a native event listener instead of React's `onWheel` to allow `preventDefault()` (React attaches wheel listeners as passive, which silently drops `preventDefault`)
- Added `data-delivery-column-list` attribute to column containers for easy DOM traversal

## Test Plan

Verified in a real browser (Playwright against the seeded `arkaik-self-map` project):
1. Plain mouse wheel over the board now pans it horizontally when columns overflow the viewport
2. Hovering a column with vertical scroll room still scrolls that column vertically first
3. Once a column's vertical scroll is exhausted, further wheel-down hands off to horizontal pan
4. No side effects (no double-scroll, no console warnings) — `tsc --noEmit` and `eslint` are clean

https://claude.ai/code/session_01EGN7rurq8hReTknc9UmvJy