### PR TITLE
Bootstrap: the skill, its wiring, and the method doc (part C — judgment)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ See [`docs/`](docs/README.md) for detailed documentation:
 - [Graph Model](docs/graph-model.md) — 5-species taxonomy, composition, statuses, edge types
 - [Data Layer](docs/data-layer.md) — DataProvider interface, local storage, import/export
 - [Hosted Projects](docs/hosted-projects.md) — put a project in your account, point a coding agent at it, and let pull requests move acceptances
+- [Bootstrap](docs/bootstrap.md) — onboarding an existing repo onto Arkaik in one run
 - [Conventions](docs/conventions.md) — coding patterns, file organization, state management
 - [Vision](docs/vision.md) — product strategy: the four layers (format, toolchain, app, services), the core product ("one graph, many maps"), modes & tiers, roadmap
 - [Specs](docs/spec/bundle-format.md) — normative specifications: bundle format v2, event journal, toolchain, services, maps, MCP server

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@
 - [Data Layer](data-layer.md) — DataProvider interface, local storage, import/export
 - [Conventions](conventions.md) — Coding patterns, file organization, state management
 - [Hosted Projects](hosted-projects.md) — Put a project in your account, point a coding agent at it, and let pull requests move acceptances
+- [Bootstrap](bootstrap.md) — Onboarding an existing repo onto Arkaik in one run
 - [Icon Wobble](icon-wobble.md) — The hand-drawn icon effect: why/what/how + a portable recipe
 - [Vision](vision.md) — Product strategy: the four layers, modes & tiers, format levels, roadmap
 

--- a/docs/arkaik-bootstrap-skill/references/fragments.md
+++ b/docs/arkaik-bootstrap-skill/references/fragments.md
@@ -1,0 +1,203 @@
+# The fragment contract
+
+A fragment is the one file a bootstrap agent writes: one JSON object at
+`.arkaik/bootstrap/fragments/<unit>.json`, where `<unit>` is your work-unit
+id from `.arkaik/bootstrap/manifest.json`. The filename **is** the unit id —
+`arkaik bootstrap merge` derives the path from the id and ignores the
+manifest's `fragment` field. A missing fragment just means the unit hasn't
+run yet (the run is resumable); invalid JSON, a top-level array, or a
+non-array value under any of the keys below fails the merge loudly, naming
+your unit.
+
+The top level:
+
+```jsonc
+{
+  "unit": "<your unit id>",
+  "wave": 1,
+  // then one or more of the six keys below, each an array of objects:
+  "nodes": [], "edges": [],                // greenfield anatomy / acceptances
+  "add": [], "update": [], "retire": [],   // brownfield reconcile
+  "events": []                             // story (wave 3)
+}
+```
+
+Merge reads **only** those six keys and ignores everything else. Two
+consequences:
+
+- You may have seen sketches of the wave-3 shape with `deliverables`,
+  `releases`, or `decisions` keys — **they do not exist in the contract**,
+  and anything written under them is silently lost. Deliverables and
+  releases are entries in `events` (`deliverable.shipped`, `release.tagged`);
+  the decisions unit's `DEC-` nodes go in `nodes` (or `add`) with their edges
+  in `edges`, like any other node. Merge never branches on `wave` — every key
+  works in every fragment.
+- One ignored key is used on purpose: **`notes`**, a free-text string where
+  you record judgment calls (e.g. why a PR was judged not user-visible).
+  Merge skips it; the wave reviewer reads it.
+
+## Nodes — `nodes` and `add`
+
+A node as an agent writes it: the bundle's node fields **minus `project_id`**
+(merge stamps it), plus an optional `created_ts`.
+
+| Field | Required | Meaning |
+|---|---|---|
+| `id` | yes | Species-prefixed kebab-case id (`F-`, `V-`, `DM-`, `API-`, `AC-`, `DEC-`) |
+| `species` | yes | `flow`, `view`, `data-model`, `api-endpoint`, `acceptance`, `decision` |
+| `title` | yes | Non-empty; concept titles capitalized, table titles the exact identifier |
+| `created_ts` | no | When this surface first shipped — becomes the `node.created` event's timestamp |
+| anything else | no | `status`, `platforms`, `metadata` (playlists, gherkin, values…) as the species requires |
+
+`created_ts` should be the merge instant of the PR that first shipped the
+surface, straight from your slice. It is consumed, not stored: merge uses it
+to synthesize the `node.created` event and drops it from the node. Absent,
+merge falls back to `project.created_at`. A malformed timestamp fails your
+unit loudly rather than minting a wrong event.
+
+`add` (brownfield) takes exactly the same node shape. Re-declaring a node
+that already exists with the **same title** is a safe no-op — no duplicate
+node, no duplicate `node.created`. The same id with a **different title** is
+a collision, and merge fails naming both titles and both units. That is the
+whole coordination model: ids are derived deterministically from titles, so
+independent agents converge on the same id for the same thing and collide
+loudly on different things.
+
+## Edges — `edges`
+
+| Field | Required | Meaning |
+|---|---|---|
+| `source_id` | yes | A node id — from this fragment, another unit's fragment, or the existing map |
+| `target_id` | yes | Same |
+| `kind` | yes | `composes`, `calls`, `displays`, `queries`, or `covers` (semantics: the `arkaik` skill) |
+
+No edge `id` — merge mints the canonical `e-{source}-{target}`. Endpoints
+resolve across fragments, so you never coordinate with another agent; an
+endpoint **nobody** created is a loud merge error. Two fragments disagreeing
+on one edge's kind is an error naming both; agreeing is a silent no-op.
+
+## Reconcile ops — `update` and `retire` (brownfield)
+
+```jsonc
+"update": [{ "id": "V-x", "patch": { ... }, "changed_ts": "<ISO instant>" }],
+"retire": [{ "id": "V-y", "reason": "why", "changed_ts": "<ISO instant>" }]
+```
+
+- **`update`** — `patch` fields replace the node's. `metadata` is special:
+  its **top-level keys merge** — keys you don't name survive — but a key you
+  **do** name is **replaced whole**, not merged recursively. Patching one
+  nested field means writing the key's full value: all of `platformStatuses`,
+  the whole `playlist`. When the patch **changes** `status` (or
+  `metadata.decision_status`), merge emits the matching `node.status_changed`
+  (or `decision.status_changed`) event at `changed_ts`; a patch restating the
+  same value emits nothing.
+- **`retire`** — never a delete. Merge sets `status: "archived"`, records
+  `metadata.retired_reason`, and emits the status event. The node count is
+  unchanged; a human decides actual removal.
+- Both ops must target a node that exists — an unknown id fails the merge.
+
+**The `changed_ts` one-shot rule.** When a status-changing op omits
+`changed_ts`, merge substitutes one constant fallback timestamp for the whole
+run. One such op per node is safe; a **second** status-changing op for the
+**same node** in the same run that also omits it lands on the identical
+timestamp, and merge refuses rather than guess an order. Give every
+status-changing op past the first, for the same node, its own explicit
+`changed_ts`.
+
+## Story events — `events`
+
+Plain journal event objects: `type`, the type's payload fields, and a real
+`ts`. **No `id`, no `actor`** — merge mints deterministic ids, which is what
+makes a re-run over unchanged fragments byte-identical. The story types:
+
+| Type | Payload |
+|---|---|
+| `deliverable.shipped` | `deliverable_id`, `title`, `summary?`, `url?`, `node_ids?`, `platform?` |
+| `release.tagged` | `version`, `notes?`, `platform?` |
+| `node.status_changed` | `node_id`, `from`, `to`, `platform?` |
+| `decision.status_changed` | `node_id`, `from`, `to` |
+| `idea.proposed` | `title`, `description?`, `node_id?` |
+
+The full vocabulary is the `arkaik` skill's event table. Timestamps come from
+the corpus — PR merge instants, not invented dates. Two **unscoped**
+`node.status_changed` for **one node at the identical `ts`** that disagree on
+`to` are refused (read-back order between them would be undefined);
+platform-scoped events — those carrying `platform` — are exempt. Real merge
+timestamps are full instants, so distinct instants are free — use them.
+
+## Examples
+
+Each example below is a fixture from the CLI's own test suite, copied
+verbatim so the docs and the tested contract cannot drift. If a fixture
+changes, change it here too.
+
+**Greenfield anatomy** (`tests/cli/bootstrap-e2e.test.js`, the `w1-home`
+fragment — note the playlist ↔ `composes` agreement and `created_ts`):
+
+```json
+{
+  "unit": "w1-home",
+  "wave": 1,
+  "nodes": [
+    {
+      "id": "F-notes",
+      "species": "flow",
+      "title": "Notes",
+      "status": "live",
+      "platforms": ["web"],
+      "created_ts": "2026-01-05T10:00:00.000Z",
+      "metadata": { "playlist": { "entries": [{ "type": "view", "view_id": "V-home" }] } }
+    },
+    {
+      "id": "V-home",
+      "species": "view",
+      "title": "Home",
+      "status": "live",
+      "platforms": ["web"],
+      "created_ts": "2026-01-05T10:00:00.000Z"
+    }
+  ],
+  "edges": [{ "source_id": "F-notes", "target_id": "V-home", "kind": "composes" }]
+}
+```
+
+**Brownfield `add`** (`tests/cli/bootstrap-merge.test.js`, the "node.created
+is not duplicated" probe — `V-home` already exists in the map and is a no-op;
+`V-new` is genuinely new):
+
+```json
+{
+  "unit": "w1-a",
+  "wave": 1,
+  "add": [
+    { "id": "V-home", "species": "view", "title": "Home", "status": "live", "platforms": ["web"] },
+    { "id": "V-new", "species": "view", "title": "New", "status": "live", "platforms": ["web"], "created_ts": "2026-03-01T00:00:00.000Z" }
+  ]
+}
+```
+
+**Brownfield `update` + `retire`** (`tests/cli/bootstrap-merge.test.js`, the
+combined reconcile fixture):
+
+```json
+{
+  "unit": "w1-a",
+  "wave": 1,
+  "update": [{ "id": "V-home", "patch": { "status": "live" }, "changed_ts": "2026-02-01T00:00:00.000Z" }],
+  "retire": [{ "id": "V-legacy", "reason": "replaced by V-home", "changed_ts": "2026-02-02T00:00:00.000Z" }]
+}
+```
+
+**Wave-3 story** (`tests/cli/bootstrap-merge.test.js`, the journal de-dup
+fixture — `V-home` is a node that already exists in the map):
+
+```json
+{
+  "unit": "w3-decisions",
+  "wave": 3,
+  "events": [
+    { "type": "deliverable.shipped", "deliverable_id": "pr-1", "title": "Ship it", "ts": "2026-01-05T00:00:00.000Z" },
+    { "type": "node.status_changed", "node_id": "V-home", "from": "backlog", "to": "live", "ts": "2026-01-05T00:00:00.000Z" }
+  ]
+}
+```

--- a/docs/arkaik-bootstrap-skill/references/waves.md
+++ b/docs/arkaik-bootstrap-skill/references/waves.md
@@ -1,0 +1,120 @@
+# Waves & gates
+
+A bootstrap run is four waves, each fanning out over work units that
+`arkaik bootstrap plan` writes to `.arkaik/bootstrap/manifest.json`:
+
+| Wave | Units | Emits |
+|---|---|---|
+| 0 · Recon | `w0-recon` (one agent) | `.arkaik/bootstrap/profile.json` |
+| 1 · Anatomy / Reconcile | `w1-<area>`, one per area | `{nodes, edges}` (greenfield) or `{add, update, retire}` (brownfield) |
+| 2 · Acceptances + values | `w2-<area>`, one per area (+ a values-balance reviewer role — not a unit) | acceptances with gherkin, values, `covers` edges, platform scoping |
+| 3 · Story | `w3-<era>` per era, plus `w3-decisions` and `w3-status-arcs` | `events` (deliverables, releases, arcs) and `DEC-` nodes |
+
+Working a unit is always the same loop: `arkaik bootstrap slice <unit>` →
+judge → write the fragment → set the unit's status to `done` in
+`.arkaik/bootstrap/manifest.json`. **Resumability is structural:** statuses
+(`pending` / `done` / `rejected`) live in the manifest and output lives in
+fragment files, so a killed session resumes at the first `pending` unit, and
+re-running `plan` preserves the status of any unit whose slice is unchanged.
+
+**Every wave ends the same way:** an adversarial reviewer — checking against
+the product, not just the schema — then `arkaik bootstrap merge` (preview
+with `--dry-run`), then `arkaik validate` on the bundle, **warning-clean**.
+Merge itself blocks only on errors; warnings never block the write, so
+warning-clean is the reviewer's gate to enforce, not the CLI's. A wave that
+does not gate green does not advance.
+
+## Wave 0 · Recon
+
+One agent reads the corpus and the repo (`slice` gives it the docs manifest)
+and writes `.arkaik/bootstrap/profile.json`: `products`, the `platforms`
+axis, `areas` (id, title, code paths — typically 8–12 for a real product),
+and `eras` (slug, title, date window). Then re-run `arkaik bootstrap plan` to
+expand waves 1–3.
+
+**Reviewer checklist — wave 0:**
+
+- [ ] Area ids and era slugs are lowercase kebab-case (they become fragment
+      filenames — `plan` rejects anything else).
+- [ ] Every area has at least one real path, and the areas together cover the
+      product's code. An area with wrong paths starves its agents of exactly
+      the PRs and surfaces they need.
+- [ ] Every era has at least one date bound; windows are half-open, so
+      adjacent eras may share a boundary date but must never overlap. Two
+      eras with only a `from` always overlap — give the earlier one a `to`.
+- [ ] The eras cover the PR timeline. A PR falling inside no era is silently
+      absent from the story.
+- [ ] The platform axis matches how the product actually ships; `products`
+      is declared only when the repo really is a family of apps.
+
+## Wave 1 · Anatomy / Reconcile
+
+One unit per area. Greenfield: map the area's flows, views, data models, API
+endpoints, and the edges between them. Brownfield: reconcile the existing map
+against the code — `add` what's missing, `update` what drifted, `retire`
+what's gone. Never delete.
+
+**Reviewer checklist — wave 1:**
+
+- [ ] Species are right: the route handler is `API-`, the page it feeds is
+      `V-`, the journey between pages is `F-`, the stored thing is `DM-`.
+- [ ] No `DM-` concept/table collisions; concept titles are capitalized
+      words, table titles the exact DB identifier.
+- [ ] Every flow has a real playlist that agrees with its `composes` edges,
+      and no flow contains itself.
+- [ ] Edge kinds match their semantics (`composes` / `calls` / `displays` /
+      `queries`) — spot-check a few against the actual code.
+- [ ] `created_ts` values come from the PRs that first shipped each surface,
+      not from today.
+- [ ] **Churn guard (brownfield): a unit proposing `retire` or `update` on
+      more than 20% of the existing nodes stops for human review.** Churn at
+      that scale is usually a wrong slice or a misread map, not a real
+      product change.
+- [ ] Nothing is deleted; every `retire` carries a reason a human could act
+      on.
+
+## Wave 2 · Acceptances + values
+
+One unit per area writes acceptances for its surfaces; one values-balance
+reviewer then reads the whole wave.
+
+**Reviewer checklist — wave 2:**
+
+- [ ] Exactly one Given/When/Then per acceptance — a second scenario is a
+      second acceptance.
+- [ ] Every `covers` edge points at an id that exists (`arkaik bootstrap
+      index`), and each acceptance anchors inside a single product.
+- [ ] Platform scoping is the fewest platforms that are true; no unscoped
+      promotion claiming every platform.
+- [ ] Values are 1–3 per acceptance, from the table, most specific element
+      first — or omitted where unsure. (Skipped entirely if the repo has no
+      values reference.)
+- [ ] **Values balance: if more than half the acceptances land on one value
+      element, the wave is rejected and re-run.** An unchecked acceptance
+      wave collapses into ~90% `simplifies`; the pyramid must show real
+      spread.
+
+## Wave 3 · Story
+
+Era units (`w3-<era>`) turn each era's user-visible PRs into
+`deliverable.shipped` events and tag the era's `release.tagged`.
+`w3-decisions` mines the design docs into `DEC-` nodes, their edges, and
+their events. `w3-status-arcs` gives each anatomy node an honest 1–3 event
+arc ending at its snapshot status.
+
+**Reviewer checklist — wave 3:**
+
+- [ ] The user-visible filter held: every PR with a Lab Note became a
+      deliverable; chores, CI, and refactors did not; borderline calls are
+      explained in the fragment's `notes`.
+- [ ] Deliverable and release timestamps are real merge instants from the
+      corpus, never invented dates.
+- [ ] Every decision traces to a real document in the corpus — decisions are
+      mined, not imagined.
+- [ ] Every arc ends at the node's snapshot status, contains no transition
+      that did not happen, and gives same-node events distinct instants.
+- [ ] Nothing project-shaped was deleted or rewritten — story only ever adds.
+
+After wave 3 gates green, the run is done: the bundle and its journal are the
+product. Landing them (and removing this skill) is the operator's move, not a
+wave.

--- a/docs/arkaik-bootstrap-skill/skill.md
+++ b/docs/arkaik-bootstrap-skill/skill.md
@@ -1,0 +1,190 @@
+---
+name: arkaik-bootstrap
+version: 1.0.0
+description: >
+  Bootstrap the Arkaik product graph map for {{PRODUCT_NAME}} from its
+  repository history — map this repo, bootstrap the map, retro-populate or
+  backfill the map from merged PRs, design docs, and code surfaces. Use this
+  skill when working a unit of an `arkaik bootstrap` run: reading a slice,
+  writing a fragment, or reviewing a wave. One-time onboarding only — ongoing
+  map maintenance belongs to the `arkaik` skill, not this one.
+---
+
+# Arkaik Bootstrap — the judgment half
+
+The bootstrap method has two halves. The `arkaik bootstrap` CLI owns
+everything deterministic: mining the corpus, planning work units, slicing
+what you read, merging what you write, validating the result. This skill owns
+what code cannot decide: which species a thing is, what a flow's playlist
+really contains, what a PR actually shipped, which value an acceptance
+genuinely earns. You are the judgment half.
+
+Two references ship beside this file:
+
+- [references/fragments.md](references/fragments.md) — the exact shape of the
+  file you write
+- [references/waves.md](references/waves.md) — the wave catalog and the
+  reviewer checklist each wave gates on
+
+> **Template parameters.** Like the maintenance skill, this file is rendered
+> by `arkaik init`. If you are reading an unrendered copy, treat the defaults
+> in parentheses as the values:
+>
+> | Parameter | Meaning | Default |
+> |---|---|---|
+> | `{{PRODUCT_NAME}}` | The product being mapped | the current product |
+> | `{{BUNDLE_PATH}}` | Where the merged map lands | `docs/arkaik/bundle.json` |
+
+## When this skill applies
+
+This skill drives a **one-time onboarding run**: building the map for
+{{PRODUCT_NAME}} out of the repository's own history. Greenfield (no bundle
+yet, or an `arkaik init` stub with zero nodes) means mapping from scratch;
+brownfield (a bundle that already carries nodes) means reconciling the
+existing map against the code. Same method either way — only the wave-1
+fragment shape differs.
+
+Ongoing edits belong to the **`arkaik` skill installed beside this one**
+(`../arkaik/SKILL.md`): if you are updating the map as a side-effect of a
+code change, that is its job, not this skill's. Once the bootstrap run has
+landed, this skill has done its one job and can be removed:
+
+```bash
+arkaik init --remove-bootstrap
+```
+
+## The contract you work under
+
+**You never read the bundle. You never write the bundle. You never write
+merge logic.** You read a slice, you write a fragment:
+
+```bash
+arkaik bootstrap slice <unit> > slice.json   # what to read
+arkaik bootstrap index                        # existing node ids, when you need to reference them
+```
+
+The slice is exactly the corpus subset your unit needs — matching PRs,
+matching surfaces, and the docs manifest when your unit asks for it — instead
+of the whole repository. The index is one tab-separated line per existing
+node (`id`, `species`, `title`, `product`): how you reference real nodes
+without loading their bodies.
+
+Your output is one JSON file at `.arkaik/bootstrap/fragments/<unit>.json`,
+in the shape defined by [references/fragments.md](references/fragments.md).
+`arkaik bootstrap merge` owns everything after that — ID-collision detection,
+cross-fragment edge resolution, journal event synthesis, validation, landing
+the result at `{{BUNDLE_PATH}}` with its journal sidecar — and a malformed
+fragment fails with your unit's name attached rather than corrupting the
+map. Never edit another unit's fragment. When yours is
+written, set your unit's status to `done` in
+`.arkaik/bootstrap/manifest.json`.
+
+## Species discrimination
+
+Four anatomy species, one question each:
+
+- **Flow (`F-`)** — a journey the user moves through. It has a playlist.
+- **View (`V-`)** — one surface the user looks at: a screen, page, or panel.
+- **Data model (`DM-`)** — a thing the product stores or reasons about.
+- **API endpoint (`API-`)** — a callable contract across a boundary: a route
+  handler, an RPC, a webhook.
+
+A route file is usually one `API-` node; the page it feeds is a `V-`; the
+navigation between pages is the `F-`. Later waves add **acceptances (`AC-`)**
+— testable promises — and **decisions (`DEC-`)** mined from design docs.
+
+**The `DM-` rule — concept vs physical table.** A conceptual model takes the
+singular concept name: the concept "Project" is `DM-project`. A physical
+table or DB view takes its exact identifier: the table `projects` is
+`DM-projects`. Both may legitimately exist in one map; they must never
+kebab-case into the same id. Full ID and title rules live in the `arkaik`
+skill beside this one and its `../arkaik/references/schema.md`.
+
+## Playlists
+
+Every flow ships a **real** `metadata.playlist` — actual entries referencing
+actual views and sub-flows, never a placeholder. Two invariants:
+
+- The playlist and the flow's `composes` edges **agree**: every view or flow
+  in the playlist has a `composes` edge from the flow, and every `composes`
+  edge appears in the playlist.
+- **No cycles** — a flow cannot contain itself, directly or through
+  sub-flows.
+
+Entry shapes — including the branching `condition` and `junction` entries —
+are in `../arkaik/references/schema.md`.
+
+## Acceptances
+
+An acceptance is a testable promise. When you write one:
+
+- **Exactly one Given/When/Then** in `metadata.gherkin`. A second scenario is
+  a second acceptance.
+- **`covers` edges to real anchors** — views or flows whose ids exist in the
+  index or in your own fragment. An acceptance covering nothing is an intake
+  idea, not mapped behavior.
+- **Single-product anchoring** — its `covers` edges may span several views
+  and flows, but they must all resolve to the same product. A promise that
+  genuinely spans two products is two acceptances.
+
+The full doctrine (per-platform statuses, anchorless intake, the parity
+layer) is the `arkaik` skill's "Acceptances" section — follow it, don't
+reinvent it.
+
+## Values
+
+Assign **1–3 Bain value elements** in `metadata.values` per acceptance. The
+**most specific element wins**; claim a higher tier of the pyramid **only
+when the acceptance genuinely operates there**. The 30-element table with
+one-line definitions is `../arkaik/references/values.md` in the skill beside
+this one. If that file is absent (the maintenance skill was installed with
+`--no-values`), value mapping is out of scope for this repo — skip it
+entirely. When unsure, omit: a wrong value is worse than a missing one, and
+the wave-2 balance check (see [references/waves.md](references/waves.md))
+rejects a lopsided wave anyway.
+
+## Platform scoping
+
+Per-platform truth lives on acceptances (`metadata.platformStatuses`), and
+history is full of platform-scoped shipping — a PR that says `AC-x@ios`, or
+that only touched the iOS target, shipped iOS and nothing else.
+
+**An unscoped promotion claims every platform.** Moving an acceptance's base
+`status` asserts the behavior everywhere the acceptance's platforms reach —
+exactly like an unscoped `AC-x` mention in a PR. When the evidence says one
+platform, write that one platform's status. **Scope to the fewest platforms
+that are true**, and keep `platforms` itself to where the behavior is
+actually expected — mobile-only behavior is `["ios", "android"]`, not
+backlog-on-web.
+
+## What counts as user-visible
+
+Wave 3 turns PRs into story. The filter:
+
+- **A PR with a Lab Note is user-visible by definition** — and the note is a
+  benefit-first title and summary already written for you. Use it.
+- **Chores, CI, refactors, dependency bumps, and docs-only changes are not.**
+- **Judge the rest** — pre-pipeline PRs carry no note. Ask: could a user of
+  {{PRODUCT_NAME}} notice the difference? Record the judgment and the reason
+  in your fragment's `notes` so the reviewer can check it.
+
+## Status arcs
+
+Every anatomy node gets an honest arc of **1–3 events ending at its snapshot
+status**: the `node.created` that merge synthesizes from `created_ts`, plus
+**0–2 `node.status_changed` written by you** — one per transition that
+actually happened, the final one landing on the node's snapshot status.
+**Never invent a transition that did not happen.** A born-live node's arc is
+its `node.created` alone — write no status event for it, not a fabricated
+idea → development → live staircase. Build the arc from evidence: the PR
+that first shipped the surface, the era it was built in. Timestamp mechanics
+(distinct instants, `changed_ts`) are in
+[references/fragments.md](references/fragments.md).
+
+## Never delete
+
+Bootstrap never deletes. In a brownfield reconcile, a node that exists in
+the map but no longer in the product is **retired** — a `retire` op with a
+`reason` — and merge archives it with the reason on record. Removal stays a
+human decision, made outside this run. If you find yourself wanting to
+delete, you are holding the wrong tool.

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -1,0 +1,204 @@
+---
+title: "Bootstrap: onboarding a repo onto Arkaik"
+navTitle: "Bootstrap"
+order: 8
+---
+
+# Bootstrap: onboarding a repo onto Arkaik
+
+> A walkthrough, not a reference. The agents' doctrine — fragment shapes, wave
+> checklists, judgment rules — lives in the
+> [`arkaik-bootstrap` skill](arkaik-bootstrap-skill/skill.md) and its
+> [references](arkaik-bootstrap-skill/references/waves.md); the full rationale
+> is the [design spec](superpowers/specs/2026-08-04-bootstrap-method-design.md).
+
+Bootstrap takes a repository from "no map" (or "stale map") to a complete
+Arkaik graph — anatomy, acceptances, values, platform scoping, and the
+product's whole history mined from its merged PRs — in one run. Agents do the
+judgment; the `arkaik bootstrap` CLI does everything deterministic; and when
+the run lands, the skill that drove it is removed. The run's cost is agent
+tokens — the levers that keep it down are below. One run, then it gets out
+of the way.
+
+**If your repo already has a map, run `arkaik init --update` before anything
+else.** The installed `arkaik` skill ships a repo-local validator, and a stale
+one predates the `acceptance` and `decision` species — so everything the run
+produces gets rejected at the gate. This is the number-one way a real run
+fails, and it fails late. Update first.
+
+## Two modes, one method
+
+- **Greenfield** — no bundle yet, or an `arkaik init` stub with zero nodes.
+  Agents mint the anatomy from scratch.
+- **Brownfield** — a bundle that already carries nodes. Agents **reconcile**
+  the existing map against the code: `add` what's missing, `update` what
+  drifted, `retire` what's gone.
+
+`arkaik bootstrap plan` detects the mode on its own; only the wave-1 fragment
+shape differs. And **bootstrap never deletes** — `retire` proposes
+`status: archived` with a reason, and removal stays a human act. That is what
+makes re-runs safe.
+
+## Why the CLI owns determinism
+
+The method's core lesson (learned the expensive way, mapping Arkaik itself):
+the costly part of a run is not judgment, it is agents re-deriving plumbing —
+`gh` pagination, ID uniqueness, cross-fragment edge resolution, journal
+sorting. So the split is absolute: **determinism lives in the CLI, judgment
+lives in agents, and they meet at a file boundary.** Agents read a slice and
+write a fragment. They never read the bundle, never write the bundle, and
+never write merge logic — `arkaik bootstrap merge` owns ID-collision
+detection, edge resolution, event synthesis, and validation gating, the same
+way every time, for every repo.
+
+## One run, start to finish
+
+```bash
+arkaik init --update                       # brownfield: get the current skill first
+arkaik init --bootstrap                    # install the one-time skill
+arkaik bootstrap corpus                    # mine PRs, docs, surfaces
+arkaik bootstrap plan                      # wave 0 only
+# ... recon agent writes .arkaik/bootstrap/profile.json ...
+arkaik bootstrap plan                      # expands waves 1-3
+arkaik bootstrap slice w1-<area>           # what one agent reads
+# ... agents write fragments ...
+arkaik bootstrap merge
+arkaik validate docs/arkaik/bundle.json    # the gate — warning-clean
+arkaik restore --dry-run                   # hosted only
+arkaik restore                             # hosted only — destructive; see below
+arkaik init --remove-bootstrap             # the skill has done its job
+```
+
+Step by step:
+
+1. **`arkaik init --update`** — the brownfield opener (see the warning above).
+   Version-gated: a no-op when the skill is already current, and it never
+   touches the bundle or journal.
+2. **`arkaik init --bootstrap`** — installs the one-time `arkaik-bootstrap`
+   skill beside the maintenance skill (`.claude/skills/arkaik-bootstrap` by
+   default). On a greenfield repo this same command also scaffolds
+   `docs/arkaik/`. The two init lines combine if you prefer:
+   `arkaik init --update --bootstrap`.
+3. **`arkaik bootstrap corpus`** — mines merged PRs (via `gh`, including Lab
+   Notes), a docs manifest, and a code-surface inventory into
+   `.arkaik/corpus/`. Run it from the repo root. `--from-git` works without
+   GitHub but loses Lab Notes; `--since <iso-date>` keeps incremental re-runs
+   cheap.
+4. **`arkaik bootstrap plan`** — writes the work-unit manifest. With no recon
+   profile yet, it plans exactly one unit: `w0-recon`, the agent that reads
+   the corpus and declares the repo's shape — products, platform axis, areas,
+   eras — in `.arkaik/bootstrap/profile.json`.
+5. **`arkaik bootstrap plan`** again — now expands waves 1–3 from the
+   profile: `w1-<area>` and `w2-<area>` per area, `w3-<era>` per era, plus
+   `w3-decisions` and `w3-status-arcs`. Unit ids come from the area ids and
+   era slugs recon declared; `plan` prints the full list. Re-planning
+   preserves the status of any unit whose slice is unchanged, so it is always
+   safe to run.
+6. **`arkaik bootstrap slice <unit>`** — prints exactly the corpus subset one
+   unit needs. This is what a work agent reads instead of the repo.
+7. **Agents write fragments** — one JSON file per unit under
+   `.arkaik/bootstrap/fragments/`, in the shape defined by the skill's
+   [fragment contract](arkaik-bootstrap-skill/references/fragments.md).
+8. **`arkaik bootstrap merge`** — assembles every fragment onto the bundle
+   and validates the result: errors block the write outright; warnings are
+   reported but never block. `--dry-run` previews without writing.
+9. **`arkaik validate docs/arkaik/bundle.json`** — the independent gate. Note
+   that it exits 0 even with warnings; **warning-clean output** is the bar a
+   wave must meet, and that is yours to enforce, not the CLI's.
+10. **`arkaik restore --dry-run`, then `arkaik restore`** — hosted projects
+    only; see below. A purely local map is done at step 9: commit the bundle
+    and its journal.
+11. **`arkaik init --remove-bootstrap`** — see
+    ["When the run is done"](#when-the-run-is-done).
+
+The merge → validate pair is not a final step — it closes **every** wave (see
+the gates below). The block above shows it once.
+
+## The wave gates
+
+A run is four waves — recon, anatomy/reconcile, acceptances + values, story —
+and every wave ends the same way: an **adversarial review** checked against
+the product (not just the schema), then `merge`, then `validate`
+**warning-clean**. A wave that does not gate green does not advance. Two of
+the checks are hard stops:
+
+- **Churn guard (wave 1, brownfield):** a unit proposing `retire` or `update`
+  on more than 20% of the existing nodes stops for human review — churn at
+  that scale is usually a wrong slice, not a real product change.
+- **Values balance (wave 2):** if more than half the acceptances land on one
+  value element, the wave is rejected and re-run.
+
+The full per-wave checklists live in the skill's
+[waves reference](arkaik-bootstrap-skill/references/waves.md) — the reviewer
+reads those, not this page.
+
+## The token model
+
+Agent tokens are the run's real cost; every lever below exists to cut them:
+
+- **Slices** — an agent reads the ~30–60KB its unit needs, never the ~1.5MB
+  whole corpus.
+- **Index over bundle** — `arkaik bootstrap index` is a ~6KB
+  id/species/title/product listing instead of a 164KB bundle, and every
+  referencing agent reads it (agents run it themselves mid-unit — it is not
+  a step in the walkthrough above).
+- **Warm in-session subagents** — the default driver: fan units out to
+  subagents in one session, no cold-start orientation tax per unit.
+  `arkaik bootstrap plan --issues` files one GitHub issue per unit instead —
+  durable and parallel across machines, at a stated price of roughly 15–30k
+  tokens per unit for the cold starts.
+- **Lab Notes as free copy** — a PR with a note already has a benefit-first
+  title and summary written.
+- **Early gates** — a bad wave fails at roughly a quarter of the cost of a
+  bad run.
+
+## `.arkaik/` is scratch
+
+Everything bootstrap produces before the final bundle — the corpus
+(`.arkaik/corpus/`), the plan (`.arkaik/bootstrap/manifest.json`), the recon
+profile, the fragments — is working material, never committed. `corpus` (or
+`plan`, whichever runs first) adds `.arkaik/` to `.gitignore` itself. The
+repo's contract stays what it already was: the bundle, the journal, and
+`arkaik validate`.
+
+Scratch does not mean fragile: unit statuses live in the manifest and output
+lives in fragment files, so a killed session resumes at the first `pending`
+unit instead of starting over.
+
+## Landing on a hosted project
+
+If the repo is linked to a hosted project (`docs/arkaik/arkaik.json` — see
+[Hosted Projects](hosted-projects.md)), `arkaik restore` lands the bootstrapped
+bundle there. **Restore is the one destructive verb the CLI offers**: it
+replaces the hosted project's snapshot *and* its journal wholesale, in one
+transaction. Three rails make it safe enough to use:
+
+- **It always backs up first.** Before sending anything, restore exports the
+  current hosted state — journal included — to
+  `docs/arkaik/.backups/<timestamp>-bundle.json`, verifies the file reads
+  back, and refuses to proceed if it cannot. The server keeps no pre-image,
+  so this file is the only undo: `arkaik restore <backup-path>` reverses a
+  restore you regret.
+- **It is `If-Match`-gated and owner-only.** A concurrent edit gets a `412`,
+  never a silent overwrite — re-run to read the current state and decide
+  again. And the token must own the project, not merely hold a write scope.
+- **`--dry-run` is an exact preview.** The server runs the same validation,
+  version, and tier gates a real write would and returns the node/edge/event
+  delta; nothing is written and no backup is taken.
+
+One more guard: if the outbound journal has fewer events than the hosted one,
+restore refuses — that shape usually means a missing `journal.jsonl`, not an
+intended rewrite. `--allow-history-loss` is the deliberate override.
+
+## When the run is done
+
+```bash
+arkaik init --remove-bootstrap
+```
+
+The bootstrap skill is deliberately opt-in and deliberately removed: it is a
+large skill for a one-time job, and leaving it installed taxes every future
+maintenance session's context for no benefit. Removal isn't precious — the
+skill is version-stamped, and `arkaik init --bootstrap` reinstalls it any
+time you want another run. Day-to-day map upkeep belongs to the `arkaik`
+skill, which stays.

--- a/docs/superpowers/plans/2026-08-04-bootstrap-method.md
+++ b/docs/superpowers/plans/2026-08-04-bootstrap-method.md
@@ -67,11 +67,13 @@
 
 | File | Responsibility |
 |---|---|
-| `plugin/skills/arkaik-bootstrap/skill.md` | The judgment skill. |
-| `plugin/skills/arkaik-bootstrap/references/fragments.md` | Fragment contract for agents. |
-| `plugin/skills/arkaik-bootstrap/references/waves.md` | Wave catalog + reviewer checklists. |
+| `docs/arkaik-bootstrap-skill/skill.md` | The judgment skill (source — rendered into repos by `init --bootstrap`; **not** under `plugin/`, see Task 13). |
+| `docs/arkaik-bootstrap-skill/references/fragments.md` | Fragment contract for agents. |
+| `docs/arkaik-bootstrap-skill/references/waves.md` | Wave catalog + reviewer checklists. |
+| `packages/cli/build.js` | Copies the skill sources into `dist/assets/bootstrap-skill/` (the plan originally omitted this). |
 | `packages/cli/src/commands/init.ts` | `--bootstrap` / `--remove-bootstrap`. |
-| `docs/bootstrap.md` | The method, for humans. |
+| `tests/cli/init.test.js` | The install/remove contract (31 new checks). |
+| `docs/bootstrap.md` | The method, for humans (also linked from `README.md` + `docs/README.md`, and in the `/docs` app nav). |
 
 ---
 
@@ -3454,20 +3456,28 @@ suggested:
 
 # Part C — PR 3: the skill and its wiring
 
-### Task 13: The `arkaik-bootstrap` skill
+### Task 13: The `arkaik-bootstrap` skill — shipped, findings below
 
-**Files:**
-- Create: `plugin/skills/arkaik-bootstrap/skill.md`
-- Create: `plugin/skills/arkaik-bootstrap/references/fragments.md`
-- Create: `plugin/skills/arkaik-bootstrap/references/waves.md`
+**The decisive finding is architectural, caught before a line was written — the plan's file location was wrong:**
 
-- [ ] **Step 1: Read the sibling skill first**
+1. **`plugin/skills/arkaik-bootstrap/` contradicts both the repo's architecture and the spec's own decision.** Everything under `plugin/skills/` is generated output of `npm run generate` (CI diffs it for drift; plugin/README.md: nothing there is hand-edited), and a marketplace plugin ships its skills to every user *permanently* — exactly the "permanent token tax for a one-time job" that spec §4's on-demand decision exists to prevent. Shipped instead at **`docs/arkaik-bootstrap-skill/`**, mirroring `docs/arkaik-skill/`'s source layout and flowing through the maintenance skill's exact pipeline: `build.js` copies it to `dist/assets/bootstrap-skill/`, `init --bootstrap` renders it (Task 14). The plugin and `npm run generate` are untouched; the plan's own self-review rule — "inventing a second convention beside an existing one is worse than reading the existing one" — is what settled it.
+2. **The spec's sketched wave-3 fragment shape never shipped, and the reference doc now says so.** Spec §3 sketches `deliverables`/`releases`/`decisions` keys; `fragments.ts` reads exactly six arrays (`nodes`/`edges`/`add`/`update`/`retire`/`events`), merge ignores unknown keys — content under spec-era keys would be **silently lost** — and never branches on `wave`. `references/fragments.md` documents the shipped contract and calls the trap out artifact-neutrally (deliverables/releases are `events` entries; `DEC-` nodes ride `nodes`/`add`).
+3. **Fixture provenance beats invented examples, but the e2e file alone couldn't supply them.** The e2e fixtures are greenfield-wave-1 only; the brownfield (`add`, `update`+`retire`) and wave-3 examples come from `tests/cli/bootstrap-merge.test.js` — equally CI-run, each block attributed to its source line in the doc, and a scripted check verified all four examples value-**and key-order**-identical to their fixtures.
+4. **Two review rounds.** Spec review: compliant; independently confirmed fixture parity, `manifest.ts` vocabulary, both mandated wave gates, and the wave-3 claim at both ends. Quality review found two Important doc-precision defects — both the program's signature silently-wrong class: (a) "deep-merges" overstated `metadata` patching (`merge.ts` is a **one-level spread**: unnamed top-level keys survive, a named key is replaced whole — the doc now says to write the key's full value, all of `platformStatuses`, the whole `playlist`); (b) the born-live status-arc rule read two ways (write nothing vs invent a `to: live` transition) — now operational: a born-live node's arc is its synthesized `node.created` alone, agents write 0–2 transitions that actually happened, the final one landing on the snapshot status. Plus four minors: the same-`ts` `node.status_changed` refusal qualified to **unscoped** events (platform-scoped are exempt per `journal-merge.ts`'s `isOrderSensitive`); the wave-2 values-balance reviewer marked as a role, not a manifest unit; a playlist entry-shapes pointer to `../arkaik/references/schema.md`; the spec-keys warning phrased for foreign repos.
+5. **Noted, not built:** a mechanical fixture↔doc parity guard (the reviewer's recommendation). The inline provenance notes make drift findable; a structural check would make it impossible — worth considering if the examples ever churn.
 
-Read `plugin/skills/arkaik/skill.md` (and `docs/arkaik-skill/skill.md`) end to end before writing a line. The new skill must match its frontmatter shape, its template-parameter convention (`{{PRODUCT_NAME}}`, `{{BUNDLE_PATH}}`), its `version` stamp, and its voice. Do not restate what the maintenance skill already teaches — link to it.
+**Files (as shipped, one commit — `feat(skill): arkaik-bootstrap — the judgment half of the method`):**
+- Create: `docs/arkaik-bootstrap-skill/skill.md` (190 lines)
+- Create: `docs/arkaik-bootstrap-skill/references/fragments.md` (203 lines)
+- Create: `docs/arkaik-bootstrap-skill/references/waves.md` (120 lines)
 
-- [ ] **Step 2: Write `skill.md`**
+- [x] **Step 1: Read the sibling skill first**
 
-Create `plugin/skills/arkaik-bootstrap/skill.md` with frontmatter mirroring the sibling's shape (`name: arkaik-bootstrap`, `version: 1.0.0`, a `description` that fires on "map this repo", "bootstrap the map", "retro-populate", "backfill the map"), and a body covering exactly these sections:
+Read `docs/arkaik-skill/skill.md` end to end before writing a line. The new skill matches its frontmatter shape, its template-parameter convention (`{{PRODUCT_NAME}}`, `{{BUNDLE_PATH}}` — used only in `skill.md`; the references are copied verbatim by the installer, so they carry **no** `{{...}}` placeholders), its `version: 1.0.0` stamp (satisfying the installer's `^version:\s*(\S+)\s*$` regex), and its voice. Doctrine is linked, not restated — the installed sibling lives at `../arkaik/SKILL.md`, its values table at `../arkaik/references/values.md`, and the Values section says in one sentence that a `--no-values` install (no values.md) puts value mapping out of scope.
+
+- [x] **Step 2: Write `skill.md`**
+
+`docs/arkaik-bootstrap-skill/skill.md` with frontmatter as above (a `description` that fires on "map this repo", "bootstrap the map", "retro-populate", "backfill the map"), and a body covering exactly these sections:
 
 1. **When this skill applies** — a one-time onboarding run, greenfield or brownfield. Ongoing edits belong to the `arkaik` skill. Say so explicitly, and say that this skill can be removed after the run (`arkaik init --remove-bootstrap`).
 2. **The contract you work under** — you never read the bundle, you never write the bundle, you never write merge logic. You read a slice, you write a fragment. Include the two commands verbatim:
@@ -3484,164 +3494,95 @@ Create `plugin/skills/arkaik-bootstrap/skill.md` with frontmatter mirroring the 
 9. **Status arcs** — 1–3 events per node, ending at the node's snapshot status. Never invent a transition that did not happen.
 10. **Never delete** — `retire` with a reason; a human decides removal.
 
-- [ ] **Step 3: Write `references/fragments.md`**
+- [x] **Step 3: Write `references/fragments.md`**
 
-Document the fragment contract exactly as `packages/cli/src/lib/bootstrap/fragments.ts` defines it — the wave-1/2 shape (`nodes`/`edges`, or `add`/`update`/`retire`), the wave-3 shape (`events`), and `created_ts`. Include one complete, valid example of each, copied from the fixtures in `tests/cli/bootstrap-e2e.test.js` so the two cannot drift.
+Documents the fragment contract exactly as `packages/cli/src/lib/bootstrap/fragments.ts` defines it — the six keys, node/edge/update/retire field tables, `created_ts` (consumed at merge, never persisted; falls back to `project.created_at`), the `changed_ts` one-shot fallback, error behavior by unit, and the story-event payload table (field-for-field against `packages/schema/src/journal-events.ts`). One complete, valid example per shape, copied verbatim from CI-run fixtures (see finding 3) with inline provenance so drift is findable. Also documents `notes` as the one deliberately-ignored key — it exists for reviewers, per skill section 8.
 
-- [ ] **Step 4: Write `references/waves.md`**
+- [x] **Step 4: Write `references/waves.md`**
 
-The wave catalog (0 recon → 1 anatomy/reconcile → 2 acceptances+values → 3 story) and one reviewer checklist per wave. The wave-2 checklist must include the values-balance check: **if more than half the acceptances land on one value element, the wave is rejected and re-run** — an unchecked acceptance wave collapses into ~90% `simplifies`. The wave-1 brownfield checklist must include the churn guard: **a unit proposing retire/update on more than 20% of existing nodes stops for human review.**
+The wave catalog (0 recon → 1 anatomy/reconcile → 2 acceptances+values → 3 story) in `manifest.ts`'s real vocabulary (`w0-recon`, `w1-<area>`, `w2-<area>`, `w3-<era>`, `w3-decisions`, `w3-status-arcs`; statuses `pending`/`done`/`rejected`; `profile.json` constraints from `profile-validate.ts`, half-open era windows included) and one reviewer checklist per wave. The wave-2 checklist includes the values-balance check: **if more than half the acceptances land on one value element, the wave is rejected and re-run** — an unchecked acceptance wave collapses into ~90% `simplifies`. The wave-1 brownfield checklist includes the churn guard: **a unit proposing retire/update on more than 20% of existing nodes stops for human review.** Wave gates are phrased truthfully against shipped behavior: `merge` blocks only on errors, so *warning-clean* is the reviewer's gate, not the CLI's.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
-git add plugin/skills/arkaik-bootstrap
+git add docs/arkaik-bootstrap-skill
 git commit -m "feat(skill): arkaik-bootstrap — the judgment half of the method"
 ```
 
 ---
 
-### Task 14: `init --bootstrap` / `--remove-bootstrap`
+### Task 14: `init --bootstrap` / `--remove-bootstrap` — shipped, findings below
 
-**Files:**
-- Modify: `packages/cli/src/commands/init.ts`
-- Test: `tests/cli/init.test.js`
+**The reference test block this section used to carry was never executed; it hid a CI-only failure, and the Files list was missing a mandatory file:**
 
-- [ ] **Step 1: Write the failing test**
+1. **The draft test asserted `skill.md` lowercase on installed paths.** Installed skills are `SKILL.md` — on this Mac's case-insensitive filesystem the lowercase check would PASS and on CI's Linux it would FAIL, the exact works-locally-breaks-in-CI class this repo has already been burned by (see the Node-20 loader story in Part B). Every installed-path assertion now routes through a single uppercase constant, with a test comment documenting the trap.
+2. **`packages/cli/build.js` was missing from the Files list.** Without an asset-copy step, `dist/assets/bootstrap-skill/` never exists and `--bootstrap` dies at `readFileSync`. Shipped: `copyBootstrapSkillAssets()` mirroring `copySkillAssets()` — explicit per-file copies, same dist substructure, called beside it.
+3. **`DEFAULT_SKILLS_DIR` is `.claude/skills/arkaik` — the arkaik skill's *own* directory, not a skills root.** The draft's "adjust the path to the constant" note, taken literally, nests one skill inside another. Shipped: the bootstrap skill is the **sibling** — `join(dirname(skillsDirPath), "arkaik-bootstrap")` — so `--skills-dir custom/skills/arkaik` puts it at `custom/skills/arkaik-bootstrap` (test-covered, install and remove).
+4. **`--remove-bootstrap` is an early return** ahead of both the `--update` branch and the scaffold path — otherwise `init --remove-bootstrap` in a fresh repo would scaffold a bundle as a side effect of a *removal* (tested that it doesn't). Removal is idempotent (second run: notice + exit 0 — the plan asserted this but its draft test never covered it). `--bootstrap --remove-bootstrap` together fails loudly; `--update --remove-bootstrap` removes without updating, per the flag's "and do nothing else" help text.
+5. **Semantics mirror the maintenance skill per-flag, machinery reused not duplicated:** plain init installs-if-absent with a skip notice; `--update --bootstrap` is version-gated through the same `extractVersion`/`compareVersions`; rendering uses the same `vars` object and `renderTemplate` (SKILL.md rendered; references copied verbatim — placeholder-free by Task 13's contract).
+6. **Quality review (approved) recorded three parity observations, deliberately not "fixed":** the version-gate conditional is duplicated between the two skill pairs (rule of three — extract a helper when a third skill appears); a partial install (SKILL.md present, references deleted) isn't self-healed — exact parity with the maintenance skill, and bootstrap uniquely has a clean remedy (`--remove-bootstrap` then `--bootstrap`); a skills-dir path colliding with a *file* dies with a raw ENOTDIR like every pre-existing init path (a friendly-error wrapper would be a CLI-wide change, not this task's).
 
-Append to `tests/cli/init.test.js`, following the file's existing helper names and dir setup:
+**Files (as shipped, one commit — `feat(cli): init --bootstrap / --remove-bootstrap`):**
+- Modify: `packages/cli/src/commands/init.ts` (USAGE + header comment + both flags + `installBootstrapSkill`/`updateBootstrapSkill`/`removeBootstrapSkill`)
+- Modify: `packages/cli/build.js` (`copyBootstrapSkillAssets()`)
+- Test: `tests/cli/init.test.js` (31 new checks across four blocks, try/finally cleanup throughout)
 
-```js
-// --- bootstrap skill installs on demand and removes cleanly ---
-{
-  const dir = mkdtempSync(path.join(tmpdir(), "arkaik-init-bootstrap-"));
-  try {
-    const plain = runCli(["init", "--product", "Demo"], dir);
-    check("plain init exits 0", plain.status === 0, plain.stderr);
-    check(
-      "plain init does NOT install the bootstrap skill",
-      !existsSync(path.join(dir, ".claude", "skills", "arkaik-bootstrap")),
-      "bootstrap skill was installed without being asked for",
-    );
+- [x] **Step 1: Write the failing test**
 
-    const withBootstrap = runCli(["init", "--product", "Demo", "--bootstrap"], dir);
-    check("init --bootstrap exits 0", withBootstrap.status === 0, withBootstrap.stderr);
-    check(
-      "bootstrap skill installed",
-      existsSync(path.join(dir, ".claude", "skills", "arkaik-bootstrap", "skill.md")),
-      "skill.md missing",
-    );
-    check(
-      "bootstrap references installed",
-      existsSync(path.join(dir, ".claude", "skills", "arkaik-bootstrap", "references", "fragments.md")),
-      "references missing",
-    );
+The draft block's coverage shipped (plain init installs nothing; `--bootstrap` installs `SKILL.md` + both references; `--remove-bootstrap` removes the dir and the maintenance skill survives) with the case fix from finding 1, plus what the draft missed: rendered-`SKILL.md` checks (no leftover `{{...}}`, product name substituted, version stamp present and matching the authored skill), `references/waves.md` too, idempotent second removal with its notice, remove-only in a fresh dir (no `docs/arkaik/bundle.json` scaffolded, no maintenance skill), contradictory flags → non-zero + message, `--bootstrap` re-run byte-identity, `--update --bootstrap` downgrade→re-render, and the custom `--skills-dir` sibling install/remove pair.
 
-    const removed = runCli(["init", "--remove-bootstrap"], dir);
-    check("init --remove-bootstrap exits 0", removed.status === 0, removed.stderr);
-    check(
-      "bootstrap skill removed",
-      !existsSync(path.join(dir, ".claude", "skills", "arkaik-bootstrap")),
-      "skill dir still present",
-    );
-    check(
-      "the maintenance skill survives removal",
-      existsSync(path.join(dir, ".claude", "skills", "arkaik", "skill.md")),
-      "maintenance skill was collateral damage",
-    );
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
-}
-```
+- [x] **Step 2: Run it to verify it fails**
 
-Adjust the skills path (`.claude/skills/...`) to whatever `init.ts`'s `DEFAULT_SKILLS_DIR` actually is — read it first and use that constant's value.
+RED confirmed: 67 passed / 18 failed, the `--bootstrap` failures carrying exactly `Unknown option: --bootstrap`, every pre-existing check still green. The spec reviewer later *reproduced* RED independently (checked out the parent's `init.ts`/`build.js` against the new tests, rebuilt, re-ran) rather than trusting the report.
 
-- [ ] **Step 2: Run it to verify it fails**
+- [x] **Step 3: Implement**
 
-Run: `npm run build -w arkaik && node tests/cli/init.test.js`
-Expected: FAIL — "Unknown option: --bootstrap".
+As the plan specified (USAGE wording, flag parsing beside `--update`/`--no-values`, `rmSync(recursive, force)` removal printing what it removed, idempotent notice + exit 0), with the corrections in findings 2–5 above: assets from `dist/assets/bootstrap-skill/` (via build.js) instead of `plugin/skills/**`, sibling install dir, early-return removal, per-flag mirrored semantics through the existing renderer/version machinery.
 
-- [ ] **Step 3: Implement**
+- [x] **Step 4: Run the test to verify it passes**
 
-In `packages/cli/src/commands/init.ts`:
+GREEN: **90 passed, 0 failed** (85 on first pass; a review round added a missing failure-detail argument and the custom-`--skills-dir` removal coverage). Full `npm run test:cli` green across all suites; repo-wide `tsc --noEmit` clean; `npx eslint` 0 problems on `init.ts` (build.js and tests are eslint-ignored by config).
 
-1. Add `--bootstrap` and `--remove-bootstrap` to `USAGE`, described as *"install (or remove) the one-time bootstrap skill; it is not installed by default because it is a large skill for a one-time job."*
-2. Parse both flags in the existing flag loop, beside `--update` and `--no-values`.
-3. When `--bootstrap` is set, render `plugin/skills/arkaik-bootstrap/**` into the skills dir using the **same** renderer the maintenance skill already goes through — template substitution and version stamping included. Do not hand-roll a second copy path.
-4. When `--remove-bootstrap` is set, remove only the `arkaik-bootstrap` directory (`rmSync(..., { recursive: true, force: true })`) and print what was removed. Never touch the `arkaik` skill.
-5. `--remove-bootstrap` on a repo that has no bootstrap skill prints a notice and exits 0 — removal is idempotent.
-
-- [ ] **Step 4: Run the test to verify it passes**
-
-Run: `npm run build -w arkaik && node tests/cli/init.test.js`
-Expected: PASS, including the pre-existing checks in that file.
-
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
-git add packages/cli/src/commands/init.ts tests/cli/init.test.js
+git add packages/cli/src/commands/init.ts packages/cli/build.js tests/cli/init.test.js
 git commit -m "feat(cli): init --bootstrap / --remove-bootstrap"
 ```
 
 ---
 
-### Task 15: The human-facing method doc + PR 3
+### Task 15: The human-facing method doc + PR 3 — shipped, findings below
 
-**Files:**
-- Create: `docs/bootstrap.md`
-- Modify: `README.md`
+**The draft walkthrough survived contact with the shipped CLI with one honest correction and a handful of accuracy upgrades:**
 
-- [ ] **Step 1: Write `docs/bootstrap.md`**
+1. **`w1-home` became `w1-<area>`.** `planUnits` mints unit ids from whatever areas recon's `profile.json` declares — `home` is a plausible id, not a guaranteed one. The doc shows the pattern and says `plan` prints the real unit list (one `[status] wN id — title` line per unit).
+2. **The doc joined the in-app `/docs` nav, not just the README lists.** `lib/utils/docs.ts` auto-discovers markdown by directory walk and sorts by frontmatter `order`; `docs/bootstrap.md` carries `title`/`navTitle`/`order: 8`, seating it right after Hosted Projects (`order: 7`) — the same neighbor it follows in `README.md` and `docs/README.md` (that second index line is a small authorized addition beyond the plan).
+3. **Two mechanical corrections against shipped code:** `.arkaik/` gets gitignored by `corpus` *or* `plan`, whichever runs first (the spec credited corpus alone; both call `ensureGitignored`); and warning-clean is the **operator's** gate — `validate` exits 0 with warnings and `merge` blocks only on errors — stated the same way `waves.md` states it.
+4. **Review round (quality reviewer: approved after fixes):** the copy-pasteable run block's one destructive line gained its marker (`# hosted only — destructive; see below` — it was the only unmarked line in the block); the step-11 cross-reference became a real anchor link (resolves on GitHub; the in-app renderer mints no heading ids, matching `hosted-projects.md`'s five `#monorepos` links — if in-app anchors ever matter, one `rehype-slug` in `MarkdownContent.tsx` fixes every doc at once); the intro now gestures at cost alongside fit and risk; the `bootstrap index` bullet says agents run it themselves mid-unit.
+5. **Restore rails documented from `restore.ts`, not from memory:** backup to `docs/arkaik/.backups/<ts>-bundle.json` with read-back verification before anything is sent, `If-Match`/412 re-run-don't-retry, the history-shrink guard and `--allow-history-loss`, `--dry-run` running the server's real gates with no backup taken, and the undo path — `arkaik restore <backup-path>` is a genuine invocation (the positional bundle argument is real).
 
-A human's walkthrough of one run, in this order, with the exact commands:
+**Files (as shipped, one commit — `docs: the bootstrap method, for humans`):**
+- Create: `docs/bootstrap.md` (204 lines, `/docs`-app frontmatter included)
+- Modify: `README.md` (+1 line, after Hosted Projects, neighbor style: no trailing period)
+- Modify: `docs/README.md` (+1 line, after Hosted Projects, capitalized after the dash per that file's convention)
 
-```bash
-arkaik init --update                       # brownfield: get the current skill first
-arkaik init --bootstrap                    # install the one-time skill
-arkaik bootstrap corpus                    # mine PRs, docs, surfaces
-arkaik bootstrap plan                      # wave 0 only
-# ... recon agent writes .arkaik/bootstrap/profile.json ...
-arkaik bootstrap plan                      # expands waves 1-3
-arkaik bootstrap slice w1-home             # what one agent reads
-# ... agents write fragments ...
-arkaik bootstrap merge
-arkaik validate docs/arkaik/bundle.json    # the gate — warning-clean
-arkaik restore --dry-run                   # hosted only
-arkaik restore
-arkaik init --remove-bootstrap             # the skill has done its job
-```
+- [x] **Step 1: Write `docs/bootstrap.md`**
 
-Cover: the two modes; why the CLI owns determinism; the token model (slices, index, warm subagents, the `--issues` trade-off); the wave gates; that `.arkaik/` is scratch and gitignored; and that restore is destructive, `If-Match`-gated, and always backs up first.
+Shipped as drafted — same run order, same coverage list (two modes; why the CLI owns determinism; the token model with spec-§6 numbers only: ~30–60KB slices vs the ~1.5MB whole, ~6KB index vs the 164KB bundle, 15–30k tokens/unit for `--issues`, quarter-cost early gates; wave gates; `.arkaik/` scratch; destructive-restore rails) — with the corrections in findings 1–5. The brownfield `arkaik init --update`-first warning is doubly placed: a bolded paragraph directly under the intro (with the why: a stale skill predates the `acceptance`/`decision` species, so everything the run produces gets rejected at the gate) AND line 1 of the run block. The close says removal isn't precious — the skill is version-stamped and `--bootstrap` reinstalls it any time.
 
-**One thing this doc must say plainly:** the first run in a brownfield repo needs `arkaik init --update` *before* anything else, because repo-local validators reject the `acceptance` and `decision` species until the skill is current.
+- [x] **Step 2: Link it from the README**
 
-- [ ] **Step 2: Link it from the README**
+Both index lines added (see Files above), each matching its file's surrounding format exactly.
 
-Add one line to `README.md`'s docs list, matching the surrounding format:
+- [x] **Step 3: Full verification**
 
-```markdown
-- [Bootstrap](docs/bootstrap.md) — onboarding an existing repo onto Arkaik in one run.
-```
+All five gates green, exit 0 each: `test:bootstrap` (667 assertions), `test:graph-restore` (pure suite, no Postgres needed), `test:cli` (313 assertions, including the 90 init checks), `validate:seeds` (all three bundles VALID), `lint` (**0 errors**; 4 pre-existing warnings, all in app files this branch never touched).
 
-- [ ] **Step 3: Full verification**
-
-Run each and confirm each exits 0:
+- [x] **Step 4: Commit and open PR 3**
 
 ```bash
-npm run test:bootstrap
-npm run test:graph-restore
-npm run test:cli
-npm run validate:seeds
-npm run lint
-```
-
-`lint` may report pre-existing errors on `main`; the bar is no new error in a file this branch touched. If any command fails, fix it before opening the PR — do not open with a red gate.
-
-- [ ] **Step 4: Commit and open PR 3**
-
-```bash
-git add docs/bootstrap.md README.md
+git add docs/bootstrap.md README.md docs/README.md
 git commit -m "docs: the bootstrap method, for humans"
 git push
 ```
@@ -3669,7 +3610,11 @@ suggested:
 
 ## After this plan
 
+**All three parts have shipped** — Part A (#342), Part B (#343), Part C (this branch: Tasks 13–15, three commits). The plan is complete; what remains is the run itself.
+
 **The Pebbles run is not in this plan** — it is an execution of what this plan ships, and it gets its own run doc once PR 3 lands. Its sequence is fixed in the spec (§ 8): `arkaik init --update` first, then corpus over 324 merged PRs, recon confirming the ios/web platform axis, wave 1 reconciling the 173 existing nodes, waves 2 and 3, then `restore --dry-run` and `restore` to `prj_5dDiZc-G6lseF3cb`.
+
+**Found by PR 3's final review, deferred on scope:** the maintenance skill's "Bootstrap: Generating a Map from Scratch" section still calls full generation "the **only** sanctioned non-surgical case" and doesn't know the bootstrap skill exists — the one place the two installed skills can point an agent in opposite directions. The fix is one cross-pointer sentence in `docs/arkaik-skill/skill.md`, but that means a version bump to 3.2.0 plus `npm run generate` (plugin churn), so it belongs to the self-map dogfood follow-up below — landing before the Pebbles run, which is exactly the both-skills-installed scenario.
 
 **Two follow-ups deliberately left out:** the self-map gaining nodes for the bootstrap surface (dogfood, its own small PR), and a server-side pre-image table for restore (would need a manual prod migration; the client-side backup covers the realistic failure and costs nothing).
 

--- a/packages/cli/build.js
+++ b/packages/cli/build.js
@@ -16,7 +16,9 @@
  * second copy of those assets under packages/cli, we copy them into
  * dist/assets/skill/ here at build time — docs/arkaik-skill/ stays the single
  * source of truth, the published CLI carries the assets it needs, and there is
- * no drift check to maintain because nothing new is committed.
+ * no drift check to maintain because nothing new is committed. The one-time
+ * bootstrap skill (`arkaik init --bootstrap`) gets the same treatment:
+ * docs/arkaik-bootstrap-skill/ is copied into dist/assets/bootstrap-skill/.
  *
  * dist/ is gitignored and rebuilt on demand (`npm run build -w arkaik`, run by
  * the root `test:cli` script and CI before the CLI tests spawn the binary).
@@ -49,6 +51,23 @@ function copySkillAssets() {
   console.log(`copied skill assets -> ${relative(dir, SKILL_DIST_DIR)}`);
 }
 
+const BOOTSTRAP_SKILL_SRC_DIR = join(dir, "..", "..", "docs", "arkaik-bootstrap-skill");
+const BOOTSTRAP_SKILL_DIST_DIR = join(dir, "dist", "assets", "bootstrap-skill");
+
+function copyBootstrapSkillAssets() {
+  mkdirSync(join(BOOTSTRAP_SKILL_DIST_DIR, "references"), { recursive: true });
+  cpSync(join(BOOTSTRAP_SKILL_SRC_DIR, "skill.md"), join(BOOTSTRAP_SKILL_DIST_DIR, "skill.md"));
+  cpSync(
+    join(BOOTSTRAP_SKILL_SRC_DIR, "references", "fragments.md"),
+    join(BOOTSTRAP_SKILL_DIST_DIR, "references", "fragments.md"),
+  );
+  cpSync(
+    join(BOOTSTRAP_SKILL_SRC_DIR, "references", "waves.md"),
+    join(BOOTSTRAP_SKILL_DIST_DIR, "references", "waves.md"),
+  );
+  console.log(`copied bootstrap skill assets -> ${relative(dir, BOOTSTRAP_SKILL_DIST_DIR)}`);
+}
+
 const { version: VERSION } = JSON.parse(readFileSync(join(dir, "package.json"), "utf8"));
 
 async function run() {
@@ -79,6 +98,7 @@ async function run() {
   console.log(`built ${relative(dir, IO_OUT_FILE)}`);
 
   copySkillAssets();
+  copyBootstrapSkillAssets();
 }
 
 run().catch((err) => {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,6 +1,7 @@
 /**
  * `arkaik init [--product <name>] [--bundle <path>] [--journal <path>]
- *              [--skills-dir <path>] [--update]`
+ *              [--skills-dir <path>] [--update] [--bootstrap]
+ *              [--remove-bootstrap]`
  *
  * Scaffolds `docs/arkaik/` in the current working directory (the target
  * repo), configures `.gitattributes` for the journal's union merge
@@ -20,6 +21,16 @@
  * re-run never clobbers local edits. `--update` is the one sanctioned way to
  * upgrade an already-installed skill (+ its generated assets), gated on the
  * `version` frontmatter stamp; it never touches the bundle or journal.
+ *
+ * `--bootstrap` additionally installs the one-time `arkaik-bootstrap` skill
+ * (rendered from `dist/assets/bootstrap-skill/`, sourced from
+ * `docs/arkaik-bootstrap-skill/`) as a *sibling* of the arkaik skill dir. It
+ * is opt-in because it is a large skill for a one-time job — bootstrapping
+ * the map from repo history. Per-flag it mirrors the maintenance skill:
+ * install-if-absent under a plain init, version-gated under `--update`.
+ * `--remove-bootstrap` is the remove-only counterpart: it deletes exactly
+ * that directory (or prints a notice when nothing is installed) and
+ * scaffolds nothing.
  */
 import {
   copyFileSync,
@@ -41,7 +52,11 @@ const DEFAULT_SKILLS_DIR = ".claude/skills/arkaik";
 // own output location by build.js (dist/index.js -> dist/assets/skill/).
 const ASSET_DIR = join(dirname(fileURLToPath(import.meta.url)), "assets", "skill");
 
-const USAGE = `arkaik init [--product <name>] [--bundle <path>] [--journal <path>] [--skills-dir <path>] [--update]
+// The one-time bootstrap skill's template + references, same pipeline
+// (docs/arkaik-bootstrap-skill/ -> dist/assets/bootstrap-skill/, see build.js).
+const BOOTSTRAP_ASSET_DIR = join(dirname(fileURLToPath(import.meta.url)), "assets", "bootstrap-skill");
+
+const USAGE = `arkaik init [--product <name>] [--bundle <path>] [--journal <path>] [--skills-dir <path>] [--update] [--bootstrap] [--remove-bootstrap]
 
 Scaffold docs/arkaik/ (bundle.json, journal.jsonl, assets/) in the current
 directory, configure .gitattributes for the journal's union merge, and
@@ -67,6 +82,14 @@ Options:
                         (and skip references/values.md). Applies when the
                         skill is installed or upgraded; a same-version
                         \`--update\` run is a no-op.
+  --bootstrap           Also install the one-time \`arkaik-bootstrap\` skill
+                        beside the arkaik skill. Not installed by default: it
+                        is a large skill for a one-time job (bootstrapping
+                        the map from repo history). Install-if-absent with a
+                        plain init; version-gated upgrade with --update.
+  --remove-bootstrap    Remove the installed \`arkaik-bootstrap\` skill and do
+                        nothing else — no scaffolding. Prints a notice and
+                        exits 0 when it isn't installed.
   -h, --help             Show this help.`;
 
 function fail(message: string): never {
@@ -81,10 +104,12 @@ interface InitOptions {
   skillsDir?: string;
   update: boolean;
   noValues: boolean;
+  bootstrap: boolean;
+  removeBootstrap: boolean;
 }
 
 function parseArgs(args: string[]): InitOptions {
-  const opts: InitOptions = { update: false, noValues: false };
+  const opts: InitOptions = { update: false, noValues: false, bootstrap: false, removeBootstrap: false };
 
   const nextValue = (i: number, flag: string): string => {
     const value = args[i];
@@ -101,6 +126,10 @@ function parseArgs(args: string[]): InitOptions {
       opts.update = true;
     } else if (arg === "--no-values") {
       opts.noValues = true;
+    } else if (arg === "--bootstrap") {
+      opts.bootstrap = true;
+    } else if (arg === "--remove-bootstrap") {
+      opts.removeBootstrap = true;
     } else if (arg === "--product") {
       opts.product = nextValue(++i, arg);
     } else if (arg === "--bundle") {
@@ -112,6 +141,9 @@ function parseArgs(args: string[]): InitOptions {
     } else {
       fail(`Unknown option: ${arg}\n\n${USAGE}`);
     }
+  }
+  if (opts.bootstrap && opts.removeBootstrap) {
+    fail(`--bootstrap and --remove-bootstrap are contradictory; pass one or the other.\n\n${USAGE}`);
   }
   return opts;
 }
@@ -291,6 +323,71 @@ function updateSkill(skillsDirPath: string, vars: Record<string, string>, noValu
   console.log(`Upgraded skill v${installedVersion ?? "unknown"} -> v${version}.`);
 }
 
+/**
+ * Render the packaged bootstrap skill template + copy its references into
+ * `bootstrapDirPath`. The references carry no template parameters (the
+ * authoring contract for docs/arkaik-bootstrap-skill/), so they are copied
+ * verbatim.
+ */
+function renderAndWriteBootstrapSkill(bootstrapDirPath: string, vars: Record<string, string>): string {
+  const rawSkill = readFileSync(join(BOOTSTRAP_ASSET_DIR, "skill.md"), "utf8");
+
+  mkdirSync(join(bootstrapDirPath, "references"), { recursive: true });
+  writeFileSync(join(bootstrapDirPath, "SKILL.md"), renderTemplate(rawSkill, vars));
+  copyFileSync(join(BOOTSTRAP_ASSET_DIR, "references", "fragments.md"), join(bootstrapDirPath, "references", "fragments.md"));
+  copyFileSync(join(BOOTSTRAP_ASSET_DIR, "references", "waves.md"), join(bootstrapDirPath, "references", "waves.md"));
+
+  return extractVersion(rawSkill) ?? "unknown";
+}
+
+/** `--bootstrap` with a plain init: install the bootstrap skill only if it isn't there yet. */
+function installBootstrapSkill(bootstrapDirPath: string, vars: Record<string, string>): void {
+  const skillPath = join(bootstrapDirPath, "SKILL.md");
+  if (existsSync(skillPath)) {
+    console.log(
+      `Skipping bootstrap skill install (already exists): ${skillPath}. Use \`arkaik init --update --bootstrap\` to upgrade.`,
+    );
+    return;
+  }
+  const version = renderAndWriteBootstrapSkill(bootstrapDirPath, vars);
+  console.log(`Installed bootstrap skill v${version} -> ${skillPath}`);
+}
+
+/** `--update --bootstrap`: upgrade the bootstrap skill only if the packaged version is newer. */
+function updateBootstrapSkill(bootstrapDirPath: string, vars: Record<string, string>): void {
+  const packagedVersion = extractVersion(readFileSync(join(BOOTSTRAP_ASSET_DIR, "skill.md"), "utf8"));
+  const skillPath = join(bootstrapDirPath, "SKILL.md");
+
+  if (!existsSync(skillPath)) {
+    const version = renderAndWriteBootstrapSkill(bootstrapDirPath, vars);
+    console.log(`No existing bootstrap skill found at ${skillPath}; installed v${version}.`);
+    return;
+  }
+
+  const installedVersion = extractVersion(readFileSync(skillPath, "utf8"));
+  if (
+    installedVersion !== undefined &&
+    packagedVersion !== undefined &&
+    compareVersions(packagedVersion, installedVersion) <= 0
+  ) {
+    console.log(`Bootstrap skill already up to date (v${installedVersion}).`);
+    return;
+  }
+
+  const version = renderAndWriteBootstrapSkill(bootstrapDirPath, vars);
+  console.log(`Upgraded bootstrap skill v${installedVersion ?? "unknown"} -> v${version}.`);
+}
+
+/** `--remove-bootstrap`: delete the bootstrap skill directory — and nothing else. */
+function removeBootstrapSkill(bootstrapDirPath: string): void {
+  if (!existsSync(bootstrapDirPath)) {
+    console.log(`No bootstrap skill installed at ${bootstrapDirPath}; nothing to remove.`);
+    return;
+  }
+  rmSync(bootstrapDirPath, { recursive: true, force: true });
+  console.log(`Removed bootstrap skill: ${bootstrapDirPath}`);
+}
+
 export function runInit(args: string[]): void {
   const opts = parseArgs(args);
   const productName = opts.product ?? defaultProductName();
@@ -302,6 +399,15 @@ export function runInit(args: string[]): void {
   const bundlePath = resolve(cwd, bundleRelPath);
   const journalPath = resolve(cwd, journalRelPath);
   const skillsDirPath = resolve(cwd, skillsDirRelPath);
+  // The bootstrap skill installs beside the arkaik skill: skillsDirPath is
+  // the arkaik skill's OWN directory, so its sibling — not a child — is the
+  // bootstrap skill's home (.claude/skills/arkaik-bootstrap by default).
+  const bootstrapSkillDirPath = join(dirname(skillsDirPath), "arkaik-bootstrap");
+
+  if (opts.removeBootstrap) {
+    removeBootstrapSkill(bootstrapSkillDirPath);
+    return;
+  }
 
   const vars = {
     PRODUCT_NAME: productName,
@@ -312,6 +418,7 @@ export function runInit(args: string[]): void {
 
   if (opts.update) {
     updateSkill(skillsDirPath, vars, opts.noValues);
+    if (opts.bootstrap) updateBootstrapSkill(bootstrapSkillDirPath, vars);
     return;
   }
 
@@ -320,4 +427,5 @@ export function runInit(args: string[]): void {
   writeIfAbsent(join(dirname(bundlePath), "assets", ".gitkeep"), "", "assets dir");
   ensureGitAttributes(journalRelPath);
   installSkill(skillsDirPath, vars, opts.noValues);
+  if (opts.bootstrap) installBootstrapSkill(bootstrapSkillDirPath, vars);
 }

--- a/tests/cli/init.test.js
+++ b/tests/cli/init.test.js
@@ -17,7 +17,11 @@
  *    name substituted) alongside its generated `references/schema.md` and
  *    `scripts/validate-bundle.js`;
  *  - `--update` upgrades an older-stamped SKILL.md and is a no-op when the
- *    packaged version is already current, without touching bundle/journal.
+ *    packaged version is already current, without touching bundle/journal;
+ *  - `--bootstrap` opt-in installs the one-time bootstrap skill (rendered
+ *    SKILL.md + verbatim references) beside the arkaik skill, and
+ *    `--remove-bootstrap` removes exactly that directory — remove-only,
+ *    idempotent, and refusing to combine with `--bootstrap`.
  */
 
 const { spawnSync } = require("child_process");
@@ -314,6 +318,211 @@ const validatorScriptPath = path.join(dir, SKILL_DIR_REL, "scripts", "validate-b
     !existsSync(path.join(freshDir, BUNDLE_REL)),
   );
   rmSync(freshDir, { recursive: true, force: true });
+}
+
+// ---------------------------------------------------------------------------
+// `--bootstrap` installs the one-time bootstrap skill on demand (never by
+// default), renders it like the maintenance skill, upgrades version-gated
+// under `--update`, and `--remove-bootstrap` removes it cleanly — and only it.
+// ---------------------------------------------------------------------------
+{
+  const bootstrapDir = mkdtempSync(path.join(tmpdir(), "arkaik-init-bootstrap-"));
+  try {
+    const bootstrapSkillDir = path.join(bootstrapDir, ".claude", "skills", "arkaik-bootstrap");
+    // Installed filename is SKILL.md (uppercase) — a lowercase existsSync
+    // would pass on macOS's case-insensitive FS and fail on CI's Linux.
+    const bootstrapSkillMdPath = path.join(bootstrapSkillDir, "SKILL.md");
+
+    const plain = runCli(["init", "--product", "Demo"], bootstrapDir);
+    check("bootstrap block: plain init exits 0", plain.status === 0, `${plain.stdout}\n${plain.stderr}`);
+    check(
+      "plain init does NOT install the bootstrap skill",
+      !existsSync(bootstrapSkillDir),
+      "bootstrap skill was installed without being asked for",
+    );
+
+    const withBootstrap = runCli(["init", "--product", "Demo", "--bootstrap"], bootstrapDir);
+    check("init --bootstrap exits 0", withBootstrap.status === 0, `${withBootstrap.stdout}\n${withBootstrap.stderr}`);
+    check("bootstrap SKILL.md installed", existsSync(bootstrapSkillMdPath), "SKILL.md missing");
+    check(
+      "bootstrap references/fragments.md installed",
+      existsSync(path.join(bootstrapSkillDir, "references", "fragments.md")),
+      "references/fragments.md missing",
+    );
+    check(
+      "bootstrap references/waves.md installed",
+      existsSync(path.join(bootstrapSkillDir, "references", "waves.md")),
+      "references/waves.md missing",
+    );
+
+    // Guarded read: a missing install reports as FAILed checks below instead
+    // of an ENOENT crash that would hide the rest of the suite.
+    const bootstrapSkill = existsSync(bootstrapSkillMdPath) ? readFileSync(bootstrapSkillMdPath, "utf8") : "";
+    check(
+      "bootstrap SKILL.md is rendered (no leftover {{...}} placeholders)",
+      bootstrapSkill !== "" && !/\{\{[A-Z_]+\}\}/.test(bootstrapSkill),
+      bootstrapSkill.slice(0, 200),
+    );
+    check("bootstrap SKILL.md substitutes the product name", bootstrapSkill.includes("Demo"), bootstrapSkill.slice(0, 200));
+    check(
+      "bootstrap SKILL.md frontmatter carries a version stamp",
+      /^version:\s*\d+\.\d+\.\d+/m.test(bootstrapSkill),
+      bootstrapSkill.slice(0, 200),
+    );
+    // Derived from the authored skill rather than pinned to a literal, like
+    // the maintenance-skill version check above.
+    const authoredBootstrap = readFileSync(path.join(ROOT, "docs", "arkaik-bootstrap-skill", "skill.md"), "utf8");
+    const authoredBootstrapVersion = authoredBootstrap.match(/^version:\s*(\S+)/m)?.[1];
+    check(
+      `bootstrap SKILL.md version matches the authored skill (${authoredBootstrapVersion})`,
+      Boolean(authoredBootstrapVersion) &&
+        new RegExp(`^version:\\s*${authoredBootstrapVersion.replace(/\./g, "\\.")}$`, "m").test(bootstrapSkill),
+      bootstrapSkill.slice(0, 200),
+    );
+
+    // Re-running `--bootstrap` is install-if-absent, like the maintenance
+    // skill under a plain init: the installed file is left byte-identical.
+    const rerun = runCli(["init", "--product", "Demo", "--bootstrap"], bootstrapDir);
+    check("re-run init --bootstrap exits 0", rerun.status === 0, `${rerun.stdout}\n${rerun.stderr}`);
+    const afterRerun = existsSync(bootstrapSkillMdPath) ? readFileSync(bootstrapSkillMdPath, "utf8") : "";
+    check(
+      "re-run leaves bootstrap SKILL.md byte-identical",
+      afterRerun !== "" && afterRerun === bootstrapSkill,
+      rerun.stdout,
+    );
+
+    // `--update --bootstrap` mirrors the maintenance skill's version gate:
+    // an older-stamped install is re-rendered to the packaged version.
+    if (bootstrapSkill !== "") {
+      writeFileSync(bootstrapSkillMdPath, bootstrapSkill.replace(/^version:\s*\S+/m, "version: 0.0.1"));
+    }
+    const updateResult = runCli(["init", "--update", "--bootstrap", "--product", "Demo"], bootstrapDir);
+    check("init --update --bootstrap exits 0", updateResult.status === 0, `${updateResult.stdout}\n${updateResult.stderr}`);
+    const upgradedBootstrap = existsSync(bootstrapSkillMdPath) ? readFileSync(bootstrapSkillMdPath, "utf8") : "";
+    check(
+      "--update --bootstrap re-renders the bootstrap skill to the packaged version",
+      Boolean(authoredBootstrapVersion) &&
+        new RegExp(`^version:\\s*${authoredBootstrapVersion.replace(/\./g, "\\.")}$`, "m").test(upgradedBootstrap),
+      upgradedBootstrap.slice(0, 200),
+    );
+
+    // Removal: only the bootstrap dir goes; the maintenance skill survives.
+    const removed = runCli(["init", "--remove-bootstrap"], bootstrapDir);
+    check("init --remove-bootstrap exits 0", removed.status === 0, `${removed.stdout}\n${removed.stderr}`);
+    check("--remove-bootstrap prints what it removed", /removed/i.test(removed.stdout), removed.stdout);
+    check("bootstrap skill removed", !existsSync(bootstrapSkillDir), "skill dir still present");
+    check(
+      "the maintenance skill survives removal",
+      existsSync(path.join(bootstrapDir, SKILL_DIR_REL, "SKILL.md")),
+      "maintenance skill was collateral damage",
+    );
+
+    // A second removal on the now-clean dir is idempotent: exit 0 + a notice.
+    const removedAgain = runCli(["init", "--remove-bootstrap"], bootstrapDir);
+    check("second --remove-bootstrap exits 0", removedAgain.status === 0, `${removedAgain.stdout}\n${removedAgain.stderr}`);
+    check(
+      "second --remove-bootstrap prints a nothing-to-remove notice",
+      /nothing to remove/i.test(removedAgain.stdout),
+      removedAgain.stdout,
+    );
+  } finally {
+    rmSync(bootstrapDir, { recursive: true, force: true });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// A custom `--skills-dir` moves the bootstrap skill with it: it installs and
+// is removed as a SIBLING of the given dir (x/arkaik-bootstrap for
+// --skills-dir x/arkaik), never nested inside the arkaik skill.
+// ---------------------------------------------------------------------------
+{
+  const customDir = mkdtempSync(path.join(tmpdir(), "arkaik-init-bootstrap-skillsdir-"));
+  try {
+    const customSkillsDir = path.join("custom", "skills", "arkaik");
+    const customBootstrapDir = path.join(customDir, "custom", "skills", "arkaik-bootstrap");
+
+    const installed = runCli(
+      ["init", "--product", "Custom Co", "--skills-dir", customSkillsDir, "--bootstrap"],
+      customDir,
+    );
+    check(
+      "custom skills-dir: init --bootstrap exits 0",
+      installed.status === 0,
+      `${installed.stdout}\n${installed.stderr}`,
+    );
+    check(
+      "custom skills-dir: bootstrap skill installs as a sibling of the skills dir",
+      existsSync(path.join(customBootstrapDir, "SKILL.md")),
+      "custom/skills/arkaik-bootstrap/SKILL.md missing",
+    );
+
+    const removed = runCli(["init", "--remove-bootstrap", "--skills-dir", customSkillsDir], customDir);
+    check(
+      "custom skills-dir: --remove-bootstrap exits 0",
+      removed.status === 0,
+      `${removed.stdout}\n${removed.stderr}`,
+    );
+    check("custom skills-dir: sibling bootstrap dir removed", !existsSync(customBootstrapDir), "skill dir still present");
+    check(
+      "custom skills-dir: the maintenance skill survives removal",
+      existsSync(path.join(customDir, customSkillsDir, "SKILL.md")),
+      "maintenance skill was collateral damage",
+    );
+  } finally {
+    rmSync(customDir, { recursive: true, force: true });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// `--remove-bootstrap` is remove-only: in a fresh directory it must not
+// scaffold anything as a side effect of a removal.
+// ---------------------------------------------------------------------------
+{
+  const removeOnlyDir = mkdtempSync(path.join(tmpdir(), "arkaik-init-remove-only-"));
+  try {
+    const result = runCli(["init", "--remove-bootstrap"], removeOnlyDir);
+    check("--remove-bootstrap in a fresh dir exits 0", result.status === 0, `${result.stdout}\n${result.stderr}`);
+    check(
+      "--remove-bootstrap in a fresh dir does not scaffold the bundle",
+      !existsSync(path.join(removeOnlyDir, BUNDLE_REL)),
+      "removal scaffolded docs/arkaik/bundle.json",
+    );
+    check(
+      "--remove-bootstrap in a fresh dir does not install the maintenance skill",
+      !existsSync(path.join(removeOnlyDir, SKILL_DIR_REL, "SKILL.md")),
+      "removal installed the maintenance skill",
+    );
+  } finally {
+    rmSync(removeOnlyDir, { recursive: true, force: true });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// `--bootstrap --remove-bootstrap` together is contradictory: refuse loudly,
+// scaffold nothing.
+// ---------------------------------------------------------------------------
+{
+  const conflictDir = mkdtempSync(path.join(tmpdir(), "arkaik-init-bootstrap-conflict-"));
+  try {
+    const result = runCli(["init", "--bootstrap", "--remove-bootstrap"], conflictDir);
+    check(
+      "--bootstrap with --remove-bootstrap exits non-zero",
+      result.status !== 0,
+      `${result.stdout}\n${result.stderr}`,
+    );
+    check(
+      "--bootstrap with --remove-bootstrap explains the contradiction",
+      /contradictory/i.test(result.stderr),
+      result.stderr,
+    );
+    check(
+      "conflicting flags scaffold nothing",
+      !existsSync(path.join(conflictDir, BUNDLE_REL)),
+      "conflicting flags still scaffolded the bundle",
+    );
+  } finally {
+    rmSync(conflictDir, { recursive: true, force: true });
+  }
 }
 
 rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## What this ships

PR 3 of the bootstrap program ([plan, Part C](docs/superpowers/plans/2026-08-04-bootstrap-method.md)) — the judgment half of the method plus its wiring:

- **The `arkaik-bootstrap` skill** (`docs/arkaik-bootstrap-skill/`): `skill.md` — the 10-section judgment doctrine (species discrimination incl. the `DM-` concept-vs-table rule, playlists, acceptances, values, platform scoping, the user-visible PR filter, status arcs, never-delete); `references/fragments.md` — the fragment contract exactly as `fragments.ts` ships it, every example copied verbatim from CI-run fixtures; `references/waves.md` — the wave catalog and per-wave reviewer checklists, including the 20% churn guard and the values-balance rejection.
- **`arkaik init --bootstrap` / `--remove-bootstrap`**: `build.js` copies the skill sources into `dist/assets/bootstrap-skill/`; `init` renders `SKILL.md` through the same template/version machinery as the maintenance skill, installs to the sibling directory, and removal is an idempotent, remove-only early return. 31 new checks in `tests/cli/init.test.js` (90/0).
- **`docs/bootstrap.md`**: the human walkthrough of one run — linked from both READMEs and seated in the `/docs` app nav beside Hosted Projects.

## One deliberate deviation from the plan

The plan drafted the skill at `plugin/skills/arkaik-bootstrap/`. Everything under `plugin/` is generated output of `npm run generate`, and a marketplace plugin ships its skills to every user **permanently** — exactly the "permanent token tax for a one-time job" the spec's on-demand decision (§4) forbids. The skill sources live at `docs/arkaik-bootstrap-skill/` instead, flowing through the maintenance skill's exact pipeline (build.js → dist assets → rendered by init). `plugin/` and `npm run generate` are untouched. Full rationale in the plan's rewritten Task 13 section.

## Verification

- `test:bootstrap` 667 · `test:cli` 313 (init 90/0) · `test:graph-restore` · `validate:seeds` — all green
- `lint`: 0 errors (4 pre-existing warnings in untouched app files) · `tsc --noEmit` clean · `npm run generate` leaves the tree clean
- Every task passed a spec-compliance review and a code-quality review with fix rounds; a final whole-branch review verified cross-artifact coherence (skill ↔ doc ↔ plan ↔ code) and walked the installed-layout journey end to end — every relative link resolves after `init` + `init --bootstrap`.

## Follow-up recorded in the plan

The maintenance skill's "Generating a Map from Scratch" section predates this skill and still calls itself the only sanctioned non-surgical path. The fix is one cross-pointer sentence plus a version bump (plugin churn), folded into the self-map dogfood follow-up — landing before the Pebbles run.

## Lab Note

```yaml
en:
  title: "A guided way to map a codebase you already have"
  summary: "Point Arkaik at an existing project and it walks you through mapping it — what to look at first, what to write down, and when you are done. Once the map exists, the guide steps out of the way."
fr:
  title: "Une méthode guidée pour cartographier un projet existant"
  summary: "Pointe Arkaik vers un projet existant et il t'accompagne pour le cartographier : par quoi commencer, quoi noter, et quand c'est terminé. Une fois la carte prête, le guide s'efface."
suggested:
  molecule: arkaik
  type: feature
  tags: [changelog]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)