### PR TITLE
Bump arkaik CLI to 0.1.2 (published to npm)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10561,7 +10561,7 @@
     },
     "packages/cli": {
       "name": "arkaik",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "bin": {
         "arkaik": "dist/index.js"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arkaik",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Arkaik CLI — link a repository to a hosted product graph, validate and pack bundles, mirror external ref status.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Records the version bump that shipped with the npm publish.

- `arkaik` **0.1.2** — now on npm with the bootstrap surface (`latest`)
- `arkaik-mcp` **0.2.2** — published unchanged, no bump needed

The previously published `arkaik@0.1.1` carried the same version number as the repo but predated every bootstrap command, so `npx arkaik` was serving stale code. That's resolved.

Chore — no Lab Note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)