### PR TITLE
fix(data): refuse a restore that drops hosted nodes or edges

### DIFF
--- a/packages/cli/src/commands/restore.ts
+++ b/packages/cli/src/commands/restore.ts
@@ -1,5 +1,5 @@
 /**
- * `arkaik restore [--dry-run] [--allow-history-loss] [--api <base-url>] [path]`
+ * `arkaik restore [--dry-run] [--allow-history-loss] [--allow-deletions] [--api <base-url>] [path]`
  *
  * Land a locally-built bundle — history included — on the hosted project
  * this repo is linked to (docs/superpowers/specs/2026-08-04-bootstrap-method-
@@ -44,6 +44,17 @@
  *    history is a valid, silent input on every other layer — see the guard
  *    below) — `--allow-history-loss` is the deliberate escape hatch when a
  *    shrink really is intended;
+ *  - the same export is diffed BY ID against the outbound snapshot, and any
+ *    hosted node or edge the local bundle does not carry refuses the run
+ *    (`--allow-deletions` is that guard's escape hatch). The count-based
+ *    history guard above structurally cannot see this class: a hosted
+ *    project that has drifted ahead of the committed cache (someone edited
+ *    it in the app) yields a delta like `nodes 173 -> 448 (+276 -1 ~172)`,
+ *    where the journal grew, every count rose, and the single `-1` is a
+ *    node the maintainer deliberately deleted being resurrected — with its
+ *    replacement and that replacement's edges dropped in exchange. In a
+ *    method whose first principle is "bootstrap never deletes", any negative
+ *    in a restore delta is a contradiction, not a number in a row;
  *  - `--dry-run` skips the backup entirely and on purpose (see the `dryRun`
  *    branch below) — nothing destructive happens in that mode, so there is
  *    nothing to back up, and writing one anyway would clutter
@@ -57,9 +68,12 @@
  *     write does (`classifyDryRun`, Task 11), so a stale version must
  *     produce the same 412 in preview as it would for real;
  *  3. real restore only: GET the export, check its journal isn't shorter
- *     than the outbound one (unless `--allow-history-loss`), then write the
- *     export to `docs/arkaik/.backups/<ts>-bundle.json` and abort on ANY
- *     failure — see above;
+ *     than the outbound one (unless `--allow-history-loss`) and that the
+ *     outbound snapshot drops none of its nodes or edges (unless
+ *     `--allow-deletions`), then write the export to
+ *     `docs/arkaik/.backups/<ts>-bundle.json` and abort on ANY failure — see
+ *     above. Both guards run BEFORE the backup is written: a refused run
+ *     should leave no trace in `.backups/`, exactly like a dry run;
  *  4. assemble the outbound bundle: the local `bundle.json` plus its journal,
  *     via `loadJournalEvents` (embedded journal wins over the `journal.jsonl`
  *     sidecar, the same precedence `arkaik validate` uses — load-bearing here
@@ -134,6 +148,13 @@ Options:
                         means a missing/gitignored journal.jsonl or a bundle
                         from the wrong directory, not an intended history
                         rewrite.
+  --allow-deletions     Proceed even though the local bundle drops nodes or
+                        edges the hosted project currently has. Without this
+                        flag, that refuses outright and names the ids — it
+                        usually means the hosted project moved ahead of your
+                        local copy (edited in the app), not an intended
+                        deletion. Undoing a restore from a backup is the
+                        common case where it IS intended.
   --api <base-url>      Override the remote from docs/arkaik/arkaik.json
                         (also overridable with $ARKAIK_URL).
   -h, --help            Show this help.
@@ -155,6 +176,8 @@ export interface RunRestoreOptions {
   dryRun?: boolean;
   /** Proceed even when the outbound journal is shorter than the hosted one. Default: false. */
   allowHistoryLoss?: boolean;
+  /** Proceed even when the outbound snapshot drops hosted nodes or edges. Default: false. */
+  allowDeletions?: boolean;
   /** Hosted API base URL, overriding $ARKAIK_URL and the link file's `remote`. */
   apiBase?: string;
   /** Base directory the link file / bundle path resolve against (default: process.cwd()). */
@@ -348,11 +371,66 @@ function writeBackupFile(filePath: string, content: string): void {
   }
 }
 
+/**
+ * Ids present in `before` but absent from `after`, matched by `id` — the same
+ * key the server's own delta matches on. Entries carrying no string id are
+ * skipped on both sides: they cannot be matched either way, and the server
+ * already accounts for them separately as `nodesMalformed`/`edgesMalformed`.
+ */
+function removedIds(before: unknown[], after: unknown[]): string[] {
+  const kept = new Set<string>();
+  for (const item of after) {
+    const id = (item as { id?: unknown } | null)?.id;
+    if (typeof id === "string") kept.add(id);
+  }
+  const removed: string[] = [];
+  for (const item of before) {
+    const id = (item as { id?: unknown } | null)?.id;
+    if (typeof id === "string" && !kept.has(id)) removed.push(id);
+  }
+  return removed;
+}
+
+/** At most `limit` ids, with an explicit "+N more" rather than a silent truncation. */
+function listIds(ids: string[], limit = 10): string {
+  if (ids.length <= limit) return ids.join(", ");
+  return `${ids.slice(0, limit).join(", ")}, and ${ids.length - limit} more`;
+}
+
+/**
+ * The refusal message for a restore that would drop hosted entities. It names
+ * the ids because a bare count is what made this class of loss cost a
+ * 20-minute investigation instead of being self-evident: `-1 node` says
+ * nothing, `-1 node (DM-bounce)` says everything.
+ */
+function describeDeletions(removedNodes: string[], removedEdges: string[], bundlePath: string): string {
+  const parts: string[] = [];
+  if (removedNodes.length > 0) parts.push(`${removedNodes.length} node${removedNodes.length === 1 ? "" : "s"}`);
+  if (removedEdges.length > 0) parts.push(`${removedEdges.length} edge${removedEdges.length === 1 ? "" : "s"}`);
+  const lines = [
+    `This restore would DELETE ${parts.join(" and ")} the hosted project currently has and ${bundlePath} does not. Nothing was sent.`,
+  ];
+  if (removedNodes.length > 0) lines.push(`  nodes: ${listIds(removedNodes)}`);
+  if (removedEdges.length > 0) lines.push(`  edges: ${listIds(removedEdges)}`);
+  lines.push(
+    `Usually this means the hosted project moved ahead of your local copy (someone edited it in the app) ` +
+      `and the local bundle is the stale side — not that you meant to delete anything. ` +
+      `Adopt the hosted state locally first: \`GET /api/graph/projects/<id>/export\` is what answers ` +
+      `"what am I about to overwrite".`,
+  );
+  lines.push(
+    `If the deletions really are intended — undoing an earlier restore from a backup legitimately removes ` +
+      `what that restore added — re-run with --allow-deletions.`,
+  );
+  return lines.join("\n");
+}
+
 export async function runRestore(options: RunRestoreOptions = {}): Promise<RunRestoreResult> {
   const cwd = options.cwd ?? process.cwd();
   const env = options.env ?? process.env;
   const dryRun = options.dryRun ?? false;
   const allowHistoryLoss = options.allowHistoryLoss ?? false;
+  const allowDeletions = options.allowDeletions ?? false;
   const httpClient = options.httpClient ?? DEFAULT_HTTP_CLIENT;
 
   const linkPath = join(cwd, LINK_FILE);
@@ -488,6 +566,19 @@ export async function runRestore(options: RunRestoreOptions = {}): Promise<RunRe
     );
   }
 
+  // ── Deletion guard ───────────────────────────────────────────────────────
+  // The history guard above compares COUNTS, so it cannot see a deletion that
+  // arrives alongside a much larger addition — the shape a brownfield
+  // bootstrap always has. Diffing the export BY ID is what makes it visible,
+  // and the export is already in hand for the backup, so this costs no extra
+  // round-trip. Runs before the backup write for the same reason the history
+  // guard does: a refused run should leave nothing behind in `.backups/`.
+  const removedNodes = removedIds(exportedBundle.nodes, Array.isArray(local.nodes) ? local.nodes : []);
+  const removedEdges = removedIds(exportedBundle.edges, Array.isArray(local.edges) ? local.edges : []);
+  if ((removedNodes.length > 0 || removedEdges.length > 0) && !allowDeletions) {
+    return fatalResult(dryRun, describeDeletions(removedNodes, removedEdges, bundlePath));
+  }
+
   // Anchored to the LINK FILE's directory, not `bundlePath`'s — the backup
   // is a pre-image of the HOSTED project (identified by the link file), not
   // of wherever the local input file happens to live. See the module doc
@@ -557,6 +648,25 @@ function printDelta(delta: DeltaSummary | undefined): void {
       delta.eventsMalformed ? `, ${delta.eventsMalformed} malformed` : ""
     })`,
   );
+
+  // A deletion is the one number in these rows that contradicts the method's
+  // own first principle, and it is the easiest to miss: it renders as a `-1`
+  // in a line whose every other figure is large and rising. Call it out in
+  // words. This is also the ONLY place a dry run can surface it — that branch
+  // never fetches the export, so it has no ids of its own to diff, only the
+  // server's counts.
+  const count = (k: string): number => (typeof delta[k] === "number" ? (delta[k] as number) : 0);
+  const nodesRemoved = count("nodesRemoved");
+  const edgesRemoved = count("edgesRemoved");
+  if (nodesRemoved > 0 || edgesRemoved > 0) {
+    const parts: string[] = [];
+    if (nodesRemoved > 0) parts.push(`${nodesRemoved} node${nodesRemoved === 1 ? "" : "s"}`);
+    if (edgesRemoved > 0) parts.push(`${edgesRemoved} edge${edgesRemoved === 1 ? "" : "s"}`);
+    console.log(
+      `  WARNING: this DELETES ${parts.join(" and ")} from the hosted project. ` +
+        `Bootstrap never deletes — check the hosted project has not moved ahead of your local bundle.`,
+    );
+  }
 }
 
 /**
@@ -610,6 +720,7 @@ export function reportRestore(result: RunRestoreResult): void {
 export function runRestoreCli(argv: string[]): void {
   let dryRun = false;
   let allowHistoryLoss = false;
+  let allowDeletions = false;
   let apiBase: string | undefined;
   const positionals: string[] = [];
 
@@ -623,6 +734,8 @@ export function runRestoreCli(argv: string[]): void {
       dryRun = true;
     } else if (arg === "--allow-history-loss") {
       allowHistoryLoss = true;
+    } else if (arg === "--allow-deletions") {
+      allowDeletions = true;
     } else if (arg === "--api") {
       const value = argv[++i];
       if (value === undefined) fail(`Missing value for --api\n\n${USAGE}`);
@@ -636,7 +749,7 @@ export function runRestoreCli(argv: string[]): void {
 
   if (positionals.length > 1) fail(`Unexpected argument(s): ${positionals.slice(1).join(" ")}\n\n${USAGE}`);
 
-  runRestore({ path: positionals[0], dryRun, allowHistoryLoss, apiBase })
+  runRestore({ path: positionals[0], dryRun, allowHistoryLoss, allowDeletions, apiBase })
     .then((result) => reportRestore(result))
     .catch((e: unknown) => fail(`FATAL: ${(e as Error).message}`));
 }

--- a/tests/cli/bootstrap-restore.test.js
+++ b/tests/cli/bootstrap-restore.test.js
@@ -488,6 +488,128 @@ async function main() {
   }
 
   // -------------------------------------------------------------------------
+  // Critical: a restore that DROPS hosted nodes or edges must refuse — zero
+  // PUTs — unless --allow-deletions. This is the class the count-based history
+  // guard structurally cannot see, and the closest a real bootstrap run came
+  // to destroying data: the hosted project had drifted ahead of the committed
+  // cache (a node deleted in the app, a replacement created, edges rewired),
+  // so the delta was `+276 -1` with a GROWING journal — every count rose while
+  // a real deletion sat inside it.
+  // -------------------------------------------------------------------------
+
+  // Hosted state that has moved ahead of the local bundle: it carries a node
+  // (and an edge onto it) that the local bundle knows nothing about.
+  const HOSTED_AHEAD = {
+    ...HOSTED_EXPORT,
+    nodes: [
+      ...HOSTED_EXPORT.nodes,
+      { id: "DM-bounces", project_id: "demo", species: "data-model", title: "Bounces", status: "live", platforms: ["web"] },
+    ],
+    edges: [{ id: "e-V-old-DM-bounces", project_id: "demo", source_id: "V-old", target_id: "DM-bounces", edge_type: "displays" }],
+  };
+
+  {
+    // (a) The exact shape of the real run: the outbound journal GREW (2 vs 1,
+    // so the history guard is satisfied and waves it through) while a hosted
+    // node and edge are dropped. Proves the two guards catch different things.
+    const { dir, bundlePath } = fixture({ sidecarEvents: [SIDECAR_EVENT, SIDECAR_EVENT_2] });
+    const httpClient = makeMockHttpClient((url) => {
+      if (url.endsWith("/api/graph/projects/prj_demo")) return jsonResponse(200, { version: "1" });
+      if (url.endsWith("/export")) return jsonResponse(200, { bundle: HOSTED_AHEAD });
+      if (url.endsWith("/bundle")) throw new Error("must not PUT: the local bundle drops DM-bounces and its edge");
+      throw new Error(`unexpected URL ${url}`);
+    });
+    const result = await runRestore({ path: bundlePath, apiBase: "http://example.invalid", env: { ARKAIK_TOKEN: "tok" }, cwd: dir, httpClient });
+    check("growing journal + dropped node: refuses (ok:false)", result.ok === false, JSON.stringify(result));
+    check("dropped node: zero PUT calls", httpClient.calls.filter((c) => c.url.endsWith("/bundle")).length === 0, JSON.stringify(httpClient.calls));
+    check("dropped node: no backup written either (aborts before the write)", backupsIn(dir).length === 0, backupsIn(dir));
+    check(
+      "dropped node: message names the node id, not just a count",
+      typeof result.fatal === "string" && result.fatal.includes("DM-bounces"),
+      result.fatal,
+    );
+    check(
+      "dropped node: message names the edge id too",
+      typeof result.fatal === "string" && result.fatal.includes("e-V-old-DM-bounces"),
+      result.fatal,
+    );
+    check(
+      "dropped node: message names the --allow-deletions escape hatch",
+      typeof result.fatal === "string" && result.fatal.includes("--allow-deletions"),
+      result.fatal,
+    );
+  }
+  {
+    // (b) Same scenario with --allow-deletions: proceeds, and still backs up.
+    const { dir, bundlePath } = fixture({ sidecarEvents: [SIDECAR_EVENT, SIDECAR_EVENT_2] });
+    const httpClient = makeMockHttpClient((url) => {
+      if (url.endsWith("/api/graph/projects/prj_demo")) return jsonResponse(200, { version: "1" });
+      if (url.endsWith("/export")) return jsonResponse(200, { bundle: HOSTED_AHEAD });
+      if (url.endsWith("/bundle")) return jsonResponse(200, { version: "2", delta: {} });
+      throw new Error(`unexpected URL ${url}`);
+    });
+    const result = await runRestore({ path: bundlePath, allowDeletions: true, apiBase: "http://example.invalid", env: { ARKAIK_TOKEN: "tok" }, cwd: dir, httpClient });
+    check("--allow-deletions: restore proceeds (ok:true, sent)", result.ok === true && result.requestSent === true, JSON.stringify(result));
+    check("--allow-deletions: a backup was still taken", backupsIn(dir).length === 1, backupsIn(dir));
+  }
+  {
+    // (c) Edge-only deletion refuses too — the real run's `-7 edges` arrived
+    // without any node id changing, so a node-only guard would have missed it.
+    const { dir, bundlePath } = fixture();
+    const hostedEdgeOnly = { ...HOSTED_EXPORT, edges: [{ id: "e-V-old-V-old", project_id: "demo", source_id: "V-old", target_id: "V-old", edge_type: "composes" }] };
+    const httpClient = makeMockHttpClient((url) => {
+      if (url.endsWith("/api/graph/projects/prj_demo")) return jsonResponse(200, { version: "1" });
+      if (url.endsWith("/export")) return jsonResponse(200, { bundle: hostedEdgeOnly });
+      if (url.endsWith("/bundle")) throw new Error("must not PUT: the local bundle drops a hosted edge");
+      throw new Error(`unexpected URL ${url}`);
+    });
+    const result = await runRestore({ path: bundlePath, apiBase: "http://example.invalid", env: { ARKAIK_TOKEN: "tok" }, cwd: dir, httpClient });
+    check("edge-only deletion: refuses", result.ok === false, JSON.stringify(result));
+    check("edge-only deletion: names the edge id", typeof result.fatal === "string" && result.fatal.includes("e-V-old-V-old"), result.fatal);
+  }
+  {
+    // (d) The ordinary additive bootstrap landing — the local bundle is a
+    // superset of the hosted one — must NOT need the flag. This is the case
+    // every real run is supposed to be, so a guard that blocked it would be
+    // worse than no guard.
+    const { dir, bundlePath } = fixture();
+    const httpClient = makeMockHttpClient((url) => {
+      if (url.endsWith("/api/graph/projects/prj_demo")) return jsonResponse(200, { version: "1" });
+      if (url.endsWith("/export")) return jsonResponse(200, { bundle: HOSTED_EXPORT });
+      if (url.endsWith("/bundle")) return jsonResponse(200, { version: "2", delta: {} });
+      throw new Error(`unexpected URL ${url}`);
+    });
+    const result = await runRestore({ path: bundlePath, apiBase: "http://example.invalid", env: { ARKAIK_TOKEN: "tok" }, cwd: dir, httpClient });
+    check("additive-only restore: proceeds without --allow-deletions", result.ok === true && result.requestSent === true, JSON.stringify(result));
+  }
+  {
+    // (e) A dry run never fetches the export, so it has no ids to diff — the
+    // server's counts are all it has. Those counts must still be called out in
+    // words, because `-1` in a row of large rising numbers is exactly what got
+    // missed.
+    const result = {
+      ok: true,
+      dryRun: true,
+      requestSent: true,
+      status: 200,
+      version: "7",
+      delta: { nodesBefore: 173, nodesAfter: 448, nodesAdded: 276, nodesRemoved: 1, nodesChanged: 172, edgesRemoved: 7 },
+    };
+    const lines = captureConsoleLog(() => reportRestore(result));
+    check(
+      "dry-run delta calls out deletions in words",
+      lines.some((l) => l.includes("WARNING") && l.includes("DELETES") && l.includes("1 node") && l.includes("7 edges")),
+      JSON.stringify(lines),
+    );
+  }
+  {
+    // (f) ...and says nothing when there is nothing to warn about.
+    const result = { ok: true, dryRun: true, requestSent: true, status: 200, version: "7", delta: { nodesAdded: 5, nodesRemoved: 0, edgesRemoved: 0 } };
+    const lines = captureConsoleLog(() => reportRestore(result));
+    check("additive delta prints no deletion warning", !lines.some((l) => l.includes("WARNING")), JSON.stringify(lines));
+  }
+
+  // -------------------------------------------------------------------------
   // Important 2 (coordinator round 2): the backup lands at
   // cwd/docs/arkaik/.backups — anchored to the LINK FILE's directory — even
   // when --path points at a bundle entirely outside docs/arkaik/.
@@ -894,6 +1016,7 @@ async function main() {
     check("restore --help exits 0", help.status === 0 && /arkaik restore/.test(help.stdout), help.stdout);
     check("help documents --dry-run", /--dry-run/.test(help.stdout));
     check("help documents --allow-history-loss", /--allow-history-loss/.test(help.stdout));
+    check("help documents --allow-deletions", /--allow-deletions/.test(help.stdout));
     check("help documents --api", /--api/.test(help.stdout));
     check("help documents ARKAIK_URL", /ARKAIK_URL/.test(help.stdout));
 


### PR DESCRIPTION
Resolves #348

The history-loss guard compares event **counts**, so it structurally cannot see a deletion that arrives alongside a much larger addition — which is the shape a brownfield bootstrap always has. The real run produced:

```
nodes  173 -> 448  (+276 -1 ~172)
edges  337 -> 971  (+641 -7 ~330)
events 290 -> 854  (+854 -290 ~0)
```

854 > 290, so the journal guard waved it through. The `-1` inside was a node the maintainer had deleted in the app being resurrected, with its replacement and that replacement's 7 edges dropped in exchange. Every rail behaved as designed while it happened.

## What changed

**A deletion guard on the real restore path.** The hosted export is already fetched for the mandatory backup, so this diffs it **by id** against the outbound snapshot at no extra round-trip, and refuses when the local bundle drops anything. `--allow-deletions` is the escape hatch, mirroring `--allow-history-loss` exactly — including on the undo path, where `arkaik restore <backupPath>` legitimately removes what the bad restore added, and where `--allow-history-loss` was already required.

The refusal runs **before** the backup is written, so a refused run leaves nothing in `.backups/` — same contract the history guard has.

**The message names the ids.** `-1 node` says nothing; `-1 node (DM-bounce)` says everything. That difference is what turned this into a 20-minute investigation instead of a glance, so the refusal lists the dropped node and edge ids (capped at 10 with an explicit "and N more", never a silent truncation) and points at `GET /api/graph/projects/<id>/export` as the thing that actually answers "what am I about to overwrite".

**A dry run flags its own negatives.** That branch never fetches the export, so it has only the server's counts — but a bare `-1` in a row of large rising numbers is precisely what got missed, so `printDelta` now calls deletions out in words.

## Key files

| File | Note |
|---|---|
| `packages/cli/src/commands/restore.ts` | `removedIds` / `describeDeletions` helpers, the guard, `--allow-deletions` wiring, the `printDelta` warning |
| `tests/cli/bootstrap-restore.test.js` | 13 new assertions across 6 cases |

## Verification

`npm run test:bootstrap` — **199 passed, 0 failed**. New coverage:

- the exact real-run shape: outbound journal **grows** (2 vs 1, history guard satisfied) while a hosted node and edge are dropped → refuses. This is the case proving the two guards catch different things
- zero PUTs, and no backup written, on a refusal
- the message names the node id, the edge id, and `--allow-deletions`
- edge-only deletion refuses too (the real `-7 edges` arrived with no node id changing, so a node-only guard would have missed it)
- `--allow-deletions` proceeds and still takes the backup
- **the ordinary additive landing proceeds without the flag** — a guard that blocked the normal case would be worse than no guard
- `printDelta` warns on the real run's delta and stays quiet on an additive one

Also green: `npm run test:cli` (all suites), `npm run lint` (0 errors, 4 pre-existing warnings in untouched files), `npm run build`.

## Not in scope

- **Suggestion 2** (wave-0 / landing diffs against the hosted export rather than the cache) is a `bootstrap.md` method change, not a CLI one. This PR makes the CLI refuse the bad outcome; it does not change what the method diffs against.
- **Suggestion 4** (state that a brownfield reconcile never rewrites `description`) is likewise a method-doc change. Worth doing — the issue is right that it was luck disguised as discipline that the 173 shared descriptions came out byte-identical.
- **Dropped journal events** are deliberately not guarded here. A bootstrap rebuild re-mints event ids, so `eventsDropped` is non-zero on every legitimate landing and a guard on it would cry wolf every time. The three hosted-only events the run nearly lost are a real gap, but they need id-stable merge semantics, not a refusal.

## Lab Note (EN/FR)

```yaml
en:
  title: "Publishing can no longer quietly delete your work"
  summary: "If publishing your map would remove something that only exists online (because you edited it there), it now stops and tells you exactly what would go, instead of counting it as just another number in the summary."
fr:
  title: "Publier ne peut plus effacer ton travail en douce"
  summary: "Si publier ta carte devait supprimer quelque chose qui n'existe qu'en ligne (parce que tu l'as modifié là-bas), l'outil s'arrête et te dit précisément ce qui allait disparaître, au lieu de le noyer dans un chiffre du résumé."
suggested:
  molecule: arkaik
  type: fix
  tags: [changelog]
```
