### PR TITLE
fix(mobile): stop viewport zoom when focusing a field

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -393,3 +393,21 @@
     }
   }
 }
+
+/* Mobile: never let focusing a field zoom the viewport.
+   iOS Safari auto-zooms when a focused control's font-size is under 16px,
+   which yanks the graph canvas out of frame and leaves it there. Bumping
+   touch-device fields to 16px removes the trigger without a
+   `maximum-scale=1` viewport meta, so deliberate pinch-zoom still works.
+   Unlayered on purpose: that beats Tailwind's `utilities` layer, so a
+   `text-sm` field still gets the bump. Fields that are already 16px or
+   larger opt out with `.arkaik-keep-font-size` — they never triggered the
+   zoom, and shrinking them would be a regression. */
+@media (pointer: coarse) {
+  input:not([type="checkbox"]):not([type="radio"]):not(.arkaik-keep-font-size),
+  select:not(.arkaik-keep-font-size),
+  textarea:not(.arkaik-keep-font-size),
+  [contenteditable]:not([contenteditable="false"]):not(.arkaik-keep-font-size) {
+    font-size: 1rem;
+  }
+}

--- a/components/panels/NodeDetailPanel.tsx
+++ b/components/panels/NodeDetailPanel.tsx
@@ -172,7 +172,7 @@ function NodeFields({ node, onUpdate, allNodes, onNavigate }: NodeFieldsProps) {
           onInput={(e) => {
             setTitle(e.currentTarget.textContent || "");
           }}
-          className="text-lg font-semibold text-foreground outline-none empty:before:text-muted-foreground empty:before:content-['Node_title'] whitespace-pre-wrap break-words"
+          className="arkaik-keep-font-size text-lg font-semibold text-foreground outline-none empty:before:text-muted-foreground empty:before:content-['Node_title'] whitespace-pre-wrap break-words"
           aria-label="Node title (editable)"
         />
         <div


### PR DESCRIPTION
iOS Safari auto-zooms on focus when the control's font-size is under 16px,
which pulled the graph canvas out of frame. Touch-pointer fields (inputs,
selects, textareas, contenteditable regions like the node description) now
render at 16px, so pinch-zoom stays available while focus no longer zooms.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01C8zMgADYHGAoMFiAdkCTqw