### PR TITLE
feat(toolbar): compact every filter menu to one square icon button

### DIFF
--- a/components/acceptances/AcceptanceFilterBar.tsx
+++ b/components/acceptances/AcceptanceFilterBar.tsx
@@ -1,18 +1,29 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { ListChevronsDownUpIcon, ListChevronsUpDownIcon, StethoscopeIcon, XIcon } from "lucide-react";
+import {
+  CircleFadingArrowUpIcon,
+  ListChevronsDownUpIcon,
+  ListChevronsUpDownIcon,
+  MonitorSmartphoneIcon,
+  PyramidIcon,
+  StethoscopeIcon,
+  WorkflowIcon,
+  XIcon,
+} from "lucide-react";
 import type { ProjectBundle } from "@/lib/data/types";
 import type { AcceptanceFilters } from "@/lib/utils/acceptance-matrix";
 import { EMPTY_FILTERS, UNANCHORED_FILTER } from "@/lib/utils/acceptance-matrix";
 import { VALUES } from "@/lib/config/values";
+import { STATUSES } from "@/lib/config/statuses";
 import { usePlatformFilterControl } from "@/lib/hooks/usePlatformFilterControl";
 import { SearchInput } from "@/components/ui/search-input";
 import { ProductOverrideSelector } from "@/components/layout/ProductOverrideSelector";
 import { Toolbar, ToolbarGroup } from "@/components/layout/Toolbar";
 import { StatusSelectItems } from "@/components/layout/StatusSelectItems";
 import { Button } from "@/components/ui/button";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Select, SelectContent, SelectItem } from "@/components/ui/select";
+import { FilterSelectTrigger } from "@/components/layout/FilterSelectTrigger";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { PLATFORM_ICONS } from "@/components/graph/nodes/node-styles";
 import { VALUE_ICON_COMPONENTS } from "@/lib/config/value-icons";
@@ -35,6 +46,13 @@ interface AcceptanceFilterBarProps {
 }
 
 const ALL = "all";
+
+/** The selected platform's own glyph, or the generic one while unfiltered. */
+function SelectedPlatformIcon({ platform }: { platform: AcceptanceFilters["platform"] }) {
+  if (platform === "all") return <MonitorSmartphoneIcon />;
+  const Icon = PLATFORM_ICONS[platform];
+  return <Icon />;
+}
 
 export function AcceptanceFilterBar({ filters, onChange, anchorOptions, projectId, project, allExpanded, onToggleExpandAll }: AcceptanceFilterBarProps) {
   // Same arity rule and same stale-filter reset as the Delivery bar; only the
@@ -114,8 +132,16 @@ export function AcceptanceFilterBar({ filters, onChange, anchorOptions, projectI
       <ToolbarGroup>
         {showPlatformFilter && (
           <Select value={filters.platform} onValueChange={(v) => onChange({ ...filters, platform: v === ALL ? "all" : (v as AcceptanceFilters["platform"]) })}>
-            <SelectTrigger className="w-[8rem]" aria-label="Platform"><SelectValue placeholder="Platforms" /></SelectTrigger>
-            <SelectContent>
+            {/* The glyph is the *selected* platform when there is one — the one
+                place where a filter's value is itself an icon, so the trigger
+                may as well say which. */}
+            <FilterSelectTrigger
+              icon={<SelectedPlatformIcon platform={filters.platform} />}
+              label="Platform"
+              active={filters.platform !== "all"}
+              valueLabel={platformOptions.find((p) => p.id === filters.platform)?.label}
+            />
+            <SelectContent align="start">
               <SelectItem value={ALL}>Platforms</SelectItem>
               {platformOptions.map((p) => {
                 const Icon = PLATFORM_ICONS[p.id];
@@ -126,16 +152,26 @@ export function AcceptanceFilterBar({ filters, onChange, anchorOptions, projectI
         )}
 
         <Select value={filters.status} onValueChange={(v) => onChange({ ...filters, status: v === ALL ? "all" : (v as AcceptanceFilters["status"]) })}>
-          <SelectTrigger className="w-[9rem]" aria-label="Status"><SelectValue placeholder="Status" /></SelectTrigger>
-          <SelectContent>
+          <FilterSelectTrigger
+            icon={<CircleFadingArrowUpIcon />}
+            label="Status"
+            active={filters.status !== "all"}
+            valueLabel={STATUSES.find((s) => s.id === filters.status)?.label}
+          />
+          <SelectContent align="start">
             <SelectItem value={ALL}>All statuses</SelectItem>
             <StatusSelectItems />
           </SelectContent>
         </Select>
 
         <Select value={filters.value} onValueChange={(v) => onChange({ ...filters, value: v === ALL ? "all" : (v as AcceptanceFilters["value"]) })}>
-          <SelectTrigger className="w-[11rem]" aria-label="Value"><SelectValue placeholder="Value" /></SelectTrigger>
-          <SelectContent>
+          <FilterSelectTrigger
+            icon={<PyramidIcon />}
+            label="Value"
+            active={filters.value !== "all"}
+            valueLabel={VALUES.find((v) => v.id === filters.value)?.label}
+          />
+          <SelectContent align="start">
             <SelectItem value={ALL}>All values</SelectItem>
             {VALUES.map((v) => {
               const Icon = VALUE_ICON_COMPONENTS[v.id];
@@ -145,8 +181,17 @@ export function AcceptanceFilterBar({ filters, onChange, anchorOptions, projectI
         </Select>
 
         <Select value={filters.anchor} onValueChange={(v) => onChange({ ...filters, anchor: v === ALL ? "all" : v })}>
-          <SelectTrigger className="w-[11rem]" aria-label="Anchor"><SelectValue placeholder="Anchor" /></SelectTrigger>
-          <SelectContent>
+          <FilterSelectTrigger
+            icon={<WorkflowIcon />}
+            label="Anchor"
+            active={filters.anchor !== "all"}
+            valueLabel={
+              filters.anchor === UNANCHORED_FILTER
+                ? "Unanchored (intake)"
+                : anchorOptions.find((a) => a.id === filters.anchor)?.title
+            }
+          />
+          <SelectContent align="start">
             <SelectItem value={ALL}>All anchors</SelectItem>
             {/* The intake inbox: ideas filed before their flows and views exist.
                 First, not sorted in among the anchors, because it is the one entry
@@ -194,6 +239,11 @@ export function AcceptanceFilterBar({ filters, onChange, anchorOptions, projectI
               aria-pressed={allExpanded}
               aria-label={allExpanded ? "Collapse all groups" : "Expand all groups"}
               onClick={onToggleExpandAll}
+              // Border only, no fill: the filter menus beside it now use a soft
+              // filled surface to say "a value is set", and this button sets no
+              // value — it opens and shuts the groups. Same shape, so the fill
+              // has to be the thing that tells them apart.
+              className="bg-transparent dark:bg-transparent"
             >
               {allExpanded
                 ? <ListChevronsUpDownIcon className="size-4" />

--- a/components/layout/FilterSelectTrigger.tsx
+++ b/components/layout/FilterSelectTrigger.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import type { ComponentProps, ReactNode } from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { cn } from "@/lib/utils";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+
+interface FilterSelectTriggerProps
+  extends Omit<ComponentProps<typeof SelectPrimitive.Trigger>, "children"> {
+  /** The glyph that stands for what this menu narrows. */
+  icon: ReactNode;
+  /** What the menu filters — the accessible name, and the tooltip's first line. */
+  label: string;
+  /** Whether a filter is currently set, i.e. anything other than "all". */
+  active?: boolean;
+  /** The current selection in words, shown in the tooltip while `active`. */
+  valueLabel?: string;
+}
+
+/**
+ * A filter menu's trigger, compacted to a single square icon button.
+ *
+ * The filter bands carry up to six controls, and two open side panels squeeze
+ * them into a column of stacked pills — so the menus drop their labels and
+ * become one glyph each. Nothing is lost that the bar was really showing:
+ * a `w-11rem` trigger reading "All values" is a label pretending to be a value.
+ * The name lives in the tooltip and in `aria-label`, and the *set* value — the
+ * only state worth a glance — is carried by a darkened border plus the tooltip's
+ * second line.
+ *
+ * Radix's chevron is dropped rather than shrunk: at this size the affordance is
+ * the button, and a chevron beside a glyph in 36px reads as noise.
+ *
+ * "Set" is drawn as a darkened border plus a soft filled surface — never the
+ * solid `default` fill, which in these bands means "toggle that is on". A menu
+ * holding a value and a toggle that is pressed are different states and must
+ * not converge on the same treatment; the toggles beside it drop their own
+ * background for the same reason.
+ */
+export function FilterSelectTrigger({
+  icon,
+  label,
+  active = false,
+  valueLabel,
+  className,
+  ...props
+}: FilterSelectTriggerProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <SelectPrimitive.Trigger
+          data-slot="select-trigger"
+          aria-label={label}
+          className={cn(
+            "inline-flex size-9 shrink-0 items-center justify-center rounded-md border bg-transparent shadow-xs outline-none focus:ring-[3px] focus:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 [&_svg:not([class*='size-'])]:size-4",
+            active
+              ? "border-foreground/50 bg-accent text-foreground dark:bg-accent/50"
+              : "border-input text-muted-foreground",
+            className,
+          )}
+          {...props}
+        >
+          {icon}
+        </SelectPrimitive.Trigger>
+      </TooltipTrigger>
+      <TooltipContent>
+        {active && valueLabel ? `${label}: ${valueLabel}` : label}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/components/layout/ProductOverrideSelector.tsx
+++ b/components/layout/ProductOverrideSelector.tsx
@@ -51,8 +51,8 @@ export function ProductOverrideSelector({ projectId, project }: ProductOverrideS
       // accessible name is two controls a screen reader cannot tell apart.
       ariaLabel="Product for this page"
       allProductsHint="Everything in the project"
-      triggerIcon={<BoxesIcon className="size-4 shrink-0 text-muted-foreground" />}
-      triggerClassName="h-9 w-[11rem] gap-2"
+      iconOnly
+      triggerIcon={<BoxesIcon className="size-4 shrink-0" />}
       contentClassName="min-w-56"
     />
   );

--- a/components/layout/ProductSelect.tsx
+++ b/components/layout/ProductSelect.tsx
@@ -8,6 +8,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { FilterSelectTrigger } from "@/components/layout/FilterSelectTrigger";
 import type { ProductScopeOption } from "@/lib/utils/product-scope";
 
 /**
@@ -39,6 +40,13 @@ interface ProductSelectProps {
   options: ProductScopeOption[];
   /** Rendered inside the trigger, before the label — an icon, usually. */
   triggerIcon?: ReactNode;
+  /**
+   * Compact the trigger to a square icon button — what the surfaces' filter
+   * bands use, where this control is one narrowing menu among several. The
+   * sidebar's global scope selector keeps the labelled trigger: it names the
+   * frame you are in, which is exactly the thing a glyph cannot say.
+   */
+  iconOnly?: boolean;
   triggerClassName?: string;
   contentClassName?: string;
   ariaLabel: string;
@@ -51,6 +59,7 @@ export function ProductSelect({
   onChange,
   options,
   triggerIcon,
+  iconOnly = false,
   triggerClassName,
   contentClassName,
   ariaLabel,
@@ -65,6 +74,15 @@ export function ProductSelect({
       value={selected ? selected.id : ALL_PRODUCTS}
       onValueChange={(next) => onChange(next === ALL_PRODUCTS ? null : next)}
     >
+      {iconOnly ? (
+        <FilterSelectTrigger
+          icon={triggerIcon}
+          label={ariaLabel}
+          active={selected !== null}
+          valueLabel={selected?.label}
+          className={triggerClassName}
+        />
+      ) : (
       <SelectTrigger aria-label={ariaLabel} className={triggerClassName}>
         {triggerIcon}
         {/* Children make Radix render this instead of portaling the selected
@@ -74,6 +92,7 @@ export function ProductSelect({
           <span className="truncate">{selected ? selected.label : "All products"}</span>
         </SelectValue>
       </SelectTrigger>
+      )}
       <SelectContent align="start" className={contentClassName}>
         <SelectItem value={ALL_PRODUCTS} textValue="All products">
           <span className="grid text-left leading-tight">


### PR DESCRIPTION
The acceptances toolbar broke down badly with a second panel open: four labelled selects plus two toggles, folded into a stacked column. Every filter menu is now a single square icon button.

## What changed

- **New `components/layout/FilterSelectTrigger.tsx`** — a 36px square Radix select trigger, glyph only, no chevron. The name lives in `aria-label` and the tooltip; the *set* value is the tooltip's second line.
- **"A filter is set"** reads as a darkened border plus a soft filled surface — never the solid `default` fill, which in these bands means "toggle is on".
- **Icons**: product keeps its pile of packages (`Boxes`), status takes `CircleFadingArrowUp`, value the `Pyramid`, anchor `Workflow`. Platform shows the *selected* platform's own glyph, falling back to `MonitorSmartphone`.
- **`ProductSelect` gained `iconOnly`**, opted into by `ProductOverrideSelector` — so this compacts on all four surfaces that carry the override (Acceptances, Delivery, Pyramid, Library). The sidebar's global scope selector keeps its label: it names the frame you are in, which is the one thing a glyph cannot say.
- **The expand/collapse toggle drops its background** — same shape as the menus beside it, but it sets no value, so the fill is what tells them apart. The parity-gap toggle keeps its amber fill, which is a real "on" state.

The other bars (Delivery, Decisions, Library, Pyramid) use toggle pills and segmented controls rather than dropdowns, so the product control is all there was to compact there.

## Verification

`tsc --noEmit` and eslint are clean on the touched files. No browser driver here, so the visual pass is manual: the acceptances toolbar with a second panel open, the set/unset border contrast in both themes, and tooltips not colliding with their popovers.

## Lab Note

```yaml
en:
  title: "Filters that stay out of the way"
  summary: "Filter menus are now compact icon buttons, so the toolbar keeps its shape even with a panel open beside it. A filled, outlined button tells you at a glance which filters are active."
fr:
  title: "Des filtres qui se font discrets"
  summary: "Les menus de filtres deviennent de petits boutons à icône : ta barre d'outils garde sa forme, même avec un panneau ouvert à côté. Un bouton rempli et souligné te montre d'un coup d'œil les filtres actifs."
suggested:
  molecule: arkaik
  type: improvement
  tags: [changelog]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)