### PR TITLE
feat(overview): one row per section, delivery wheel tiles, and the value pyramid on its side

### DIFF
--- a/app/project/[id]/overview/page.tsx
+++ b/app/project/[id]/overview/page.tsx
@@ -2,7 +2,9 @@
 
 import { useMemo } from "react";
 import { buildProductUsageIndex, computeParityGaps, listMaps } from "@arkaik/schema";
+import { LayoutGridIcon, RowsIcon } from "lucide-react";
 import { BacklogCard } from "@/components/overview/BacklogCard";
+import { OverviewLayoutProvider } from "@/components/overview/OverviewLayoutContext";
 import { DeliverySnapshotCard } from "@/components/overview/DeliverySnapshotCard";
 import { HealthCard } from "@/components/overview/HealthCard";
 import { InventoryCard } from "@/components/overview/InventoryCard";
@@ -16,6 +18,8 @@ import { PageLoading } from "@/components/layout/PageLoading";
 import { PageShell } from "@/components/layout/PageShell";
 import { PageSurface } from "@/components/layout/PageSurface";
 import { EmptyState } from "@/components/ui/empty-state";
+import { SegmentedControl, type SegmentedControlOption } from "@/components/ui/segmented-control";
+import { useOverviewLayout, type OverviewLayout } from "@/lib/hooks/useOverviewLayout";
 import { useEdges } from "@/lib/hooks/useEdges";
 import { useJournal } from "@/lib/hooks/useJournal";
 import { useNodes } from "@/lib/hooks/useNodes";
@@ -43,8 +47,14 @@ import { computeScopedPyramidTiers } from "@/lib/utils/pyramid";
  * every card jumps off into the working surface that owns the detail.
  * Deliberately read-only.
  */
+const LAYOUTS: readonly SegmentedControlOption<OverviewLayout>[] = [
+  { id: "grid", label: "Grid", icon: LayoutGridIcon },
+  { id: "rows", label: "Rows", icon: RowsIcon },
+];
+
 export default function OverviewPage() {
   const id = useProjectId();
+  const [layout, setLayout] = useOverviewLayout();
 
   const { nodes: dataNodes, loading: nodesLoading, error: nodesError, reload: reloadNodes } = useNodes(id);
   const { edges: dataEdges, loading: edgesLoading, error: edgesError, reload: reloadEdges } = useEdges(id);
@@ -178,35 +188,53 @@ export default function OverviewPage() {
       title="Overview"
       meta={productScopeMetaLabel(scope)}
       headerExtra={
-        projectBundle?.project.version ? (
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
-            <span>Current version</span>
-            <span className="rounded-full border px-2 py-0.5 font-medium text-foreground">
-              {projectBundle.project.version}
-            </span>
-          </div>
-        ) : null
+        <div className="flex items-center gap-3">
+          {projectBundle?.project.version && (
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <span>Current version</span>
+              <span className="rounded-full border px-2 py-0.5 font-medium text-foreground">
+                {projectBundle.project.version}
+              </span>
+            </div>
+          )}
+          <SegmentedControl
+            options={LAYOUTS}
+            value={layout}
+            onChange={setLayout}
+            ariaLabel="Overview display"
+          />
+        </div>
       }
     >
-      <PageSurface contentClassName="grid gap-4 md:grid-cols-2">
-        {isEmpty ? (
-          <EmptyState
-            className="md:col-span-2"
-            message="Nothing here yet. Sketch the product on the Journey map or add nodes in the Library, and the Overview fills itself in."
-          />
-        ) : (
-          <>
-            <PlatformGaugesCard rollup={rollup} platforms={gaugePlatforms} projectId={id} />
-            <ParityCard gaps={parityGaps} platforms={scope.platforms} projectId={id} />
-            <PyramidCard tiers={pyramidTiers} platforms={scope.platforms} projectId={id} />
-            <DeliverySnapshotCard snapshot={snapshot} projectId={id} />
-            <ReleasePulseCard releases={releases} projectId={id} />
-            <BacklogCard backlog={backlog} projectId={id} />
-            <InventoryCard inventory={inventory} projectId={id} />
-            <HealthCard indicators={health} projectId={id} />
-            <MapsCard maps={maps} projectId={id} />
-          </>
-        )}
+      {/*
+        Two displays of the same nine sections. The grid is a two-column wall of
+        cards; rows give each section a full width, heading left and content
+        right, which is the only shape the platform tiles and the 90° value
+        pyramid have room to draw in. The switch is the reader's, remembered.
+      */}
+      <PageSurface
+        contentClassName={layout === "rows" ? "flex flex-col divide-y" : "grid gap-4 md:grid-cols-2"}
+      >
+        <OverviewLayoutProvider value={layout}>
+          {isEmpty ? (
+            <EmptyState
+              className={layout === "rows" ? "" : "md:col-span-2"}
+              message="Nothing here yet. Sketch the product on the Journey map or add nodes in the Library, and the Overview fills itself in."
+            />
+          ) : (
+            <>
+              <PlatformGaugesCard rollup={rollup} platforms={gaugePlatforms} projectId={id} />
+              <ParityCard gaps={parityGaps} platforms={scope.platforms} projectId={id} />
+              <PyramidCard tiers={pyramidTiers} platforms={scope.platforms} projectId={id} />
+              <DeliverySnapshotCard snapshot={snapshot} projectId={id} />
+              <ReleasePulseCard releases={releases} projectId={id} />
+              <BacklogCard backlog={backlog} projectId={id} />
+              <InventoryCard inventory={inventory} projectId={id} />
+              <HealthCard indicators={health} projectId={id} />
+              <MapsCard maps={maps} projectId={id} />
+            </>
+          )}
+        </OverviewLayoutProvider>
       </PageSurface>
     </PageShell>
   );

--- a/app/project/[id]/overview/page.tsx
+++ b/app/project/[id]/overview/page.tsx
@@ -4,11 +4,11 @@ import { useMemo } from "react";
 import { buildProductUsageIndex, computeParityGaps, listMaps } from "@arkaik/schema";
 import { LayoutGridIcon, RowsIcon } from "lucide-react";
 import { BacklogCard } from "@/components/overview/BacklogCard";
-import { OverviewLayoutProvider } from "@/components/overview/OverviewLayoutContext";
 import { DeliverySnapshotCard } from "@/components/overview/DeliverySnapshotCard";
 import { HealthCard } from "@/components/overview/HealthCard";
 import { InventoryCard } from "@/components/overview/InventoryCard";
 import { MapsCard, type MapsCardEntry } from "@/components/overview/MapsCard";
+import { OverviewLayoutProvider } from "@/components/overview/OverviewLayoutContext";
 import { ParityCard } from "@/components/overview/ParityCard";
 import { PlatformGaugesCard } from "@/components/overview/PlatformGaugesCard";
 import { PyramidCard } from "@/components/overview/PyramidCard";
@@ -19,10 +19,10 @@ import { PageShell } from "@/components/layout/PageShell";
 import { PageSurface } from "@/components/layout/PageSurface";
 import { EmptyState } from "@/components/ui/empty-state";
 import { SegmentedControl, type SegmentedControlOption } from "@/components/ui/segmented-control";
-import { useOverviewLayout, type OverviewLayout } from "@/lib/hooks/useOverviewLayout";
 import { useEdges } from "@/lib/hooks/useEdges";
 import { useJournal } from "@/lib/hooks/useJournal";
 import { useNodes } from "@/lib/hooks/useNodes";
+import { useOverviewLayout, type OverviewLayout } from "@/lib/hooks/useOverviewLayout";
 import { useEffectiveProduct } from "@/lib/hooks/useProductScope";
 import { useProject } from "@/lib/hooks/useProject";
 import { useProjectId } from "@/lib/hooks/useProjectId";
@@ -40,6 +40,11 @@ import { getRollupPlatforms } from "@/lib/utils/platform-status";
 import { productScopeMetaLabel, type ProductGraph } from "@/lib/utils/product-scope";
 import { computeScopedPyramidTiers } from "@/lib/utils/pyramid";
 
+const LAYOUTS: readonly SegmentedControlOption<OverviewLayout>[] = [
+  { id: "rows", label: "Rows", icon: RowsIcon },
+  { id: "grid", label: "Grid", icon: LayoutGridIcon },
+];
+
 /**
  * The Overview: "Where does this product stand?" — the strategist reading
  * (vision.md § Core Product; docs/spec/maps.md § Overview Composition).
@@ -47,11 +52,6 @@ import { computeScopedPyramidTiers } from "@/lib/utils/pyramid";
  * every card jumps off into the working surface that owns the detail.
  * Deliberately read-only.
  */
-const LAYOUTS: readonly SegmentedControlOption<OverviewLayout>[] = [
-  { id: "grid", label: "Grid", icon: LayoutGridIcon },
-  { id: "rows", label: "Rows", icon: RowsIcon },
-];
-
 export default function OverviewPage() {
   const id = useProjectId();
   const [layout, setLayout] = useOverviewLayout();

--- a/components/graph/nodes/PlatformRingSet.tsx
+++ b/components/graph/nodes/PlatformRingSet.tsx
@@ -34,6 +34,52 @@ function describeRing(title: string, segments: readonly StatusSegment[]): string
   return `${title}: ${parts.join(", ")}`;
 }
 
+interface PlatformRingProps {
+  rollup: PlatformStatusRollup;
+  platform: PlatformId;
+  size?: StatusRingSize;
+  /** Names what this ring's footer counts. */
+  platformCountLabel?: string;
+}
+
+/**
+ * One platform's ring, hover-revealing its status breakdown.
+ *
+ * Split out of {@link PlatformRings} so a surface can put its own chrome around
+ * a ring — the Overview's rows display draws each platform as a titled tile —
+ * without rebuilding the ring, the hover card and the accessible name a fourth
+ * time. Everything the ring *is* lives here; callers only decide what surrounds
+ * it and how many there are.
+ */
+export function PlatformRing({ rollup, platform, size = "lg", platformCountLabel = "acceptances" }: PlatformRingProps) {
+  const segments = getPlatformRollupSegments(rollup, platform);
+  // Summed from the segments, not read from `rollup.totals`, so the footer
+  // count and the rows above it can never disagree.
+  const platformTotal = segments.reduce((sum, segment) => sum + segment.count, 0);
+  const Icon = PLATFORM_ICONS[platform];
+  const label = PLATFORM_LABELS[platform];
+
+  return (
+    <HoverCard openDelay={150}>
+      <HoverCardTrigger asChild>
+        <span className={TRIGGER_CLASS}>
+          <StatusRing segments={segments} size={size} label={describeRing(label, segments)}>
+            <Icon className={`${size === "lg" ? "size-4" : "size-3"} text-muted-foreground`} />
+          </StatusRing>
+        </span>
+      </HoverCardTrigger>
+      <HoverCardContent className="w-60 p-3">
+        <StatusBreakdownPopover
+          title={label}
+          icon={Icon}
+          segments={segments}
+          footer={`${platformTotal} ${platformCountLabel} on ${label}`}
+        />
+      </HoverCardContent>
+    </HoverCard>
+  );
+}
+
 interface PlatformRingsProps {
   rollup: PlatformStatusRollup;
   /** The platforms to draw a ring for, in any order — re-sorted to RING_ORDER. */
@@ -54,41 +100,28 @@ interface PlatformRingsProps {
  * about what a platform ring looks like.
  */
 export function PlatformRings({ rollup, platforms, size = "lg", platformCountLabel = "acceptances" }: PlatformRingsProps) {
-  const ringPlatforms = platforms.slice().sort((left, right) => rank(left) - rank(right));
-  const centerIcon = size === "lg" ? "size-4" : "size-3";
-
   return (
     <>
-      {ringPlatforms.map((platform) => {
-        const segments = getPlatformRollupSegments(rollup, platform);
-        // Summed from the segments, not read from `rollup.totals`, so the footer
-        // count and the rows above it can never disagree.
-        const platformTotal = segments.reduce((sum, segment) => sum + segment.count, 0);
-        const Icon = PLATFORM_ICONS[platform];
-        const label = PLATFORM_LABELS[platform];
-
-        return (
-          <HoverCard key={platform} openDelay={150}>
-            <HoverCardTrigger asChild>
-              <span className={TRIGGER_CLASS}>
-                <StatusRing segments={segments} size={size} label={describeRing(label, segments)}>
-                  <Icon className={`${centerIcon} text-muted-foreground`} />
-                </StatusRing>
-              </span>
-            </HoverCardTrigger>
-            <HoverCardContent className="w-60 p-3">
-              <StatusBreakdownPopover
-                title={label}
-                icon={Icon}
-                segments={segments}
-                footer={`${platformTotal} ${platformCountLabel} on ${label}`}
-              />
-            </HoverCardContent>
-          </HoverCard>
-        );
-      })}
+      {sortRingPlatforms(platforms).map((platform) => (
+        <PlatformRing
+          key={platform}
+          rollup={rollup}
+          platform={platform}
+          size={size}
+          platformCountLabel={platformCountLabel}
+        />
+      ))}
     </>
   );
+}
+
+/**
+ * The platforms in ring order, whatever order the caller holds them in — shared
+ * so a surface arranging rings itself (the Overview's tiles) cannot reshuffle
+ * them relative to every other surface.
+ */
+export function sortRingPlatforms(platforms: readonly PlatformId[]): PlatformId[] {
+  return platforms.slice().sort((left, right) => rank(left) - rank(right));
 }
 
 interface PlatformRingSetProps {

--- a/components/overview/BacklogCard.tsx
+++ b/components/overview/BacklogCard.tsx
@@ -19,6 +19,7 @@ export function BacklogCard({ backlog, projectId }: BacklogCardProps) {
     <OverviewSection
       title="Backlog"
       icon={InboxIcon}
+      description="What the journal has recorded as wanted but not yet drawn into the graph."
       subtitle={
         backlog.items.length === 0
           ? "No open ideas or requests."

--- a/components/overview/DeliverySnapshotCard.tsx
+++ b/components/overview/DeliverySnapshotCard.tsx
@@ -16,6 +16,7 @@ export function DeliverySnapshotCard({ snapshot, projectId }: DeliverySnapshotCa
     <OverviewSection
       title="Delivery snapshot"
       icon={SquareKanbanIcon}
+      description="How much of the product is shipped, and how much is still on its way."
       subtitle={
         snapshot.totalItems === 0
           ? "Nothing in flight yet."

--- a/components/overview/HealthCard.tsx
+++ b/components/overview/HealthCard.tsx
@@ -28,6 +28,7 @@ export function HealthCard({ indicators, projectId }: HealthCardProps) {
     <OverviewSection
       title="Health"
       icon={HeartPulseIcon}
+      description="The graph's own soundness — what is orphaned, unanchored, or contradicting itself."
       subtitle={
         flagged === 0
           ? "Every indicator is at zero — the documentation is whole."

--- a/components/overview/InventoryCard.tsx
+++ b/components/overview/InventoryCard.tsx
@@ -19,6 +19,7 @@ export function InventoryCard({ inventory, projectId }: InventoryCardProps) {
     <OverviewSection
       title="Inventory"
       icon={BookOpenIcon}
+      description="How much product there is to read at all, by species."
       subtitle={`${inventory.nodeCount} nodes · ${inventory.edgeCount} edges · ${inventory.journalEventCount} journal events`}
       href={`/project/${projectId}/library`}
       linkLabel="Library"

--- a/components/overview/MapsCard.tsx
+++ b/components/overview/MapsCard.tsx
@@ -29,6 +29,7 @@ export function MapsCard({ maps, projectId }: MapsCardProps) {
     <OverviewSection
       title="Maps"
       icon={MapIcon}
+      description="The views onto this graph, and how much each one draws."
       subtitle={
         maps.length === 0
           ? "No maps yet."

--- a/components/overview/OverviewLayoutContext.tsx
+++ b/components/overview/OverviewLayoutContext.tsx
@@ -9,10 +9,10 @@ import type { OverviewLayout } from "@/lib/hooks/useOverviewLayout";
  *
  * A context rather than a prop threaded through nine cards: the seven whose
  * body is identical in both displays would otherwise take a prop they never
- * read, purely to hand it to their shell. `"grid"` is the default so a card
- * rendered outside the provider (a test, a future surface) still draws.
+ * read, purely to hand it to their shell. The default matches the page's, so a card rendered
+ * outside the provider (a test, a future surface) still draws.
  */
-const OverviewLayoutContext = createContext<OverviewLayout>("grid");
+const OverviewLayoutContext = createContext<OverviewLayout>("rows");
 
 export const OverviewLayoutProvider = OverviewLayoutContext.Provider;
 

--- a/components/overview/OverviewLayoutContext.tsx
+++ b/components/overview/OverviewLayoutContext.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { createContext, useContext } from "react";
+import type { OverviewLayout } from "@/lib/hooks/useOverviewLayout";
+
+/**
+ * Which display the Overview is drawing, read by `OverviewSection` to pick a
+ * shell — and by the two cards whose *body* differs between the displays.
+ *
+ * A context rather than a prop threaded through nine cards: the seven whose
+ * body is identical in both displays would otherwise take a prop they never
+ * read, purely to hand it to their shell. `"grid"` is the default so a card
+ * rendered outside the provider (a test, a future surface) still draws.
+ */
+const OverviewLayoutContext = createContext<OverviewLayout>("grid");
+
+export const OverviewLayoutProvider = OverviewLayoutContext.Provider;
+
+export function useOverviewLayoutContext(): OverviewLayout {
+  return useContext(OverviewLayoutContext);
+}

--- a/components/overview/OverviewSection.tsx
+++ b/components/overview/OverviewSection.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import type { LucideIcon } from "lucide-react";
 import type { ReactNode } from "react";
+import { useOverviewLayoutContext } from "./OverviewLayoutContext";
 
 interface OverviewSectionProps {
   title: string;
@@ -10,6 +11,12 @@ interface OverviewSectionProps {
   icon: LucideIcon;
   /** The card's headline number, or a sentence when it has none to give. */
   subtitle?: ReactNode;
+  /**
+   * What question this section answers, in one line. Drawn only by the rows
+   * display, whose left column is wide enough to say it; the card's header has
+   * room for the numbers and nothing else.
+   */
+  description?: string;
   /** Jump-off target — the Overview links into the working surfaces (vision.md § IA). */
   href?: string;
   linkLabel?: string;
@@ -19,22 +26,26 @@ interface OverviewSectionProps {
 }
 
 /**
- * The dashboard's shared card shell.
+ * The dashboard's shared section, in whichever shell the reader picked.
+ *
+ * Both shells carry the same header material — icon, title, summary line,
+ * jump-off link — and differ only in where they put it: stacked above the body
+ * in a card, or beside it in a row. Cards call this and never choose; the
+ * choice is the page's, read from `OverviewLayoutContext`.
+ */
+export function OverviewSection(props: OverviewSectionProps) {
+  return useOverviewLayoutContext() === "rows" ? <OverviewRow {...props} /> : <OverviewCard {...props} />;
+}
+
+/**
+ * The card shell.
  *
  * The header is the Pyramid element card's header (`PyramidElementCard`): one
  * large icon over a real title with a quiet line beneath it. That line is where
  * a card's summary numbers belong — "412 nodes · 980 edges" is what the reader
  * came for, so it sits under the title rather than as the first row of the body.
  */
-export function OverviewSection({
-  title,
-  icon: Icon,
-  subtitle,
-  href,
-  linkLabel,
-  className,
-  children,
-}: OverviewSectionProps) {
+function OverviewCard({ title, icon: Icon, subtitle, href, linkLabel, className, children }: OverviewSectionProps) {
   return (
     <section className={`flex flex-col gap-3 rounded-xl border bg-card p-4 ${className ?? ""}`}>
       <div className="flex items-start justify-between gap-2">
@@ -52,6 +63,54 @@ export function OverviewSection({
         )}
       </div>
       {children}
+    </section>
+  );
+}
+
+/**
+ * The row shell: heading on the left, content on the right.
+ *
+ * No border and no card background — the rows sit inside one surface separated
+ * by hairlines (`divide-y` on their container), because nine bordered boxes
+ * stacked full-width is a stack of lids rather than a document. The left column
+ * is width-capped rather than a fraction so the content column keeps the same
+ * left edge down the page whatever the viewport does; below `md` the two
+ * columns stack and the row reads exactly like today's card.
+ */
+function OverviewRow({
+  title,
+  icon: Icon,
+  subtitle,
+  description,
+  href,
+  linkLabel,
+  className,
+  children,
+}: OverviewSectionProps) {
+  return (
+    <section className={`grid gap-4 py-6 md:grid-cols-[minmax(0,17rem)_1fr] md:gap-8 ${className ?? ""}`}>
+      <div className="flex min-w-0 flex-col gap-3">
+        <Icon className="size-7 text-muted-foreground" aria-hidden="true" />
+        <div className="flex flex-col gap-1">
+          <h2 className="text-base font-semibold leading-tight">{title}</h2>
+          {description && <p className="text-xs text-muted-foreground">{description}</p>}
+          {subtitle && <p className="text-xs font-medium text-foreground/80">{subtitle}</p>}
+        </div>
+        {href && linkLabel && (
+          <Link
+            href={href}
+            className="text-xs text-muted-foreground transition-colors hover:text-foreground"
+          >
+            {linkLabel} →
+          </Link>
+        )}
+      </div>
+      {/* `min-w-0` on a grid child, or a wide body (the pyramid, a gauge list)
+          pushes the column past its track instead of scrolling inside it. */}
+      {/* Same `flex-col gap-3` as the card's body: a card whose body is two
+          blocks (a gauge list and its chips) relies on that gap for its
+          spacing, and a bare block here would collapse them together. */}
+      <div className="flex min-w-0 flex-col gap-3">{children}</div>
     </section>
   );
 }

--- a/components/overview/ParityCard.tsx
+++ b/components/overview/ParityCard.tsx
@@ -26,20 +26,14 @@ interface ParityCardProps {
  * cannot have one — would read as a clean bill of health nobody earned. The
  * threshold is `platformAvailabilityShape`'s and not a second `>= 2` written
  * here, so this card can never disagree with the shapes around it.
+ *
+ * Silenced means *absent*, not a section explaining its own absence. A heading
+ * over the sentence "nothing to compare" is a row of the dashboard spent
+ * telling the reader that this dashboard has nothing for them — on a
+ * single-platform product that row appeared every single visit.
  */
 export function ParityCard({ gaps, platforms, projectId }: ParityCardProps) {
-  if (platformAvailabilityShape(platforms) === "bar") {
-    return (
-      <OverviewSection
-        title="Platform parity"
-        icon={ScaleIcon}
-        description="Whether every platform in scope tells the same story."
-        subtitle="Parity compares platforms, and fewer than two are in scope — nothing to compare."
-        href={`/project/${projectId}/acceptances`}
-        linkLabel="Acceptances"
-      />
-    );
-  }
+  if (platformAvailabilityShape(platforms) === "bar") return null;
 
   return (
     <OverviewSection

--- a/components/overview/ParityCard.tsx
+++ b/components/overview/ParityCard.tsx
@@ -33,6 +33,7 @@ export function ParityCard({ gaps, platforms, projectId }: ParityCardProps) {
       <OverviewSection
         title="Platform parity"
         icon={ScaleIcon}
+        description="Whether every platform in scope tells the same story."
         subtitle="Parity compares platforms, and fewer than two are in scope — nothing to compare."
         href={`/project/${projectId}/acceptances`}
         linkLabel="Acceptances"
@@ -44,6 +45,7 @@ export function ParityCard({ gaps, platforms, projectId }: ParityCardProps) {
     <OverviewSection
       title="Platform parity"
       icon={ScaleIcon}
+      description="Whether every platform in scope tells the same story."
       subtitle={
         gaps.length === 0 ? (
           "No parity gaps — every acceptance ships evenly across its platforms."

--- a/components/overview/PlatformGaugesCard.tsx
+++ b/components/overview/PlatformGaugesCard.tsx
@@ -5,6 +5,7 @@ import { PlatformGaugeList } from "@/components/graph/nodes/PlatformGaugeList";
 import { PLATFORM_LABELS } from "@/components/graph/nodes/node-styles";
 import type { PlatformId } from "@/lib/config/platforms";
 import type { PlatformStatusRollup } from "@/lib/utils/platform-status";
+import { platformAvailabilityShape } from "@/lib/utils/product-scope";
 import { useOverviewLayoutContext } from "./OverviewLayoutContext";
 import { OverviewSection } from "./OverviewSection";
 import { PlatformWheelTiles } from "./PlatformWheelTiles";
@@ -16,43 +17,45 @@ interface PlatformGaugesCardProps {
   projectId: string;
 }
 
-/** The flow cards' delivery gauges at product scale — every view, per platform. */
+/**
+ * The flow cards' delivery gauges at product scale — every view, per platform.
+ *
+ * **Absent below two platforms**, on the same threshold and for the same reason
+ * as `ParityCard`: this section exists to break delivery down *by platform*, and
+ * with one platform the breakdown is the total. That total is what the Delivery
+ * snapshot already says, in more useful detail — so the section is not a
+ * shrunken version of itself here, it is a duplicate, and it goes.
+ */
 export function PlatformGaugesCard({ rollup, platforms, projectId }: PlatformGaugesCardProps) {
-  // The tiles need a platform each to be tiles at all. At one platform the row
-  // would show a single tile, which reads as "the other two failed to load"
-  // rather than "there is only one" — the same reason `PlatformAvailability`
-  // drops to a bar below two platforms. So the wheels are the multi-platform
-  // rendition only, and one platform keeps the gauge in both displays.
-  const asTiles = useOverviewLayoutContext() === "rows" && platforms.length >= 2;
+  const asTiles = useOverviewLayoutContext() === "rows";
+
+  // The same threshold `ParityCard` is silenced by, read through the same
+  // helper rather than a second `>= 2` written here.
+  if (platformAvailabilityShape(platforms) === "bar") return null;
 
   return (
     <OverviewSection
       title="Platform delivery"
       icon={GaugeIcon}
       description="Which platforms the product is actually shipped on, view by view."
-      subtitle={
-        platforms.length === 0
-          ? "No counted view work yet."
-          : `Every view's delivery status across ${platforms.length} platform${platforms.length === 1 ? "" : "s"}`
-      }
+      subtitle={`Every view's delivery status across ${platforms.length} platforms`}
       href={`/project/${projectId}/delivery`}
       linkLabel="Delivery"
     >
-      {platforms.length > 0 &&
-        (asTiles ? (
-          <PlatformWheelTiles rollup={rollup} platforms={platforms} countLabel="views" />
-        ) : (
-          <>
-            <PlatformGaugeList rollup={rollup} platforms={platforms} showLabels />
-            <div className="flex flex-wrap items-center gap-2">
-              {platforms.map((platform) => (
-                <span key={platform} className="rounded-full border px-2 py-0.5 text-xs text-muted-foreground">
-                  {PLATFORM_LABELS[platform]} {rollup.totals[platform] ?? 0}
-                </span>
-              ))}
-            </div>
-          </>
-        ))}
+      {asTiles ? (
+        <PlatformWheelTiles rollup={rollup} platforms={platforms} countLabel="views" />
+      ) : (
+        <>
+          <PlatformGaugeList rollup={rollup} platforms={platforms} showLabels />
+          <div className="flex flex-wrap items-center gap-2">
+            {platforms.map((platform) => (
+              <span key={platform} className="rounded-full border px-2 py-0.5 text-xs text-muted-foreground">
+                {PLATFORM_LABELS[platform]} {rollup.totals[platform] ?? 0}
+              </span>
+            ))}
+          </div>
+        </>
+      )}
     </OverviewSection>
   );
 }

--- a/components/overview/PlatformGaugesCard.tsx
+++ b/components/overview/PlatformGaugesCard.tsx
@@ -5,7 +5,9 @@ import { PlatformGaugeList } from "@/components/graph/nodes/PlatformGaugeList";
 import { PLATFORM_LABELS } from "@/components/graph/nodes/node-styles";
 import type { PlatformId } from "@/lib/config/platforms";
 import type { PlatformStatusRollup } from "@/lib/utils/platform-status";
+import { useOverviewLayoutContext } from "./OverviewLayoutContext";
 import { OverviewSection } from "./OverviewSection";
+import { PlatformWheelTiles } from "./PlatformWheelTiles";
 
 interface PlatformGaugesCardProps {
   rollup: PlatformStatusRollup;
@@ -16,10 +18,18 @@ interface PlatformGaugesCardProps {
 
 /** The flow cards' delivery gauges at product scale — every view, per platform. */
 export function PlatformGaugesCard({ rollup, platforms, projectId }: PlatformGaugesCardProps) {
+  // The tiles need a platform each to be tiles at all. At one platform the row
+  // would show a single tile, which reads as "the other two failed to load"
+  // rather than "there is only one" — the same reason `PlatformAvailability`
+  // drops to a bar below two platforms. So the wheels are the multi-platform
+  // rendition only, and one platform keeps the gauge in both displays.
+  const asTiles = useOverviewLayoutContext() === "rows" && platforms.length >= 2;
+
   return (
     <OverviewSection
       title="Platform delivery"
       icon={GaugeIcon}
+      description="Which platforms the product is actually shipped on, view by view."
       subtitle={
         platforms.length === 0
           ? "No counted view work yet."
@@ -28,18 +38,21 @@ export function PlatformGaugesCard({ rollup, platforms, projectId }: PlatformGau
       href={`/project/${projectId}/delivery`}
       linkLabel="Delivery"
     >
-      {platforms.length > 0 && (
-        <>
-          <PlatformGaugeList rollup={rollup} platforms={platforms} showLabels />
-          <div className="flex flex-wrap items-center gap-2">
-            {platforms.map((platform) => (
-              <span key={platform} className="rounded-full border px-2 py-0.5 text-xs text-muted-foreground">
-                {PLATFORM_LABELS[platform]} {rollup.totals[platform] ?? 0}
-              </span>
-            ))}
-          </div>
-        </>
-      )}
+      {platforms.length > 0 &&
+        (asTiles ? (
+          <PlatformWheelTiles rollup={rollup} platforms={platforms} countLabel="views" />
+        ) : (
+          <>
+            <PlatformGaugeList rollup={rollup} platforms={platforms} showLabels />
+            <div className="flex flex-wrap items-center gap-2">
+              {platforms.map((platform) => (
+                <span key={platform} className="rounded-full border px-2 py-0.5 text-xs text-muted-foreground">
+                  {PLATFORM_LABELS[platform]} {rollup.totals[platform] ?? 0}
+                </span>
+              ))}
+            </div>
+          </>
+        ))}
     </OverviewSection>
   );
 }

--- a/components/overview/PlatformWheelTiles.tsx
+++ b/components/overview/PlatformWheelTiles.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { PlatformRing, sortRingPlatforms } from "@/components/graph/nodes/PlatformRingSet";
+import { PLATFORM_LABELS } from "@/components/graph/nodes/node-styles";
+import type { PlatformId } from "@/lib/config/platforms";
+import type { PlatformStatusRollup } from "@/lib/utils/platform-status";
+
+interface PlatformWheelTilesProps {
+  rollup: PlatformStatusRollup;
+  /** Platforms with any counted work — the caller's list, re-sorted to ring order. */
+  platforms: PlatformId[];
+  /** Names what a tile's number counts. */
+  countLabel?: string;
+}
+
+/**
+ * One tile per platform: its delivery wheel, its name, and what it counts.
+ *
+ * The rows display's answer to the stacked gauge bars. A bar reads as a
+ * proportion and nothing else, which is the right shape squeezed into a card;
+ * given a full-width row, the wheel the rest of the app already uses for
+ * delivery says the same thing in the idiom every other surface speaks, and the
+ * tile gives it the label a bare ring has to be hovered for.
+ *
+ * The wheel itself is `PlatformRing` — this component owns the chrome around it
+ * and nothing about the ring.
+ */
+export function PlatformWheelTiles({ rollup, platforms, countLabel = "views" }: PlatformWheelTilesProps) {
+  return (
+    <div className="flex flex-wrap gap-3">
+      {sortRingPlatforms(platforms).map((platform) => {
+        const total = rollup.totals[platform] ?? 0;
+
+        return (
+          <div
+            key={platform}
+            className="flex min-w-[9rem] flex-1 items-center gap-3 rounded-lg border bg-card px-3 py-2.5"
+          >
+            <PlatformRing rollup={rollup} platform={platform} size="lg" platformCountLabel={countLabel} />
+            <div className="flex min-w-0 flex-col">
+              <span className="truncate text-sm font-medium">{PLATFORM_LABELS[platform]}</span>
+              <span className="text-xs tabular-nums text-muted-foreground">
+                {total} {countLabel}
+              </span>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/overview/PyramidCard.tsx
+++ b/components/overview/PyramidCard.tsx
@@ -6,7 +6,9 @@ import type { PlatformId } from "@/lib/config/platforms";
 import { VALUE_TIERS_CONFIG } from "@/lib/config/values";
 import { mergeRollups } from "@/lib/utils/platform-status";
 import type { PyramidTier } from "@/lib/utils/pyramid";
+import { useOverviewLayoutContext } from "./OverviewLayoutContext";
 import { OverviewSection } from "./OverviewSection";
+import { ValuePyramidWheels } from "./ValuePyramidWheels";
 
 const TIER_LABEL = new Map(VALUE_TIERS_CONFIG.map((t) => [t.id, t.label]));
 
@@ -33,17 +35,27 @@ export function PyramidCard({ tiers, platforms, projectId }: PyramidCardProps) {
     (sum, tier) => sum + tier.elements.filter((element) => element.acceptanceCount > 0).length,
     0,
   );
+  // The wheel pyramid needs the width of a full row: thirty rings in seven
+  // columns is a shape at 1fr and a smudge inside a half-width card.
+  const asWheels = useOverviewLayoutContext() === "rows";
 
   return (
     <OverviewSection
       title="Value pyramid"
       icon={PyramidIcon}
+      description="What the product is worth to the people using it — and where it says nothing yet."
       subtitle={`${addressedCount}/${elementCount} elements addressed across ${tiers.length} tier${tiers.length === 1 ? "" : "s"}`}
       href={`/project/${projectId}/pyramid`}
       linkLabel="Pyramid"
     >
-      <div className="flex flex-col gap-2.5">
-        {tiers.map((tier) => {
+      {asWheels ? (
+        <ValuePyramidWheels
+          tiers={tiers}
+          hrefForValue={(value) => `/project/${projectId}/acceptances?value=${encodeURIComponent(value)}`}
+        />
+      ) : (
+        <div className="flex flex-col gap-2.5">
+          {tiers.map((tier) => {
           const rollup = mergeRollups(...tier.elements.map((element) => element.rollup));
           // Elements addressed, not acceptances summed: an acceptance carrying two
           // values from the same tier would be counted twice by a naive sum, so the
@@ -69,8 +81,9 @@ export function PyramidCard({ tiers, platforms, projectId }: PyramidCardProps) {
               />
             </div>
           );
-        })}
-      </div>
+          })}
+        </div>
+      )}
     </OverviewSection>
   );
 }

--- a/components/overview/ReleasePulseCard.tsx
+++ b/components/overview/ReleasePulseCard.tsx
@@ -18,6 +18,7 @@ export function ReleasePulseCard({ releases, projectId }: ReleasePulseCardProps)
     <OverviewSection
       title="Release pulse"
       icon={TagsIcon}
+      description="How often this product ships, and what went out last."
       subtitle={
         releases.length === 0
           ? "No releases tagged yet."

--- a/components/overview/ValuePyramidWheels.tsx
+++ b/components/overview/ValuePyramidWheels.tsx
@@ -38,7 +38,13 @@ interface ValuePyramidWheelsProps {
  */
 export function ValuePyramidWheels({ tiers, hrefForValue }: ValuePyramidWheelsProps) {
   return (
-    <div className="flex items-stretch gap-4 overflow-x-auto pb-1">
+    // `overflow-y-hidden` is load-bearing, not tidying: `overflow-x: auto`
+    // computes the *other* axis to `auto` too, so a container one pixel taller
+    // than its content becomes a vertical scroll container and swallows every
+    // wheel event over the pyramid — the page stops scrolling under the
+    // cursor. Pinning y to `hidden` gives the wheel back to the page. Nothing
+    // is clipped: the columns are centred and shorter than the track.
+    <div className="flex items-stretch gap-4 overflow-x-auto overflow-y-hidden pb-1">
       {tiers.map((tier) => {
         const config = TIER_CONFIG.get(tier.tier);
         const addressed = tier.elements.filter((element) => element.acceptanceCount > 0).length;

--- a/components/overview/ValuePyramidWheels.tsx
+++ b/components/overview/ValuePyramidWheels.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import Link from "next/link";
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
+import { StatusBreakdownPopover } from "@/components/graph/nodes/StatusBreakdownPopover";
+import { StatusRing } from "@/components/graph/nodes/StatusRing";
+import { ValueIcon } from "@/components/values/ValueBadge";
+import { VALUE_TIERS_CONFIG, VALUES } from "@/lib/config/values";
+import { getRollupTotalSegments } from "@/lib/utils/platform-status";
+import { splitTierColumns, type PyramidElement, type PyramidTier } from "@/lib/utils/pyramid";
+
+const TIER_CONFIG = new Map(VALUE_TIERS_CONFIG.map((tier) => [tier.id, tier]));
+const VALUE_LABEL = new Map(VALUES.map((value) => [value.id, value.label]));
+
+interface ValuePyramidWheelsProps {
+  tiers: PyramidTier[];
+  /** Where an element's wheel jumps to — the acceptances carrying that value. */
+  hrefForValue: (value: string) => string;
+}
+
+/**
+ * The 30 value elements as one wheel each, laid out as a pyramid on its side.
+ *
+ * Tiers read left to right, base first: the functional tier's fourteen elements
+ * stack as two columns of seven, emotional as two of five, life-changing as
+ * three and two, and social impact's single element is the apex. Every column
+ * is vertically centred, so the silhouette is a triangle pointing right — the
+ * Pyramid page's shape, at a size a dashboard row can hold.
+ *
+ * The columns come from `splitTierColumns`, which derives them from each tier's
+ * own length; nothing here knows that the taxonomy is 14/10/5/1.
+ *
+ * Each wheel is the element's delivery across every platform in scope, not one
+ * ring per platform: thirty wheels is already the density limit of a row, and
+ * the per-platform reading is what the Pyramid page itself is for. An element
+ * nothing speaks to draws the bare muted track and dims, which is how the
+ * Pyramid grid has always shown "unserved".
+ */
+export function ValuePyramidWheels({ tiers, hrefForValue }: ValuePyramidWheelsProps) {
+  return (
+    <div className="flex items-stretch gap-4 overflow-x-auto pb-1">
+      {tiers.map((tier) => {
+        const config = TIER_CONFIG.get(tier.tier);
+        const addressed = tier.elements.filter((element) => element.acceptanceCount > 0).length;
+
+        return (
+          <div key={tier.tier} className="flex shrink-0 flex-col items-center gap-2">
+            <div className="flex flex-1 items-center gap-1.5">
+              {splitTierColumns(tier.elements).map((column, index) => (
+                <div key={index} className="flex flex-col justify-center gap-1.5">
+                  {column.map((element) => (
+                    <ValueWheel key={element.value} element={element} href={hrefForValue(element.value)} />
+                  ))}
+                </div>
+              ))}
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span
+                className="size-1.5 shrink-0 rounded-full"
+                style={{ backgroundColor: config?.color }}
+                aria-hidden="true"
+              />
+              <span className="text-[11px] text-muted-foreground">
+                {config?.label ?? tier.tier}
+                <span className="ml-1 tabular-nums opacity-70">
+                  {addressed}/{tier.elements.length}
+                </span>
+              </span>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function ValueWheel({ element, href }: { element: PyramidElement; href: string }) {
+  const label = VALUE_LABEL.get(element.value) ?? element.value;
+  const segments = getRollupTotalSegments(element.rollup);
+  const served = element.acceptanceCount > 0;
+  const description = served
+    ? `${label}: ${element.acceptanceCount} acceptance${element.acceptanceCount === 1 ? "" : "s"}`
+    : `${label}: nothing addresses this yet`;
+
+  return (
+    <HoverCard openDelay={150}>
+      <HoverCardTrigger asChild>
+        <Link
+          href={href}
+          className={`block transition-opacity hover:opacity-100 ${served ? "" : "opacity-45"}`}
+          aria-label={description}
+        >
+          <StatusRing segments={segments} size="sm" label={description}>
+            <ValueIcon valueId={element.value} className="size-3 text-muted-foreground" />
+          </StatusRing>
+        </Link>
+      </HoverCardTrigger>
+      <HoverCardContent className="w-60 p-3">
+        <StatusBreakdownPopover
+          title={label}
+          segments={segments}
+          footer={
+            served
+              ? `${element.acceptanceCount} acceptance${element.acceptanceCount === 1 ? "" : "s"} carry this element`
+              : "Nothing addresses this element yet"
+          }
+        />
+      </HoverCardContent>
+    </HoverCard>
+  );
+}

--- a/docs/superpowers/specs/2026-08-08-overview-rows-layout-design.md
+++ b/docs/superpowers/specs/2026-08-08-overview-rows-layout-design.md
@@ -1,0 +1,93 @@
+# Overview: a second display — one row per section
+
+**Date:** 2026-08-08
+**Status:** approved, implementing
+
+## Problem
+
+The Overview is a two-column grid of nine cards. Each card is a small box with a
+header and a cramped body, and the two richest readings — platform delivery and
+the value pyramid — are squeezed into that box as stacked bars and four tier
+rows. A wider row, heading on the left and content on the right, gives those two
+readings the horizontal room to draw what they actually mean.
+
+This is a *second* display, not a replacement: the grid stays, and the reader
+picks.
+
+## Design
+
+### 1. The switch
+
+`useOverviewLayout()` (lib/hooks) reads and writes `localStorage`
+`arkaik:overview-layout`, values `"grid" | "rows"`, default `"grid"`. It is a
+global preference, not per project — a reader who prefers rows prefers them
+everywhere. The stored value is read in an effect so the server render and the
+first client render agree; the toggle is a `SegmentedControl` (the repo's
+existing icon-segmented control) in `PageShell`'s `headerExtra`, beside the
+version chip.
+
+### 2. One shell contract, two shells
+
+`OverviewLayoutContext` wraps the section list with the current layout.
+`OverviewSection` becomes the dispatcher: it reads the context and renders
+either today's card or the new `OverviewRow`. The seven cards whose body does
+not change need no edit beyond a new `description` prop.
+
+`OverviewRow` is `grid md:grid-cols-[minmax(0,18rem)_1fr] gap-6 py-6`, with rows
+separated by `divide-y` inside one `PageSurface` and no per-row card chrome.
+Left column: icon, title, description, the stats subtitle, and the jump-off
+link. Right column: the body.
+
+`PyramidCard` and `PlatformGaugesCard` read the same context to choose their
+*body*, which is the only reason a card ever inspects the layout.
+
+### 3. Platform wheel tiles
+
+`PlatformWheelTiles` (components/overview) replaces the stacked gauge bars in
+rows mode: one bordered tile per platform, holding that platform's status wheel
+with the platform icon centred, the platform name, and its counted total.
+
+To build the tile without re-deriving the hover card and the accessible name, a
+single ring is extracted out of `PlatformRings` as an exported `PlatformRing`;
+`PlatformRings` maps over it and the tile wraps it in its own chrome. Nothing
+about either rendering changes.
+
+**The arity rule is untouched.** At one or zero platforms the rows layout falls
+back to `PlatformAvailability`, exactly as every other surface does — a lone
+tile beside three-tile scopes reads as *data missing* rather than *absent*.
+
+### 4. The 90° value pyramid
+
+`ValuePyramidWheels` (components/overview) draws one wheel per value element,
+fed by the `pyramidTiers` the page already computes.
+
+Columns are **derived, not hardcoded**: a tier of `n` elements splits into
+`ceil(n/2)` and `floor(n/2)`, or one column when `n === 1`. For today's
+14/10/5/1 taxonomy that is 7+7 / 5+5 / 3+2 / 1 — the shape asked for — and it
+survives a change to the taxonomy rather than silently mis-chunking. The split
+lives in `lib/utils/pyramid.ts` as `splitTierColumns()` so a plain Node test can
+pin it.
+
+The wheels lay out as a `flex items-center` row, widest tier first and each
+column vertically centred — a triangle pointing right. A tier's columns group
+under a small label in the tier's colour. Each wheel is a `StatusRing` over the
+element's aggregate segments (`getRollupTotalSegments`) with the value icon
+centred, dimmed at `acceptanceCount === 0`, linked to the element's acceptances
+and hover-carding its status breakdown.
+
+### 5. Copy
+
+Nine one-line descriptions, one per section, saying what the section answers.
+They live with their cards.
+
+## Testing
+
+`splitTierColumns` gets a unit test in `tests/app/pyramid.test.js` (the existing
+DB-free harness). The layout components are verified statically and by a visual
+checklist handed to Alexis — there is no browser driver in this environment.
+
+## Out of scope
+
+- Any change to what the Overview computes. Every number is the same projection.
+- Row layouts for other pages.
+- Server-persisted layout preference.

--- a/docs/superpowers/specs/2026-08-08-overview-rows-layout-design.md
+++ b/docs/superpowers/specs/2026-08-08-overview-rows-layout-design.md
@@ -19,7 +19,9 @@ picks.
 ### 1. The switch
 
 `useOverviewLayout()` (lib/hooks) reads and writes `localStorage`
-`arkaik:overview-layout`, values `"grid" | "rows"`, default `"grid"`. It is a
+`arkaik:overview-layout`, values `"grid" | "rows"`, **default `"rows"`** — the
+rows display leads the toggle and is what a reader with no stored preference
+gets. It is a
 global preference, not per project — a reader who prefers rows prefers them
 everywhere. The stored value is read in an effect so the server render and the
 first client render agree; the toggle is a `SegmentedControl` (the repo's
@@ -52,9 +54,13 @@ single ring is extracted out of `PlatformRings` as an exported `PlatformRing`;
 `PlatformRings` maps over it and the tile wraps it in its own chrome. Nothing
 about either rendering changes.
 
-**The arity rule is untouched.** At one or zero platforms the rows layout falls
-back to `PlatformAvailability`, exactly as every other surface does — a lone
-tile beside three-tile scopes reads as *data missing* rather than *absent*.
+**Below two platforms the section is absent**, in both displays, on
+`platformAvailabilityShape`'s threshold — the same one that silences
+`ParityCard`. This section exists to break delivery down *by platform*; with one
+platform the breakdown is the total, which the Delivery snapshot already gives
+in more useful detail. And `ParityCard`'s single-platform branch stops rendering
+a heading over "nothing to compare": a silenced section is absent, not a row
+spent explaining its own absence.
 
 ### 4. The 90° value pyramid
 
@@ -74,6 +80,11 @@ under a small label in the tier's colour. Each wheel is a `StatusRing` over the
 element's aggregate segments (`getRollupTotalSegments`) with the value icon
 centred, dimmed at `acceptanceCount === 0`, linked to the element's acceptances
 and hover-carding its status breakdown.
+
+The row scrolls horizontally, and its container pins `overflow-y: hidden`:
+`overflow-x: auto` computes the cross axis to `auto` as well, which turns the
+pyramid into a vertical scroll container that swallows every wheel event over
+it — the page freezes under the cursor.
 
 ### 5. Copy
 

--- a/lib/hooks/useOverviewLayout.ts
+++ b/lib/hooks/useOverviewLayout.ts
@@ -1,0 +1,79 @@
+"use client";
+
+import { useCallback, useSyncExternalStore } from "react";
+
+/** The Overview's two displays: today's card grid, or one row per section. */
+export type OverviewLayout = "grid" | "rows";
+
+const STORAGE_KEY = "arkaik:overview-layout";
+const DEFAULT_LAYOUT: OverviewLayout = "grid";
+
+const isLayout = (value: string | null): value is OverviewLayout =>
+  value === "grid" || value === "rows";
+
+/**
+ * Lazily hydrated from localStorage on first read, then cached — which is what
+ * makes `getSnapshot` safe to call on every render.
+ */
+let layout: OverviewLayout | undefined;
+const listeners = new Set<() => void>();
+
+/**
+ * Guarded twice over, like the product scope store: `window` is absent during
+ * SSR, and `localStorage` itself throws in private-mode browsers that enforce a
+ * zero quota rather than reporting one.
+ */
+function read(): OverviewLayout {
+  if (typeof window === "undefined") return DEFAULT_LAYOUT;
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    return isLayout(stored) ? stored : DEFAULT_LAYOUT;
+  } catch {
+    return DEFAULT_LAYOUT;
+  }
+}
+
+function getSnapshot(): OverviewLayout {
+  if (layout === undefined) layout = read();
+  return layout;
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/**
+ * The reader's chosen Overview display, remembered across sessions.
+ *
+ * Global rather than per project, unlike the product scope: which shape you
+ * like reading a dashboard in is a fact about you, not about the product. That
+ * is also why it stays out of the URL — a link to the Overview is a link to the
+ * product's standing, not to someone else's layout preference.
+ *
+ * A module store read through `useSyncExternalStore`, matching
+ * lib/utils/product-scope-store.ts, rather than `useState` hydrated in an
+ * effect: the effect version calls `setState` in an effect body, which is a
+ * cascading render and a lint error, and this shape has the same one-frame
+ * behaviour without either. `getServerSnapshot` is the default layout because
+ * localStorage does not exist during SSR; React renders that through hydration
+ * and re-reads the real store immediately after.
+ */
+export function useOverviewLayout(): [OverviewLayout, (next: OverviewLayout) => void] {
+  const current = useSyncExternalStore(subscribe, getSnapshot, () => DEFAULT_LAYOUT);
+
+  const choose = useCallback((next: OverviewLayout) => {
+    if (getSnapshot() === next) return;
+    layout = next;
+    try {
+      window.localStorage.setItem(STORAGE_KEY, next);
+    } catch {
+      // Best-effort: the layout still switches now, it just won't be remembered.
+    }
+    for (const listener of listeners) listener();
+  }, []);
+
+  return [current, choose];
+}

--- a/lib/hooks/useOverviewLayout.ts
+++ b/lib/hooks/useOverviewLayout.ts
@@ -2,11 +2,11 @@
 
 import { useCallback, useSyncExternalStore } from "react";
 
-/** The Overview's two displays: today's card grid, or one row per section. */
+/** The Overview's two displays: one row per section, or the card grid. */
 export type OverviewLayout = "grid" | "rows";
 
 const STORAGE_KEY = "arkaik:overview-layout";
-const DEFAULT_LAYOUT: OverviewLayout = "grid";
+const DEFAULT_LAYOUT: OverviewLayout = "rows";
 
 const isLayout = (value: string | null): value is OverviewLayout =>
   value === "grid" || value === "rows";

--- a/lib/utils/pyramid.ts
+++ b/lib/utils/pyramid.ts
@@ -122,3 +122,27 @@ export function computeScopedPyramidTiers(
     { platforms: scope.platforms },
   );
 }
+
+/**
+ * A tier's elements split into the columns the Overview's 90° pyramid draws.
+ *
+ * The pyramid lies on its side: tiers read left to right, widest first, and a
+ * tier's own elements stack vertically in one or two columns. Two rather than a
+ * single tall column because a 14-element functional tier in one column is a
+ * ladder, not a pyramid — split in half it is the base the shape needs.
+ *
+ * **Derived, never hardcoded.** Today's taxonomy is 14/10/5/1, which this turns
+ * into 7+7, 5+5, 3+2 and 1 — the intended shape. Writing those numbers down
+ * instead would mis-chunk silently the day an element is added to a tier, and
+ * "silently" is the whole problem: the pyramid would still render, just wrong.
+ *
+ * A tier of one gets a single column: an apex is a point, and 1+0 would leave
+ * an empty column's worth of gap beside it.
+ */
+export function splitTierColumns<T>(elements: readonly T[]): T[][] {
+  if (elements.length === 0) return [];
+  if (elements.length === 1) return [[elements[0]]];
+
+  const first = Math.ceil(elements.length / 2);
+  return [elements.slice(0, first), elements.slice(first)];
+}

--- a/tests/app/pyramid.test.js
+++ b/tests/app/pyramid.test.js
@@ -14,6 +14,7 @@ const { loadPyramid, BUILD_DIR } = require("./load-pyramid");
 const {
   computePyramidAggregation,
   computeScopedPyramidTiers,
+  splitTierColumns,
   filterAcceptances,
   EMPTY_FILTERS,
   resolveProductScope,
@@ -332,6 +333,25 @@ const emptySegments = getRollupTotalSegments(createEmptyRollup());
 assert(
   emptySegments.length === 4 && emptySegments.every((s) => s.count === 0 && s.ratio === 0 && s.percentage === 0),
   "an empty rollup yields all-zero segments and never divides by zero",
+);
+
+// --- splitTierColumns: the Overview's 90° pyramid shape -------------------
+// The whole point of deriving the columns is that today's 14/10/5/1 taxonomy
+// comes out as 7+7 / 5+5 / 3+2 / 1 without those numbers appearing anywhere.
+const columnShape = (n) => splitTierColumns(Array.from({ length: n }, (_, i) => i)).map((col) => col.length);
+
+assert(eq(columnShape(14), [7, 7]), "a 14-element tier splits into two columns of 7");
+assert(eq(columnShape(10), [5, 5]), "a 10-element tier splits into two columns of 5");
+assert(eq(columnShape(5), [3, 2]), "an odd tier puts the extra element in the first column");
+assert(eq(columnShape(1), [1]), "the apex is one column, not 1 + 0");
+assert(eq(columnShape(0), []), "an empty tier draws no columns at all");
+assert(
+  eq(splitTierColumns(["a", "b", "c"]), [["a", "b"], ["c"]]),
+  "elements keep their order, split at the halfway point",
+);
+assert(
+  tiers.every((tier) => splitTierColumns(tier.elements).flat().length === tier.elements.length),
+  "every element of every real tier lands in exactly one column",
 );
 
 fs.rmSync(BUILD_DIR, { recursive: true, force: true });


### PR DESCRIPTION
The Overview gains a second display, and it is now the one you land on: **one row per section**, heading on the left, content on the right. The card grid is still there behind a toggle in the header, and your choice is remembered.

A full-width row buys two readings the room they always wanted:

- **Platform delivery** draws a titled wheel tile per platform — the delivery wheel the rest of the app already speaks in — instead of stacked gauge bars.
- **The value pyramid** draws all 30 elements as one wheel each, tiers reading left to right in two columns apiece: a pyramid lying on its side. Unserved elements dim to their bare track, so the gaps are the shape you see first.

Two sections now disappear below two platforms instead of rendering empty. Parity has nothing to compare, and platform delivery's per-platform breakdown is just the total — which the Delivery snapshot already gives in more detail. Both read the same `platformAvailabilityShape` threshold every other surface does.

### Notes

- `splitTierColumns()` derives each tier's columns from its own length, so today's 14/10/5/1 taxonomy comes out 7+7 / 5+5 / 3+2 / 1 without those numbers appearing anywhere. Unit-tested.
- `PlatformRing` is extracted out of `PlatformRings` so the tile can wrap its own chrome around a ring without a fourth copy of the hover card and accessible name.
- The pyramid's container pins `overflow-y: hidden`: `overflow-x: auto` computes the cross axis to `auto` too, which had turned it into a scroll container that swallowed every wheel event over it.
- Spec: `docs/superpowers/specs/2026-08-08-overview-rows-layout-design.md`.

Verified: `tsc --noEmit` clean, eslint 0 errors, `npm run build` compiles, all 19 `tests/app` suites pass. The visual pass is unverified — there is no browser driver in this environment.

## Lab Note

```yaml
en:
  title: "Your Overview, rewritten as a story you can read down"
  summary: "The Overview now gives every section a full-width row: what it answers on the left, the answer on the right. Your value pyramid shows all thirty elements as one dial each, so the gaps jump out — and sections that have nothing to say for your product simply step aside. Prefer the old grid? One click in the header, and it remembers."
fr:
  title: "Ta vue d'ensemble, enfin lisible d'un trait"
  summary: "Chaque section a désormais toute la largeur : la question à gauche, la réponse à droite. Ta pyramide de valeur affiche ses trente éléments en autant de cadrans — les manques sautent aux yeux — et les sections qui n'ont rien à dire sur ton produit s'effacent. Tu préfères l'ancienne grille ? Un clic dans l'en-tête, et c'est retenu."
suggested:
  molecule: arkaik
  type: improvement
  tags: [changelog]
```
